### PR TITLE
[Cleanup] Move default zone selection to DeckImporterMain

### DIFF
--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -271,6 +271,25 @@ function checkTaboos(tabooId, slots, playerColor, configuration)
   end
 end
 
+-- Returns the zone name where the specified card should be placed, based on its metadata.
+---@param cardMetadata: Table of card metadata.  Metadata fields type and permanent are required; all others are optional.
+---@return: Zone name such as "Deck", "SetAside1", etc. See Zones object documentation for a list of valid zones.
+function getDefaultCardZone(cardMetadata)
+  if cardMetadata.type == "Investigator" then
+    return "Investigator"
+  elseif cardMetadata.type == "Minicard" then
+    return "Minicard"
+  elseif cardMetadata.permanent then
+    return "SetAside1"
+  elseif bondedList[cardMetadata.id] then
+    return "SetAside2"
+    -- SetAside3 is used for Ancestral Knowledge / Underworld Market
+    -- SetAside4 is used for upgrade sheets
+  else
+    return "Deck"
+  end
+end
+
 -- Process the slot list, which defines the card Ids and counts of cards to load. Spawn those cards at the appropriate zones
 -- and report an error to the user if any could not be loaded.
 -- This method uses an encapsulated coroutine with yields to make the card spawning cleaner.
@@ -291,7 +310,7 @@ function loadCards(slots, investigatorId, playerColor, commandManager, configura
     for cardId, cardCount in pairs(slots) do
       local card = allCardsBag.call("getCardById", { id = cardId })
       if card ~= nil then
-        local cardZone = Zones.getDefaultCardZone(card.metadata)
+        local cardZone = getDefaultCardZone(card.metadata)
         for i = 1, cardCount do
           table.insert(cardsToSpawn, { data = card.data, metadata = card.metadata, zone = cardZone })
         end

--- a/src/playermat/Zones.ttslua
+++ b/src/playermat/Zones.ttslua
@@ -108,26 +108,6 @@ do
   Zones["Red"] = Zones["Orange"]
   Zones["Green"] = Zones["White"]
 
-  -- Returns the zone name where the specified card should be placed, based on its metadata.
-  ---@param cardMetadata: Table of card metadata.  Metadata fields type and permanent are required; all others are optional.
-  ---@return: Zone name such as "Deck", "SetAside1", etc. See Zones object documentation for a list of valid zones.
-  function Zones.getDefaultCardZone(cardMetadata)
-    if cardMetadata.type == "Investigator" then
-      return "Investigator"
-    elseif cardMetadata.type == "Minicard" then
-      return "Minicard"
-    elseif cardMetadata.permanent then
-      return "SetAside1"
-    -- TODO: Figure out how to handled bonded information which isn't her now that we split the file
-    -- elseif bondedList[cardMetadata.id] then
-    --   return "SetAside2"
-      -- SetAside3 is used for Ancestral Knowledge / Underworld Market
-      -- SetAside4 is used for upgrade sheets
-    else
-      return "Deck"
-    end
-  end
-
   -- Gets the global position for the given zone on the specified player mat.
   ---@param playerColor: Color name of the player mat to get the zone position for (e.g. "Red")
   ---@param zoneName: Name of the zone to get the position for.  See Zones object documentation for a list of valid zones.


### PR DESCRIPTION
The current way of tracking bonded cards to spawn them in the right zone  didn't play well with the default zone method being in Zones.  Since  it's really a deck loader-only functionality anyway, moved it to the  loader.