### PR TITLE
Metadata update, Part 2

### DIFF
--- a/objects/AllPlayerCards.15bb07/35Winchester.c32e40.gmnotes
+++ b/objects/AllPlayerCards.15bb07/35Winchester.c32e40.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "06195-t",
+  "id": "06195",
   "type": "Asset",
   "class": "Guardian",
   "cost": 4,

--- a/objects/AllPlayerCards.15bb07/AgnesBaker.6797bb.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AgnesBaker.6797bb.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "01004-r",
+  "id": "01504",
   "type": "Investigator",
   "class": "Mystic",
   "traits": "Sorcerer.",

--- a/objects/AllPlayerCards.15bb07/AgnesBaker.8c997c.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBaker.8c997c.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"01004-revised-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
+  "GMNotes": "{\n  \"id\": \"01504-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GUID": "8c997c",
   "Grid": true,
   "GridProjection": false,
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/AgnesBaker.e53693.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBaker.e53693.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/AkachiOnyele.6a9578.json
+++ b/objects/AllPlayerCards.15bb07/AkachiOnyele.6a9578.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/AlchemicalDistillation.502a4d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AlchemicalDistillation.502a4d.gmnotes
@@ -19,22 +19,22 @@
     {
       "name": "Mending Distillate",
       "xp": 1,
-      "text": "Add this option: �€�? Heal 2 damage.�€?"
+      "text": "Add this option: â€œâŸ� Heal 2 damage.â€�"
     },
     {
       "name": "Calming Distillate",
       "xp": 1,
-      "text": "Add this option: �€�? Heal 2 horror.�€?"
+      "text": "Add this option: â€œâŸ� Heal 2 horror.â€�"
     },
     {
       "name": "Enlightening Distillate",
       "xp": 1,
-      "text": "Add this option: �€�? Place 1 charge or secret on an asset you control.�€?"
+      "text": "Add this option: â€œâŸ� Place 1 charge or secret on an asset you control.â€�"
     },
     {
       "name": "Quickening Distillate",
       "xp": 1,
-      "text": "Add this option: �€�? Move up to 2 times.�€?"
+      "text": "Add this option: â€œâŸ� Move up to 2 times.â€�"
     },
     {
       "name": "Refined",

--- a/objects/AllPlayerCards.15bb07/AmandaSharpe.155746.json
+++ b/objects/AllPlayerCards.15bb07/AmandaSharpe.155746.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/AminaZidane.458edc.json
+++ b/objects/AllPlayerCards.15bb07/AminaZidane.458edc.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/AminaZidane.4c2a3d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AminaZidane.4c2a3d.gmnotes
@@ -6,5 +6,6 @@
   "willpowerIcons": 3,
   "intellectIcons": 3,
   "combatIcons": 3,
-  "agilityIcons": 3
+  "agilityIcons": 3,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Analysis.80285f.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Analysis.80285f.gmnotes
@@ -6,5 +6,6 @@
   "traits": "Practiced.",
   "permanent": false,
   "weakness": false,
-  "wildIcons": 1
+  "wildIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Antiquary3.452db2.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Antiquary3.452db2.gmnotes
@@ -11,6 +11,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/ArcaneStudies4.ca23d4.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ArcaneStudies4.ca23d4.gmnotes
@@ -12,6 +12,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/AshcanPete.b8fd86.json
+++ b/objects/AllPlayerCards.15bb07/AshcanPete.b8fd86.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/BaseballBat2.567525.gmnotes
+++ b/objects/AllPlayerCards.15bb07/BaseballBat2.567525.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Weapon. Melee.",
   "permanent": false,
   "weakness": false,
-  "combatIcons": 2
+  "combatIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/BestowResolve2.39e14a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/BestowResolve2.39e14a.gmnotes
@@ -14,5 +14,6 @@
       "type": "Charge",
       "token": "resource"
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/BindersJar1.c72750.gmnotes
+++ b/objects/AllPlayerCards.15bb07/BindersJar1.c72750.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Relic.",
   "permanent": false,
   "weakness": false,
-  "willpowerIcons": 1
+  "willpowerIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/BizarreDiagnosis.2423d4.gmnotes
+++ b/objects/AllPlayerCards.15bb07/BizarreDiagnosis.2423d4.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Insight. Science.",
   "permanent": false,
   "weakness": false,
-  "intellectIcons": 2
+  "intellectIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/BobJenkins.aa1c23.json
+++ b/objects/AllPlayerCards.15bb07/BobJenkins.aa1c23.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/Bolas.d4b254.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Bolas.d4b254.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "combatIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Bonesaw.4b371d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Bonesaw.4b371d.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09005",
   "type": "Asset",
+  "class": "Neutral",
   "cost": 3,
   "traits": "Item. Tool. Melee.",
   "permanent": false,

--- a/objects/AllPlayerCards.15bb07/BonnieWalsh.634e9e.gmnotes
+++ b/objects/AllPlayerCards.15bb07/BonnieWalsh.634e9e.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09019",
   "type": "Asset",
+  "class": "Neutral",
   "cost": 3,
   "traits": "Ally. Civic. Assistant.",
   "permanent": false,

--- a/objects/AllPlayerCards.15bb07/BreachtheDoor.74969c.gmnotes
+++ b/objects/AllPlayerCards.15bb07/BreachtheDoor.74969c.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "intellectIcons": 1,
-  "combatIcons": 1
+  "combatIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Bruiser3.8ec9cb.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Bruiser3.8ec9cb.gmnotes
@@ -11,6 +11,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/CalvinWright.510d45.json
+++ b/objects/AllPlayerCards.15bb07/CalvinWright.510d45.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/CalvinWright.b02a1e.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CalvinWright.b02a1e.gmnotes
@@ -3,5 +3,9 @@
   "type": "Investigator",
   "class": "Survivor",
   "traits": "Cursed. Drifter.",
+  "willpowerIcons": 0,
+  "intellectIcons": 0,
+  "combatIcons": 0,
+  "agilityIcons": 0,
   "cycle": "The Forgotten Age"
 }

--- a/objects/AllPlayerCards.15bb07/CarolynFern.30614e.json
+++ b/objects/AllPlayerCards.15bb07/CarolynFern.30614e.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/CarolynFern.b57bab.json
+++ b/objects/AllPlayerCards.15bb07/CarolynFern.b57bab.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/CarsonSinclair.c0f76c.json
+++ b/objects/AllPlayerCards.15bb07/CarsonSinclair.c0f76c.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/CarsonSinclair.dc96d1.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CarsonSinclair.dc96d1.gmnotes
@@ -2,9 +2,10 @@
   "id": "09001",
   "type": "Investigator",
   "class": "Guardian",
-  "traits": "",
+  "traits": "Assistant.",
   "willpowerIcons": 2,
   "intellectIcons": 2,
   "combatIcons": 2,
