### PR TITLE
Metadata update, Part 3

### DIFF
--- a/objects/AllPlayerCards.15bb07/AgnesBaker.25e2db.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBaker.25e2db.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AgnesBaker.6797bb.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBaker.6797bb.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AgnesBakerParallel.01b6ef.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBakerParallel.01b6ef.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AgnesBakerParallelBack.909f30.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBakerParallelBack.909f30.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AgnesBakerParallelFront.02db0a.json
+++ b/objects/AllPlayerCards.15bb07/AgnesBakerParallelFront.02db0a.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 355,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AkachiOnyele.452ed8.json
+++ b/objects/AllPlayerCards.15bb07/AkachiOnyele.452ed8.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AmandaSharpe.05b950.json
+++ b/objects/AllPlayerCards.15bb07/AmandaSharpe.05b950.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AminaZidane.4c2a3d.json
+++ b/objects/AllPlayerCards.15bb07/AminaZidane.4c2a3d.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/AshcanPete.5294c3.json
+++ b/objects/AllPlayerCards.15bb07/AshcanPete.5294c3.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/BobJenkins.419b0c.json
+++ b/objects/AllPlayerCards.15bb07/BobJenkins.419b0c.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/CalvinWright.b02a1e.json
+++ b/objects/AllPlayerCards.15bb07/CalvinWright.b02a1e.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/CarolynFern.b03b12.json
+++ b/objects/AllPlayerCards.15bb07/CarolynFern.b03b12.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/CarolynFernpromoversion.f0533d.json
+++ b/objects/AllPlayerCards.15bb07/CarolynFernpromoversion.f0533d.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/CarsonSinclair.dc96d1.json
+++ b/objects/AllPlayerCards.15bb07/CarsonSinclair.dc96d1.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/CharlieKane.4deeff.json
+++ b/objects/AllPlayerCards.15bb07/CharlieKane.4deeff.json
@@ -43,7 +43,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "ScenarioCard"
+    "Minicard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/CharlieKane.95fb5e.json
+++ b/objects/AllPlayerCards.15bb07/CharlieKane.95fb5e.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DaisyWalker.6938eb.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalker.6938eb.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DaisyWalker.ac7047.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalker.ac7047.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DaisyWalkerParallel.282857.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalkerParallel.282857.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DaisyWalkerParallelBack.2f2e0d.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalkerParallelBack.2f2e0d.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DaisyWalkerParallelFront.e8cafc.json
+++ b/objects/AllPlayerCards.15bb07/DaisyWalkerParallelFront.e8cafc.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DanielaReyes.444830.json
+++ b/objects/AllPlayerCards.15bb07/DanielaReyes.444830.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DarrellSimmons.5d3d67.json
+++ b/objects/AllPlayerCards.15bb07/DarrellSimmons.5d3d67.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DexterDrake.e015f8.json
+++ b/objects/AllPlayerCards.15bb07/DexterDrake.e015f8.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DexterDrakepromoversion.389792.json
+++ b/objects/AllPlayerCards.15bb07/DexterDrakepromoversion.389792.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/DianaStanley.32b091.json
+++ b/objects/AllPlayerCards.15bb07/DianaStanley.32b091.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/FatherMateo.eb96e6.json
+++ b/objects/AllPlayerCards.15bb07/FatherMateo.eb96e6.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/FinnEdwards.dd40c0.json
+++ b/objects/AllPlayerCards.15bb07/FinnEdwards.dd40c0.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 2,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/GloriaGoldberg.571596.json
+++ b/objects/AllPlayerCards.15bb07/GloriaGoldberg.571596.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/HarveyWalters.1fa944.json
+++ b/objects/AllPlayerCards.15bb07/HarveyWalters.1fa944.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/JacquelineFine.a2cd75.json
+++ b/objects/AllPlayerCards.15bb07/JacquelineFine.a2cd75.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/JennyBarnes.9058d3.json
+++ b/objects/AllPlayerCards.15bb07/JennyBarnes.9058d3.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/JennyBarnespromoversion.f8d3f7.json
+++ b/objects/AllPlayerCards.15bb07/JennyBarnespromoversion.f8d3f7.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/JimCulver.ca079b.json
+++ b/objects/AllPlayerCards.15bb07/JimCulver.ca079b.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/JoeDiamond.6dc626.json
+++ b/objects/AllPlayerCards.15bb07/JoeDiamond.6dc626.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/KymaniJones.9a9830.json
+++ b/objects/AllPlayerCards.15bb07/KymaniJones.9a9830.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/LeoAnderson.126932.json
+++ b/objects/AllPlayerCards.15bb07/LeoAnderson.126932.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/LilyChen.cc21e0.json
+++ b/objects/AllPlayerCards.15bb07/LilyChen.cc21e0.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/LolaHayes.d37332.json
+++ b/objects/AllPlayerCards.15bb07/LolaHayes.d37332.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/LolaHayesTaboo.475460.json
+++ b/objects/AllPlayerCards.15bb07/LolaHayesTaboo.475460.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/LukeRobinson.c59b75.json
+++ b/objects/AllPlayerCards.15bb07/LukeRobinson.c59b75.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/MandyThompson.57d586.json
+++ b/objects/AllPlayerCards.15bb07/MandyThompson.57d586.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/MandyThompsonTaboo.754b0a.json
+++ b/objects/AllPlayerCards.15bb07/MandyThompsonTaboo.754b0a.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 2,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/MarieLambeau.11122f.json
+++ b/objects/AllPlayerCards.15bb07/MarieLambeau.11122f.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/MarkHarrigan.01ac1b.json
+++ b/objects/AllPlayerCards.15bb07/MarkHarrigan.01ac1b.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/MinhThiPhan.6c4c58.json
+++ b/objects/AllPlayerCards.15bb07/MinhThiPhan.6c4c58.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/MontereyJack.46b145.json
+++ b/objects/AllPlayerCards.15bb07/MontereyJack.46b145.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/NathanielCho.65588a.json
+++ b/objects/AllPlayerCards.15bb07/NathanielCho.65588a.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/NormanWithers.e0a155.json
+++ b/objects/AllPlayerCards.15bb07/NormanWithers.e0a155.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/NormanWitherspromoversion.70d488.json
+++ b/objects/AllPlayerCards.15bb07/NormanWitherspromoversion.70d488.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/PatriceHathaway.a7b79f.json
+++ b/objects/AllPlayerCards.15bb07/PatriceHathaway.a7b79f.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/PrestonFairmont.5e6298.json
+++ b/objects/AllPlayerCards.15bb07/PrestonFairmont.5e6298.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RexMurphy.4271cb.json
+++ b/objects/AllPlayerCards.15bb07/RexMurphy.4271cb.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RexMurphyTaboo.9724b7.json
+++ b/objects/AllPlayerCards.15bb07/RexMurphyTaboo.9724b7.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RitaYoung.bb8296.json
+++ b/objects/AllPlayerCards.15bb07/RitaYoung.bb8296.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RolandBanks.9e9e98.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.9e9e98.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RolandBanks.ed1557.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.ed1557.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RolandBanksParallel.502768.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanksParallel.502768.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RolandBanksParallelBack.560cef.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanksParallelBack.560cef.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RolandBanksParallelFront.f7361e.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanksParallelFront.f7361e.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/RolandBankspromoversion.ff1f6e.json
+++ b/objects/AllPlayerCards.15bb07/RolandBankspromoversion.ff1f6e.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SefinaRousseau.342311.json
+++ b/objects/AllPlayerCards.15bb07/SefinaRousseau.342311.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SilasMarsh.3f92cf.json
+++ b/objects/AllPlayerCards.15bb07/SilasMarsh.3f92cf.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SilasMarshpromoversion.1da958.json
+++ b/objects/AllPlayerCards.15bb07/SilasMarshpromoversion.1da958.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SisterMary.617aeb.json
+++ b/objects/AllPlayerCards.15bb07/SisterMary.617aeb.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SkidsOToole.9015b4.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOToole.9015b4.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SkidsOToole.a41f81.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOToole.a41f81.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 1,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SkidsOTooleParallel.22ebb2.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOTooleParallel.22ebb2.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SkidsOTooleParallelBack.a03077.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOTooleParallelBack.a03077.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/SkidsOTooleParallelFront.8116a6.json
+++ b/objects/AllPlayerCards.15bb07/SkidsOTooleParallelFront.8116a6.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/StellaClark.00e18e.json
+++ b/objects/AllPlayerCards.15bb07/StellaClark.00e18e.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/TommyMuldoon.e637cd.json
+++ b/objects/AllPlayerCards.15bb07/TommyMuldoon.e637cd.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/TonyMorgan.53a412.json
+++ b/objects/AllPlayerCards.15bb07/TonyMorgan.53a412.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/TrishScarborough.333fe7.json
+++ b/objects/AllPlayerCards.15bb07/TrishScarborough.333fe7.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/UrsulaDowns.07c37d.json
+++ b/objects/AllPlayerCards.15bb07/UrsulaDowns.07c37d.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/VincentLee.c431f3.json
+++ b/objects/AllPlayerCards.15bb07/VincentLee.c431f3.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WendyAdams.11bcb3.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdams.11bcb3.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WendyAdams.fc1d17.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdams.fc1d17.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WendyAdamsParallel.fd91ea.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdamsParallel.fd91ea.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WendyAdamsParallelBack.4232d9.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdamsParallelBack.4232d9.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 2,
     "rotY": 180,
     "rotZ": 1,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WendyAdamsParallelFront.61503e.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdamsParallelFront.61503e.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 359,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WilliamYorick.7e4c56.json
+++ b/objects/AllPlayerCards.15bb07/WilliamYorick.7e4c56.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/WinifredHabbamock.cd4028.json
+++ b/objects/AllPlayerCards.15bb07/WinifredHabbamock.cd4028.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""

--- a/objects/AllPlayerCards.15bb07/ZoeySamaras.98a0e1.json
+++ b/objects/AllPlayerCards.15bb07/ZoeySamaras.98a0e1.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Investigator",
     "PlayerCard"
   ],
   "Tooltip": true,
@@ -52,9 +53,9 @@
     "rotX": 0,
     "rotY": 180,
     "rotZ": 0,
-    "scaleX": 1.1,
+    "scaleX": 1.15,
     "scaleY": 1,
-    "scaleZ": 1.1
+    "scaleZ": 1.15
   },
   "Value": 0,
   "XmlUI": ""


### PR DESCRIPTION
Add Investigator tag to all investigator cards.  This will support tagging the snap points on playmats.

Set size of all investigators to 1.15.  This puts them over the threshold where TTS will combine them with a standard deck and resize them.