-  "agilityIcons": 2
+  "agilityIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/CharlieKane.4deeff.json
+++ b/objects/AllPlayerCards.15bb07/CharlieKane.4deeff.json
@@ -24,6 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
+  "GMNotes": "{\n  \"id\": \"09018-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GMNotes_path": "AllPlayerCards.15bb07/CharlieKane.4deeff.gmnotes",
   "GUID": "4deeff",
   "Grid": true,

--- a/objects/AllPlayerCards.15bb07/ChuckFergus2.ea31c2.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ChuckFergus2.ea31c2.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "combatIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/CleanSneak4.537171.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CleanSneak4.537171.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Gambit. Trick.",
   "permanent": false,
   "weakness": false,
-  "agilityIcons": 2
+  "agilityIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Crafty3.fa994a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Crafty3.fa994a.gmnotes
@@ -11,6 +11,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/CustomModifications.d2252d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CustomModifications.d2252d.gmnotes
@@ -7,8 +7,6 @@
   "traits": "Upgrade. Supply.",
   "permanent": false,
   "weakness": false,
-  "combatIcons": 1,
-  "agilityIcons": 1,
   "customizations": [
     {
       "name": "Notched Sight",
@@ -28,7 +26,7 @@
     {
       "name": "Leather Grip",
       "xp": 3,
-      "text": "Custom Modifications gets �€“1 cost and gains �€�Fast. Play only during your turn.�€?",
+      "text": "Custom Modifications gets â€“1 cost and gains â€œFast. Play only during your turn.â€�",
       "replaces": {
         "cost": 2
       }
@@ -43,5 +41,6 @@
       "xp": 4,
       "text": "If you succeed by 3 or more while attacking with attached asset, this attack deals +1 damage."
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/DaisyWalker.5fa10d.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalker.5fa10d.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"01002-revised-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
+  "GMNotes": "{\n  \"id\": \"01502-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GUID": "5fa10d",
   "Grid": true,
   "GridProjection": false,
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DaisyWalker.ac7047.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DaisyWalker.ac7047.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "01002-r",
+  "id": "01502",
   "type": "Investigator",
   "class": "Seeker",
   "traits": "Miskatonic.",

--- a/objects/AllPlayerCards.15bb07/DaisyWalker.bce6a5.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalker.bce6a5.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DamningTestimony.3369a5.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DamningTestimony.3369a5.gmnotes
@@ -48,12 +48,12 @@
     {
       "name": "Surveil",
       "xp": 3,
-      "text": "You may use Damning Testimony�€�s ability to investigate the chosen enemy�€�s location instead of your location."
+      "text": "You may use Damning Testimonyâ€™s ability to investigate the chosen enemyâ€™s location instead of your location."
     },
     {
       "name": "Expose",
       "xp": 4,
-      "text": "When you successfully investigate using Damning Testimony, you may spend X evidence to discard the chosen enemy if it is non-Elite. X is that enemy�€�s remaining health."
+      "text": "When you successfully investigate using Damning Testimony, you may spend X evidence to discard the chosen enemy if it is non-Elite. X is that enemyâ€™s remaining health."
     }
   ],
   "cycle": "The Scarlet Keys"

--- a/objects/AllPlayerCards.15bb07/DanielaReyes.df8ec4.json
+++ b/objects/AllPlayerCards.15bb07/DanielaReyes.df8ec4.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DarkProphecyTaboo.94cdf6.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DarkProphecyTaboo.94cdf6.gmnotes
@@ -1,7 +1,7 @@
 {
   "id": "04032-t",
   "alternate_ids": [
-    "60417"
+    "60417-t"
   ],
   "type": "Event",
   "class": "Mystic",

--- a/objects/AllPlayerCards.15bb07/DarrellSimmons.3b3b7a.json
+++ b/objects/AllPlayerCards.15bb07/DarrellSimmons.3b3b7a.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DarrellsKodak.caa382.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DarrellsKodak.caa382.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09016",
   "type": "Asset",
+  "class": "Neutral",
   "startsInPlay": true,
   "cost": 2,
   "traits": "Item. Tool.",

--- a/objects/AllPlayerCards.15bb07/DetachedfromReality.d12359.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DetachedfromReality.d12359.gmnotes
@@ -5,11 +5,5 @@
   "traits": "Madness.",
   "permanent": false,
   "weakness": true,
-  "bonded": [
-    {
-      "count": 1,
-      "id": "06015b"
-    }
-  ],
   "cycle": "The Dream-Eaters"
 }

--- a/objects/AllPlayerCards.15bb07/DexterDrake.57668a.json
+++ b/objects/AllPlayerCards.15bb07/DexterDrake.57668a.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DexterDrake.fc63ca.json
+++ b/objects/AllPlayerCards.15bb07/DexterDrake.fc63ca.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DianaStanley.359ef4.json
+++ b/objects/AllPlayerCards.15bb07/DianaStanley.359ef4.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/DigDeep4.734b45.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DigDeep4.734b45.gmnotes
@@ -12,6 +12,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/DirtyFighting2.fa1be0.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DirtyFighting2.fa1be0.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Talent. Trick. Illicit.",
   "permanent": false,
   "weakness": false,
-  "combatIcons": 1
+  "combatIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/DissectionTools.95ca5d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DissectionTools.95ca5d.gmnotes
@@ -4,8 +4,9 @@
   "class": "Seeker",
   "cost": 2,
   "level": 0,
-  "traits": "",
+  "traits": "Item. Tool. Science.",
   "permanent": false,
   "weakness": false,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/DowsingRod4.bcb13d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DowsingRod4.bcb13d.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Charm.",
   "permanent": false,
   "weakness": false,
-  "intellectIcons": 2
+  "intellectIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/DrWilliamTMaleson2.3ee7a5.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DrWilliamTMaleson2.3ee7a5.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "intellectIcons": 1
+  "intellectIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Dream-Gate.fa4c1e.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Dream-Gate.fa4c1e.gmnotes
@@ -8,12 +8,5 @@
   "traits": "Dreamlands.",
   "permanent": false,
   "weakness": false,
-  "uses": [
-    {
-      "countPerInvestigator": 0,
-      "type": "Clue",
-      "token": "clue"
-    }
-  ],
   "cycle": "The Dream-Eaters"
 }

--- a/objects/AllPlayerCards.15bb07/EmpiricalHypothesis.62c67d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/EmpiricalHypothesis.62c67d.gmnotes
@@ -12,37 +12,37 @@
     {
       "name": "Pessimistic Outlook",
       "xp": 1,
-      "text": "Add the following criteria: �€�you run out of cards in your hand.�€?"
+      "text": "Add the following criteria: â€œyou run out of cards in your hand.â€�"
     },
     {
       "name": "Trial and Error",
       "xp": 1,
-      "text": "Add the following criteria: �€�you are dealt damage or horror.�€?"
+      "text": "Add the following criteria: â€œyou are dealt damage or horror.â€�"
     },
     {
       "name": "Independent Variable",
       "xp": 1,
-      "text": "Add the following criteria: �€�you discard a treachery or enemy from play.�€?"
+      "text": "Add the following criteria: â€œyou discard a treachery or enemy from play.â€�"
     },
     {
       "name": "Field Research",
       "xp": 1,
-      "text": "Add the following criteria: �€�you enter a location with 3 or more shroud.�€?"
+      "text": "Add the following criteria: â€œyou enter a location with 3 or more shroud.â€�"
     },
     {
       "name": "Peer Review",
       "xp": 2,
-      "text": "The chosen criteria is met if any investigator at your location meets it, instead of only you. Other investigators at your location may trigger ? abilities on Empirical Hypothesis."
+      "text": "The chosen criteria is met if any investigator at your location meets it, instead of only you. Other investigators at your location may trigger ðŸ—² abilities on Empirical Hypothesis."
     },
     {
       "name": "Research Grant",
       "xp": 2,
-      "text": "Empirical Hypothesis gains: �€�? Spend 2 evidence: Reduce the cost of the next card you play this phase by 3.�€?"
+      "text": "Empirical Hypothesis gains: â€œðŸ—² Spend 2 evidence: Reduce the cost of the next card you play this phase by 3.â€�"
     },
     {
       "name": "Irrefutable Proof",
       "xp": 3,
-      "text": "Empirical Hypothesis gains: �€�? Spend 3 evidence: Discover 1 clue at your location.�€?"
+      "text": "Empirical Hypothesis gains: â€œðŸ—² Spend 3 evidence: Discover 1 clue at your location.â€�"
     },
     {
       "name": "Alternative Hypothesis",

--- a/objects/AllPlayerCards.15bb07/EndoftheRoad.a3d041.gmnotes
+++ b/objects/AllPlayerCards.15bb07/EndoftheRoad.a3d041.gmnotes
@@ -6,5 +6,6 @@
   "level": 0,
   "traits": "Insight. Spirit.",
   "permanent": false,
-  "weakness": false
+  "weakness": false,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Eucatastrophe3Taboo.b2ccf8.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Eucatastrophe3Taboo.b2ccf8.gmnotes
@@ -1,8 +1,7 @@
 {
   "id": "05324-t",
   "alternate_ids": [
-    "01692-t",
-    "01692"
+    "01692-t"
   ],
   "type": "Event",
   "class": "Survivor",

--- a/objects/AllPlayerCards.15bb07/EverVigilant4.ac910a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/EverVigilant4.ac910a.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "intellectIcons": 2
+  "intellectIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/ExplosiveWard.f86c67.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ExplosiveWard.f86c67.gmnotes
@@ -2,10 +2,10 @@
   "id": "09087",
   "type": "Event",
   "class": "Mystic",
-  "cost": 0,
   "level": 0,
   "traits": "Spell.",
   "permanent": false,
   "weakness": false,
-  "combatIcons": 2
+  "combatIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/FatherMateo.df852c.json
+++ b/objects/AllPlayerCards.15bb07/FatherMateo.df852c.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/FickleFortune3.1b4684.gmnotes
+++ b/objects/AllPlayerCards.15bb07/FickleFortune3.1b4684.gmnotes
@@ -5,5 +5,7 @@
   "level": 3,
   "traits": "Dilemma. Fortune.",
   "permanent": false,
-  "weakness": false
+  "weakness": false,
+  "intellectIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/FingerprintKit4.33b09e.gmnotes
+++ b/objects/AllPlayerCards.15bb07/FingerprintKit4.33b09e.gmnotes
@@ -14,5 +14,6 @@
       "type": "Supply",
       "token": "resource"
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/FinnEdwards.82dc80.json
+++ b/objects/AllPlayerCards.15bb07/FinnEdwards.82dc80.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/FirstAid3.bc80ab.gmnotes
+++ b/objects/AllPlayerCards.15bb07/FirstAid3.bc80ab.gmnotes
@@ -1,8 +1,5 @@
 {
   "id": "03230",
-  "alternate_ids": [
-    "01683"
-  ],
   "type": "Asset",
   "class": "Guardian",
   "cost": 2,

--- a/objects/AllPlayerCards.15bb07/Flashlight3.2b3301.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Flashlight3.2b3301.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09122",
   "type": "Asset",
+  "class": "Neutral",
   "cost": 2,
   "level": 3,
   "traits": "Item. Tool.",
@@ -14,5 +15,6 @@
       "type": "Supply",
       "token": "resource"
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/FriendsinLowPlaces.c332af.gmnotes
+++ b/objects/AllPlayerCards.15bb07/FriendsinLowPlaces.c332af.gmnotes
@@ -33,7 +33,7 @@
     {
       "name": "Prompt",
       "xp": 2,
-      "text": "Friends in Low Places gains fast and �€�play during any ? window.�€?"
+      "text": "Friends in Low Places gains fast and â€œplay during any ðŸ—² window.â€�"
     },
     {
       "name": "Experienced",

--- a/objects/AllPlayerCards.15bb07/GhastlyPossession.63282f.gmnotes
+++ b/objects/AllPlayerCards.15bb07/GhastlyPossession.63282f.gmnotes
@@ -6,5 +6,6 @@
   "traits": "Innate. Spell.",
   "permanent": false,
   "weakness": false,
-  "wildIcons": 1
+  "wildIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/GloriaGoldberg.aa6282.json
+++ b/objects/AllPlayerCards.15bb07/GloriaGoldberg.aa6282.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/GrapplingHook.09f1a2.gmnotes
+++ b/objects/AllPlayerCards.15bb07/GrapplingHook.09f1a2.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09009",
   "type": "Asset",
+  "class": "Neutral",
   "cost": 3,
   "traits": "Item. Tool.",
   "permanent": false,

--- a/objects/AllPlayerCards.15bb07/GrimMemoir.d1f1d9.gmnotes
+++ b/objects/AllPlayerCards.15bb07/GrimMemoir.d1f1d9.gmnotes
@@ -4,7 +4,7 @@
   "class": "Seeker",
   "cost": 3,
   "level": 0,
-  "traits": "",
+  "traits": "Item. Tome.",
   "permanent": false,
   "weakness": false,
   "intellectIcons": 1,
@@ -14,5 +14,6 @@
       "type": "Secret",
       "token": "resource"
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/GuardDog2.9009db.gmnotes
+++ b/objects/AllPlayerCards.15bb07/GuardDog2.9009db.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "combatIcons": 1
+  "combatIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Guidance1.425841.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Guidance1.425841.gmnotes
@@ -4,9 +4,10 @@
   "class": "Seeker",
   "cost": 0,
   "level": 1,
-  "traits": "",
+  "traits": "Insight.",
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "wildIcons": 1
+  "wildIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Gumption1.4cb0c9.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Gumption1.4cb0c9.gmnotes
@@ -5,5 +5,6 @@
   "level": 1,
   "traits": "Innate.",
   "permanent": false,
-  "weakness": false
+  "weakness": false,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/Handcuffs2.07c480.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Handcuffs2.07c480.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "combatIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/HardKnocks4.9565f0.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HardKnocks4.9565f0.gmnotes
@@ -12,6 +12,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/HarveyWalters.2d6db0.json
+++ b/objects/AllPlayerCards.15bb07/HarveyWalters.2d6db0.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/HonedInstinct.1cde62.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HonedInstinct.1cde62.gmnotes
@@ -4,7 +4,7 @@
   "class": "Rogue",
   "cost": 1,
   "level": 0,
-  "traits": "",
+  "traits": "Gambit.",
   "permanent": false,
   "weakness": false,
   "agilityIcons": 1,
@@ -12,27 +12,27 @@
     {
       "name": "Reflex Response",
       "xp": 1,
-      "text": "Add the following play condition: �€�\u003d You take damage or horror.�€?"
+      "text": "Add the following play condition: â€œ\u003d You take damage or horror.â€�"
     },
     {
       "name": "Situational Awareness",
       "xp": 1,
-      "text": "Add the following play condition: �€�\u003d A location enters play or is revealed.�€?"
+      "text": "Add the following play condition: â€œ\u003d A location enters play or is revealed.â€�"
     },
     {
       "name": "Killer Instinct",
       "xp": 1,
-      "text": "Add the following play condition: �€�\u003d An enemy engages you.�€?"
+      "text": "Add the following play condition: â€œ\u003d An enemy engages you.â€�"
     },
     {
       "name": "Gut Reaction",
       "xp": 1,
-      "text": "Add the following play condition: �€�\u003d A treachery enters your threat area .�€?"
+      "text": "Add the following play condition: â€œ\u003d A treachery enters your threat area .â€�"
     },
     {
       "name": "Muscle Memory",
       "xp": 1,
-      "text": "Add the following play condition: �€�\u003d You play an asset.�€?"
+      "text": "Add the following play condition: â€œ\u003d You play an asset.â€�"
     },
     {
       "name": "Sharpened Talent",
@@ -42,7 +42,7 @@
     {
       "name": "Impulse Control",
       "xp": 3,
-      "text": "You may include up to three copies of Honed Instinct in your deck. Honed Instinct gets �€“1 cost.",
+      "text": "You may include up to three copies of Honed Instinct in your deck. Honed Instinct gets â€“1 cost.",
       "replaces": {
         "cost": 0
       }
@@ -52,5 +52,6 @@
       "xp": 5,
       "text": "When you play Honed Instinct, you may take 2 actions instead of 1 (one at a time). Then, remove it from the game."
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/HuntersArmor.a85f1d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HuntersArmor.a85f1d.gmnotes
@@ -12,7 +12,7 @@
     {
       "name": "Enchanted",
       "xp": 1,
-      "text": "Hunter�€�s Armor gains the Relic trait and takes up an arcane slot instead of a body slot.",
+      "text": "Hunterâ€™s Armor gains the Relic trait and takes up an arcane slot instead of a body slot.",
       "replaces": {
         "traits": "Item. Armor. Relic."
       }
@@ -20,22 +20,22 @@
     {
       "name": "Protective Runes",
       "xp": 2,
-      "text": "Hunter�€�s Armor may be assigned damage and/or horror dealt to other investigators at your location."
+      "text": "Hunterâ€™s Armor may be assigned damage and/or horror dealt to other investigators at your location."
     },
     {
       "name": "Durable",
       "xp": 2,
-      "text": "Hunter�€�s Armor gets +2 health."
+      "text": "Hunterâ€™s Armor gets +2 health."
     },
     {
       "name": "Hallowed",
       "xp": 2,
-      "text": "Hunter�€�s Armor gets +2 sanity."
+      "text": "Hunterâ€™s Armor gets +2 sanity."
     },
     {
       "name": "Lightweight",
       "xp": 2,
-      "text": "Hunter�€�s Armor gets �€“1 cost and playing it does not provoke attacks of opportunity.",
+      "text": "Hunterâ€™s Armor gets â€“1 cost and playing it does not provoke attacks of opportunity.",
       "replaces": {
         "cost": 3
       }
@@ -43,12 +43,12 @@
     {
       "name": "Hexdrinker",
       "xp": 3,
-      "text": "After 1 or more damage or horror is assigned to Hunter�€�s Armor from a treachery effect, you may exhaust it to draw 1 card."
+      "text": "After 1 or more damage or horror is assigned to Hunterâ€™s Armor from a treachery effect, you may exhaust it to draw 1 card."
     },
     {
       "name": "Armor of Thorns",
       "xp": 3,
-      "text": "After 1 or more damage or horror is assigned to Hunter�€�s Armor from an enemy attack, you may exhaust it to deal 1 damage to that enemy."
+      "text": "After 1 or more damage or horror is assigned to Hunterâ€™s Armor from an enemy attack, you may exhaust it to deal 1 damage to that enemy."
     }
   ],
   "cycle": "The Scarlet Keys"

--- a/objects/AllPlayerCards.15bb07/Hyperawareness4.78adda.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Hyperawareness4.78adda.gmnotes
@@ -12,6 +12,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/HyperphysicalShotcaster.2a6e0d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HyperphysicalShotcaster.2a6e0d.gmnotes
@@ -19,27 +19,27 @@
     {
       "name": "Railshooter",
       "xp": 2,
-      "text": "Hyperphysical Shotcaster has this form: �€�Manifest �€“ Fight. Fight with any skill. This attack deals +1 damage.�€?"
+      "text": "Hyperphysical Shotcaster has this form: â€œManifest â€“ Fight. Fight with any skill. This attack deals +1 damage.â€�"
     },
     {
       "name": "Telescanner",
       "xp": 2,
-      "text": "Hyperphysical Shotcaster has this form: �€�Manifest �€“ Investigate. Investigate with any skill. If you succeed, discover a clue at any revealed location instead of your location."
+      "text": "Hyperphysical Shotcaster has this form: â€œManifest â€“ Investigate. Investigate with any skill. If you succeed, discover a clue at any revealed location instead of your location."
     },
     {
       "name": "Translocator",
       "xp": 2,
-      "text": "Hyperphysical Shotcaster has this form: �€�Manifest �€“ Evade. Attempt to evade with any skill. Before or after this attempt, you may move an investigator or a non-Elite enemy at your location to a connecting location, or vice versa.�€?"
+      "text": "Hyperphysical Shotcaster has this form: â€œManifest â€“ Evade. Attempt to evade with any skill. Before or after this attempt, you may move an investigator or a non-Elite enemy at your location to a connecting location, or vice versa.â€�"
     },
     {
       "name": "Realitycollapser",
       "xp": 2,
-      "text": "Hyperphysical Shotcaster has this form: �€�Manifest �€“ Test any skill (3). If you succeed, discard from play a non�€‘weakness treachery that is not attached to an Elite enemy.�€?"
+      "text": "Hyperphysical Shotcaster has this form: â€œManifest â€“ Test any skill (3). If you succeed, discard from play a nonâ€‘weakness treachery that is not attached to an Elite enemy.â€�"
     },
     {
       "name": "Matterweaver",
       "xp": 2,
-      "text": "Hyperphysical Shotcaster has this form: �€�Manifest �€“ Choose an asset in your hand and test any skill (X), where X is that asset�€�s cost. If you succeed, play that asset at no cost.�€?"
+      "text": "Hyperphysical Shotcaster has this form: â€œManifest â€“ Choose an asset in your hand and test any skill (X), where X is that assetâ€™s cost. If you succeed, play that asset at no cost.â€�"
     },
     {
       "name": "Aetheric Link",
@@ -60,5 +60,6 @@
       "xp": 4,
       "text": "While using a Manifest ability, you get +2 skill value."
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/JacquelineFine.9b0378.json
+++ b/objects/AllPlayerCards.15bb07/JacquelineFine.9b0378.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/JennyBarnes.48b174.json
+++ b/objects/AllPlayerCards.15bb07/JennyBarnes.48b174.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/JennyBarnes.f4e909.json
+++ b/objects/AllPlayerCards.15bb07/JennyBarnes.f4e909.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/JimCulver.b7a676.json
+++ b/objects/AllPlayerCards.15bb07/JimCulver.b7a676.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/JoeDiamond.d55364.json
+++ b/objects/AllPlayerCards.15bb07/JoeDiamond.d55364.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/KatjaEastbank2.2f100c.gmnotes
+++ b/objects/AllPlayerCards.15bb07/KatjaEastbank2.2f100c.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "intellectIcons": 1
+  "intellectIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/KickingtheHornetsNest.4d6da5.gmnotes
+++ b/objects/AllPlayerCards.15bb07/KickingtheHornetsNest.4d6da5.gmnotes
@@ -2,9 +2,12 @@
   "id": "09068",
   "type": "Event",
   "class": "Rogue",
+  "cost": 0,
+  "level": 0,
   "traits": "Gambit. Tactic.",
   "permanent": false,
   "weakness": false,
   "intellectIcons": 1,
-  "combatIcons": 1
+  "combatIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/KymaniJones.d3d7fb.json
+++ b/objects/AllPlayerCards.15bb07/KymaniJones.d3d7fb.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/LabCoat1.a825ad.gmnotes
+++ b/objects/AllPlayerCards.15bb07/LabCoat1.a825ad.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Clothing. Science.",
   "permanent": false,
   "weakness": false,
-  "willpowerIcons": 1
+  "willpowerIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/LeoAnderson.8925b0.json
+++ b/objects/AllPlayerCards.15bb07/LeoAnderson.8925b0.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/Lifeline1.895047.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Lifeline1.895047.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Fortune.",
   "permanent": false,
   "weakness": false,
-  "wildIcons": 1
+  "wildIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/LilyChen.4d0128.json
+++ b/objects/AllPlayerCards.15bb07/LilyChen.4d0128.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/LivingInk.42b36d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/LivingInk.42b36d.gmnotes
@@ -52,12 +52,13 @@
     {
       "name": "Macabre Depiction",
       "xp": 3,
-      "text": "Living Ink gains: �€�? After you reveal a chaos token with a symbol, exhaust Living Ink: Place 1 charge on it.�€?"
+      "text": "Living Ink gains: â€œðŸ—² After you reveal a chaos token with a symbol, exhaust Living Ink: Place 1 charge on it.â€�"
     },
     {
       "name": "Vibrancy",
       "xp": 3,
-      "text": "Living Ink grants an additional +1 to the circled skill(s) and �€“1 to each other skill."
+      "text": "Living Ink grants an additional +1 to the circled skill(s) and â€“1 to each other skill."
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/LolaHayes.b127ab.json
+++ b/objects/AllPlayerCards.15bb07/LolaHayes.b127ab.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/LukeRobinson.88c4f4.json
+++ b/objects/AllPlayerCards.15bb07/LukeRobinson.88c4f4.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/LurkerintheDark.79cc11.gmnotes
+++ b/objects/AllPlayerCards.15bb07/LurkerintheDark.79cc11.gmnotes
@@ -1,7 +1,10 @@
 {
   "id": "09124",
   "type": "Enemy",
+  "class": "Neutral",
   "traits": "Monster. Shoggoth.",
   "permanent": false,
-  "weakness": false
+  "weakness": true,
+  "basicWeaknessCount": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/LurkerintheDark.79cc11.json
+++ b/objects/AllPlayerCards.15bb07/LurkerintheDark.79cc11.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "ScenarioCard"
+    "PlayerCard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/MakeshiftTrap.aa897f.gmnotes
+++ b/objects/AllPlayerCards.15bb07/MakeshiftTrap.aa897f.gmnotes
@@ -25,12 +25,12 @@
     {
       "name": "Tripwire",
       "xp": 1,
-      "text": "Only trigger Makeshift Trap�€�s forced ability if there are 1 or more enemies at attached location."
+      "text": "Only trigger Makeshift Trapâ€™s forced ability if there are 1 or more enemies at attached location."
     },
     {
       "name": "Simple",
       "xp": 2,
-      "text": "Makeshift Trap gains fast and �€�play during any ? window.�€?"
+      "text": "Makeshift Trap gains fast and â€œplay during any ðŸ—² window.â€�"
     },
     {
       "name": "Poisonous",
@@ -52,5 +52,6 @@
       "xp": 4,
       "text": "When Makeshift Trap has no time and is discarded, deal 3 damage to each enemy and investigator at attached location."
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/MandyThompson.12d3de.json
+++ b/objects/AllPlayerCards.15bb07/MandyThompson.12d3de.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/MarieLambeau.b05c03.json
+++ b/objects/AllPlayerCards.15bb07/MarieLambeau.b05c03.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/MarkHarrigan.cc354d.json
+++ b/objects/AllPlayerCards.15bb07/MarkHarrigan.cc354d.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/MinhThiPhan.fe6430.json
+++ b/objects/AllPlayerCards.15bb07/MinhThiPhan.fe6430.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/MontereyJack.f74398.json
+++ b/objects/AllPlayerCards.15bb07/MontereyJack.f74398.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/MoonlightRitual2.ad3efc.gmnotes
+++ b/objects/AllPlayerCards.15bb07/MoonlightRitual2.ad3efc.gmnotes
@@ -4,10 +4,11 @@
   "class": "Mystic",
   "cost": 0,
   "level": 2,
-  "traits": "",
+  "traits": "Spell. Insight.",
   "permanent": false,
   "weakness": false,
   "intellectIcons": 1,
   "agilityIcons": 1,
-  "wildIcons": 1
+  "wildIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/NathanielCho.1806e5.json
+++ b/objects/AllPlayerCards.15bb07/NathanielCho.1806e5.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/NormanWithers.a5d9bb.json
+++ b/objects/AllPlayerCards.15bb07/NormanWithers.a5d9bb.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/NormanWitherspromoversion.31fe5e.json
+++ b/objects/AllPlayerCards.15bb07/NormanWitherspromoversion.31fe5e.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/ObsidianBracelet.972250.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ObsidianBracelet.972250.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Charm.",
   "permanent": false,
   "weakness": false,
-  "willpowerIcons": 1
+  "willpowerIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/OldKeyring3.e7d988.gmnotes
+++ b/objects/AllPlayerCards.15bb07/OldKeyring3.e7d988.gmnotes
@@ -14,5 +14,6 @@
       "type": "Key",
       "token": "resource"
     }
-  ]
+  ],
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/OntheMend.ac3502.gmnotes
+++ b/objects/AllPlayerCards.15bb07/OntheMend.ac3502.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09006",
   "type": "Skill",
+  "class": "Neutral",
   "traits": "Innate.",
   "permanent": false,
   "weakness": false,

--- a/objects/AllPlayerCards.15bb07/OnyxPentacle.95f4b0.gmnotes
+++ b/objects/AllPlayerCards.15bb07/OnyxPentacle.95f4b0.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Charm.",
   "permanent": false,
   "weakness": false,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/OnyxPentacle4.647c62.gmnotes
+++ b/objects/AllPlayerCards.15bb07/OnyxPentacle4.647c62.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Charm.",
   "permanent": false,
   "weakness": false,
-  "agilityIcons": 2
+  "agilityIcons": 2,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/PatriceHathaway.877f4d.json
+++ b/objects/AllPlayerCards.15bb07/PatriceHathaway.877f4d.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/PhysicalTraining4.ab51ce.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PhysicalTraining4.ab51ce.gmnotes
@@ -12,6 +12,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/PocketMultiTool.7421ed.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PocketMultiTool.7421ed.gmnotes
@@ -42,7 +42,7 @@
     {
       "name": "Spring-Loaded",
       "xp": 4,
-      "text": "Pocket Multi Tool�€�s ability is now a ? ability with the trigger: �€�When you would fail a skill test you are performing, exhaust Pocket Multi Tool�€��€?"
+      "text": "Pocket Multi Toolâ€™s ability is now a ðŸ—² ability with the trigger: â€œWhen you would fail a skill test you are performing, exhaust Pocket Multi Toolâ€¦â€�"
     }
   ],
   "cycle": "The Scarlet Keys"

--- a/objects/AllPlayerCards.15bb07/PowerWord.c91c1d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PowerWord.c91c1d.gmnotes
@@ -12,27 +12,27 @@
     {
       "name": "Betray",
       "xp": 1,
-      "text": "Add the command: �€�? �€�Betray.�€� Deal 1 damage to any enemy at this enemy�€�s location with an equal or lower fight value than this enemy.�€?"
+      "text": "Add the command: â€œâŸ� â€˜Betray.â€™ Deal 1 damage to any enemy at this enemyâ€™s location with an equal or lower fight value than this enemy.â€�"
     },
     {
       "name": "Mercy",
       "xp": 1,
-      "text": "Add the command: �€�? �€�Mercy.�€� An investigator at this enemy�€�s location heals damage or horror equal to this enemy�€�s respective damage/horror value.�€?"
+      "text": "Add the command: â€œâŸ� â€˜Mercy.â€™ An investigator at this enemyâ€™s location heals damage or horror equal to this enemyâ€™s respective damage/horror value.â€�"
     },
     {
       "name": "Confess",
       "xp": 1,
-      "text": "Add the command: �€�? �€�Confess.�€� Discover 1 clue at this enemy�€�s location if its health is equal to or higher than its location�€�s shroud.�€?"
+      "text": "Add the command: â€œâŸ� â€˜Confess.â€™ Discover 1 clue at this enemyâ€™s location if its health is equal to or higher than its locationâ€™s shroud.â€�"
     },
     {
       "name": "Distract",
       "xp": 1,
-      "text": "Add the command: �€�? �€�Distract.�€� Automatically evade any enemy at this enemy�€�s location with an equal or lower evade value than this enemy.�€?"
+      "text": "Add the command: â€œâŸ� â€˜Distract.â€™ Automatically evade any enemy at this enemyâ€™s location with an equal or lower evade value than this enemy.â€�"
     },
     {
       "name": "Greater Control",
       "xp": 2,
-      "text": "Power Word gains �€�?: Return Power Word to your hand.�€?"
+      "text": "Power Word gains â€œðŸ—²: Return Power Word to your hand.â€�"
     },
     {
       "name": "Bonded",

--- a/objects/AllPlayerCards.15bb07/PreparedfortheWorst2.a4f62a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PreparedfortheWorst2.a4f62a.gmnotes
@@ -9,5 +9,6 @@
   "weakness": false,
   "intellectIcons": 1,
   "combatIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/PressPass2.a6c839.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PressPass2.a6c839.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/PrestonFairmont.78c512.json
+++ b/objects/AllPlayerCards.15bb07/PrestonFairmont.78c512.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/Prophetic3.0e64cb.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Prophetic3.0e64cb.gmnotes
@@ -11,6 +11,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/Rastrad1.f1f24e.json
+++ b/objects/AllPlayerCards.15bb07/Rastrad1.f1f24e.json
@@ -37,7 +37,7 @@
   "LuaScriptState": "",
   "MeasureMovement": false,
   "Name": "Card",
-  "Nickname": "RÃ­astrad (1)",
+  "Nickname": "Ríastrad (1)",
   "SidewaysCard": false,
   "Snap": true,
   "Sticky": true,

--- a/objects/AllPlayerCards.15bb07/Refine.482b10.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Refine.482b10.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/RexMurphy.9ba3f0.json
+++ b/objects/AllPlayerCards.15bb07/RexMurphy.9ba3f0.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/RitaYoung.bdef4d.json
+++ b/objects/AllPlayerCards.15bb07/RitaYoung.bdef4d.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/RitualCandlesTaboo.e99e75.gmnotes
+++ b/objects/AllPlayerCards.15bb07/RitualCandlesTaboo.e99e75.gmnotes
@@ -1,7 +1,7 @@
 {
   "id": "02029-t",
   "alternate_ids": [
-    "60405"
+    "60405-t"
   ],
   "type": "Asset",
   "class": "Mystic",

--- a/objects/AllPlayerCards.15bb07/RolandBanks.1b8e88.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.1b8e88.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/RolandBanks.5bde90.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.5bde90.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/RolandBanks.ed1557.gmnotes
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.ed1557.gmnotes
@@ -1,8 +1,5 @@
 {
-  "id": "01001-r",
-  "alternate_ids": [
-    "98004"
-  ],
+  "id": "01501",
   "type": "Investigator",
   "class": "Guardian",
   "traits": "Agency. Detective.",

--- a/objects/AllPlayerCards.15bb07/RolandBanks.f8cea5.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.f8cea5.json
@@ -24,6 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
+  "GMNotes": "{\n  \"id\": \"01501-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GMNotes_path": "AllPlayerCards.15bb07/RolandBanks.f8cea5.gmnotes",
   "GUID": "f8cea5",
   "Grid": true,
@@ -42,7 +43,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/RunicAxe.7cdb0a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/RunicAxe.7cdb0a.gmnotes
@@ -11,7 +11,6 @@
   "uses": [
     {
       "count": 4,
-      "replenish": 1,
       "type": "Charge",
       "token": "resource"
     }
@@ -29,22 +28,22 @@
     {
       "name": "Inscription of Glory",
       "xp": 1,
-      "text": "Add this inscription: �€�? Glory - If this attack defeats an enemy, choose one: draw 1 card, heal 1 damage, or heal 1 horror.�€?"
+      "text": "Add this inscription: â€œâŸ� Glory - If this attack defeats an enemy, choose one: draw 1 card, heal 1 damage, or heal 1 horror.â€�"
     },
     {
       "name": "Inscription of the Elders",
       "xp": 1,
-      "text": "Add this inscription: �€�? Elders - If this attack succeeds by an amount equal to or grather than your location\u0027s shroud, discover 1 clue at your location.�€?"
+      "text": "Add this inscription: â€œâŸ� Elders - If this attack succeeds by an amount equal to or grather than your location\u0027s shroud, discover 1 clue at your location.â€�"
     },
     {
       "name": "Inscription of the Hunt",
       "xp": 1,
-      "text": "Add this inscription: �€�? Hunt - Immediately move to a connecting location or engage an enemy at your location.�€?"
+      "text": "Add this inscription: â€œâŸ� Hunt - Immediately move to a connecting location or engage an enemy at your location.â€�"
     },
     {
       "name": "Inscription of Fury",
       "xp": 1,
-      "text": "Add this inscription: �€�? Fury - If this attack is successful, in addition to its standard damage, deal 1 damage to each other enemy engaged with you.�€?"
+      "text": "Add this inscription: â€œâŸ� Fury - If this attack is successful, in addition to its standard damage, deal 1 damage to each other enemy engaged with you.â€�"
     },
     {
       "name": "Ancient Power",

--- a/objects/AllPlayerCards.15bb07/ScrollofSecrets3Taboo.a2136a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ScrollofSecrets3Taboo.a2136a.gmnotes
@@ -2,9 +2,11 @@
   "id": "05188-t",
   "type": "Asset",
   "class": "Seeker",
-  "traits": "Item. Tome.",
+  "cost": 1,
   "level": 3,
+  "traits": "Item. Tome.",
   "permanent": false,
+  "weakness": false,
   "intellectIcons": 2,
   "uses": [
     {

--- a/objects/AllPlayerCards.15bb07/SefinaRousseau.d35705.json
+++ b/objects/AllPlayerCards.15bb07/SefinaRousseau.d35705.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/ShedaLight.2c165a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ShedaLight.2c165a.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "intellectIcons": 1,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/SilasMarsh.574b59.json
+++ b/objects/AllPlayerCards.15bb07/SilasMarsh.574b59.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/SilasMarsh.888fcc.json
+++ b/objects/AllPlayerCards.15bb07/SilasMarsh.888fcc.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/SisterMary.1c78ea.json
+++ b/objects/AllPlayerCards.15bb07/SisterMary.1c78ea.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/SkidsOToole.02463b.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOToole.02463b.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"01003-revised-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
+  "GMNotes": "{\n  \"id\": \"01503-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GUID": "02463b",
   "Grid": true,
   "GridProjection": false,
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/SkidsOToole.6b00ec.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOToole.6b00ec.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/SkidsOToole.a41f81.gmnotes
+++ b/objects/AllPlayerCards.15bb07/SkidsOToole.a41f81.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "01003-r",
+  "id": "01503",
   "type": "Investigator",
   "class": "Rogue",
   "traits": "Criminal.",

--- a/objects/AllPlayerCards.15bb07/Sleuth3.1bdb15.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Sleuth3.1bdb15.gmnotes
@@ -11,6 +11,7 @@
   "uses": [
     {
       "count": 2,
+      "replenish": 2,
       "type": "Resource",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/StellaClark.dd3dbd.json
+++ b/objects/AllPlayerCards.15bb07/StellaClark.dd3dbd.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/StylishCoat1.0a1b3a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/StylishCoat1.0a1b3a.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Item. Clothing.",
   "permanent": false,
   "weakness": false,
-  "agilityIcons": 1
+  "agilityIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/SummonedServitor.73b311.gmnotes
+++ b/objects/AllPlayerCards.15bb07/SummonedServitor.73b311.gmnotes
@@ -17,17 +17,17 @@
     {
       "name": "Claws that Catch",
       "xp": 1,
-      "text": "Add this action: �€�? Fight. You fight any enemy at this location with a base Combat of 4. Ignore the aloof and retaliate keywords for this attack.�€?"
+      "text": "Add this action: â€œâŸ� Fight. You fight any enemy at this location with a base Combat of 4. Ignore the aloof and retaliate keywords for this attack.â€�"
     },
     {
       "name": "Jaws that Snatch",
       "xp": 1,
-      "text": "Add this action: �€�? Evade. You attempt to evade any enemy at this location with a base Agility of 4. Ignore the alert keyword for this evasion attempt.�€?"
+      "text": "Add this action: â€œâŸ� Evade. You attempt to evade any enemy at this location with a base Agility of 4. Ignore the alert keyword for this evasion attempt.â€�"
     },
     {
       "name": "Eyes of Flame",
       "xp": 1,
-      "text": "Add this action: �€�? Investigate. You investigate this location with a base Intellect of 4.�€?"
+      "text": "Add this action: â€œâŸ� Investigate. You investigate this location with a base Intellect of 4.â€�"
     },
     {
       "name": "Wings of Night",
@@ -42,10 +42,10 @@
     {
       "name": "Dreaming Call",
       "xp": 3,
-      "text": "Instead of discarding another asset you control in order to play Summoned Servitor, you may return that asset to its owner�€�s hand."
+      "text": "Instead of discarding another asset you control in order to play Summoned Servitor, you may return that asset to its ownerâ€™s hand."
     },
     {
-      "name": "D�monic Influence",
+      "name": "DÃ¦monic Influence",
       "xp": 5,
       "text": "Summoned Servitor can take 2 different actions instead of 1 during each of your turns."
     }

--- a/objects/AllPlayerCards.15bb07/SummonedServitor.d187dd.json
+++ b/objects/AllPlayerCards.15bb07/SummonedServitor.d187dd.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/TheRavenQuill.b81037.gmnotes
+++ b/objects/AllPlayerCards.15bb07/TheRavenQuill.b81037.gmnotes
@@ -12,7 +12,7 @@
     {
       "name": "Living Quill",
       "xp": 1,
-      "text": "Using attached asset�€�s ? abilities does not provoke attacks of opportunity."
+      "text": "Using attached assetâ€™s âž½ abilities does not provoke attacks of opportunity."
     },
     {
       "name": "Spectral Binding",
@@ -32,12 +32,12 @@
     {
       "name": "Energy Sap",
       "xp": 2,
-      "text": "The Raven Quill gains: �€�? Exhaust The Raven Quill: Move 1 secret or charge from an asset you control to attached asset.�€?"
+      "text": "The Raven Quill gains: â€œðŸ—² Exhaust The Raven Quill: Move 1 secret or charge from an asset you control to attached asset.â€�"
     },
     {
       "name": "Interwoven Ink",
       "xp": 3,
-      "text": "After you resolve an ? ability on attached asset, you may exhaust The Raven Quill to ready another asset you control."
+      "text": "After you resolve an âž½ ability on attached asset, you may exhaust The Raven Quill to ready another asset you control."
     },
     {
       "name": "Supernatural Record",

--- a/objects/AllPlayerCards.15bb07/TommyMuldoon.5e73c6.json
+++ b/objects/AllPlayerCards.15bb07/TommyMuldoon.5e73c6.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/TonyMorgan.4f0f4a.json
+++ b/objects/AllPlayerCards.15bb07/TonyMorgan.4f0f4a.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/TriggerMan3.11d7ad.gmnotes
+++ b/objects/AllPlayerCards.15bb07/TriggerMan3.11d7ad.gmnotes
@@ -7,5 +7,6 @@
   "traits": "Ally. Criminal.",
   "permanent": false,
   "weakness": false,
-  "combatIcons": 1
+  "combatIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/TrishScarborough.fc5d62.json
+++ b/objects/AllPlayerCards.15bb07/TrishScarborough.fc5d62.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/TrueMagick5.79870f.gmnotes
+++ b/objects/AllPlayerCards.15bb07/TrueMagick5.79870f.gmnotes
@@ -12,6 +12,7 @@
   "uses": [
     {
       "count": 1,
+      "replenish": 1,
       "type": "Charge",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/TruthfromFiction2.45cd73.gmnotes
+++ b/objects/AllPlayerCards.15bb07/TruthfromFiction2.45cd73.gmnotes
@@ -10,7 +10,7 @@
   "intellectIcons": 3,
   "uses": [
     {
-      "count": 2,
+      "count": 3,
       "type": "Secret",
       "token": "resource"
     }

--- a/objects/AllPlayerCards.15bb07/UncagetheSoul3.343f3a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/UncagetheSoul3.343f3a.gmnotes
@@ -8,5 +8,6 @@
   "permanent": false,
   "weakness": false,
   "willpowerIcons": 1,
-  "wildIcons": 1
+  "wildIcons": 1,
+  "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/UnspeakableOathBloodthirst.a5be8b.gmnotes
+++ b/objects/AllPlayerCards.15bb07/UnspeakableOathBloodthirst.a5be8b.gmnotes
@@ -6,5 +6,6 @@
   "permanent": false,
   "weakness": true,
   "basicWeaknessCount": 1,
+  "hidden": true,
   "cycle": "Return to the Path to Carcosa"
 }

--- a/objects/AllPlayerCards.15bb07/UnspeakableOathCowardice.ea0fa1.gmnotes
+++ b/objects/AllPlayerCards.15bb07/UnspeakableOathCowardice.ea0fa1.gmnotes
@@ -6,5 +6,6 @@
   "permanent": false,
   "weakness": true,
   "basicWeaknessCount": 1,
+  "hidden": true,
   "cycle": "Return to the Path to Carcosa"
 }

--- a/objects/AllPlayerCards.15bb07/UnspeakableOathCuriosity.f6aba5.gmnotes
+++ b/objects/AllPlayerCards.15bb07/UnspeakableOathCuriosity.f6aba5.gmnotes
@@ -6,5 +6,6 @@
   "permanent": false,
   "weakness": true,
   "basicWeaknessCount": 1,
+  "hidden": true,
   "cycle": "Return to the Path to Carcosa"
 }

--- a/objects/AllPlayerCards.15bb07/UrsulaDowns.c91482.json
+++ b/objects/AllPlayerCards.15bb07/UrsulaDowns.c91482.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/VincentLee.43ad8a.json
+++ b/objects/AllPlayerCards.15bb07/VincentLee.43ad8a.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WatcherfromAnotherDimension.6945f7.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WatcherfromAnotherDimension.6945f7.gmnotes
@@ -5,5 +5,6 @@
   "traits": "Monster. Extradimensional.",
   "permanent": false,
   "weakness": true,
+  "hidden": true,
   "cycle": "The Dream-Eaters"
 }

--- a/objects/AllPlayerCards.15bb07/WendyAdams.11bcb3.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WendyAdams.11bcb3.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "01005-r",
+  "id": "01505",
   "type": "Investigator",
   "class": "Survivor",
   "traits": "Drifter.",

--- a/objects/AllPlayerCards.15bb07/WendyAdams.15e40d.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdams.15e40d.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WendyAdams.9b1e1f.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdams.9b1e1f.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"01005-revised-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
+  "GMNotes": "{\n  \"id\": \"01505-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GUID": "9b1e1f",
   "Grid": true,
   "GridProjection": false,
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WilliamYorick.98d974.json
+++ b/objects/AllPlayerCards.15bb07/WilliamYorick.98d974.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WinifredHabbamock.038599.json
+++ b/objects/AllPlayerCards.15bb07/WinifredHabbamock.038599.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WordofWeal.5edfc2.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WordofWeal.5edfc2.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09013",
   "type": "Event",
+  "class": "Neutral",
   "cost": 0,
   "traits": "Pact.",
   "permanent": false,

--- a/objects/AllPlayerCards.15bb07/WordofWoe.bb7174.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WordofWoe.bb7174.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "09012",
   "type": "Event",
+  "class": "Neutral",
   "cost": 2,
   "traits": "Pact.",
   "permanent": false,

--- a/objects/AllPlayerCards.15bb07/WoundedBystander.fb54d3.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WoundedBystander.fb54d3.gmnotes
@@ -9,7 +9,7 @@
     {
       "count": 3,
       "type": "Damage",
-      "token": "Damage"
+      "token": "damage"
     }
   ],
   "cycle": "The Scarlet Keys"

--- a/objects/AllPlayerCards.15bb07/ZoeySamaras.ef75e7.json
+++ b/objects/AllPlayerCards.15bb07/ZoeySamaras.ef75e7.json
@@ -42,7 +42,7 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {


### PR DESCRIPTION
- Adds cycle field to a lot of TSK cards that didn't have it
- Syncs TSK cards with ArkhamDB data which wasn't available for 2.3
- Adds a Minicard tag and removes the PlayerCard tag for Minicards
- Change Revised investigators to their official IDs
- Integrates hotfix releases
--- Add stats for Calvin
--- Correct ID for .35 Winchester (standard had the taboo ID)
--- Add replenish field to uses for appropriate cards
--- Fix level and class fields for Flashlight(3) and Kicking the Hornet's Nest
--- Add some missing fields for Scroll of Secrets