### PR TITLE
Refactor upgrade sheet handling in the deck loader

### DIFF
--- a/objects/AllPlayerCards.15bb07/AlchemicalDistillationUpgradeSheet.156166.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AlchemicalDistillationUpgradeSheet.156166.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09040-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/AlchemicalDistillationUpgradeSheet.156166.json
+++ b/objects/AllPlayerCards.15bb07/AlchemicalDistillationUpgradeSheet.156166.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09040-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/AlchemicalDistillationUpgradeSheet.156166.gmnotes",
   "GUID": "156166",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/CustomModificationsUpgradeSheet.4104bf.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CustomModificationsUpgradeSheet.4104bf.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09023-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/CustomModificationsUpgradeSheet.4104bf.json
+++ b/objects/AllPlayerCards.15bb07/CustomModificationsUpgradeSheet.4104bf.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09023-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/CustomModificationsUpgradeSheet.4104bf.gmnotes",
   "GUID": "4104bf",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/DamningTestimonyUpgradeSheet.dc4a62.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DamningTestimonyUpgradeSheet.dc4a62.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09059-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/DamningTestimonyUpgradeSheet.dc4a62.json
+++ b/objects/AllPlayerCards.15bb07/DamningTestimonyUpgradeSheet.dc4a62.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09059-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/DamningTestimonyUpgradeSheet.dc4a62.gmnotes",
   "GUID": "dc4a62",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/EmpiricalHypothesisUpgradeSheet.0c46a7.gmnotes
+++ b/objects/AllPlayerCards.15bb07/EmpiricalHypothesisUpgradeSheet.0c46a7.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09041-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/EmpiricalHypothesisUpgradeSheet.0c46a7.json
+++ b/objects/AllPlayerCards.15bb07/EmpiricalHypothesisUpgradeSheet.0c46a7.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09041-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/EmpiricalHypothesisUpgradeSheet.0c46a7.gmnotes",
   "GUID": "0c46a7",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/FriendsinLowPlacesUpgradeSheet.9fb3b9.gmnotes
+++ b/objects/AllPlayerCards.15bb07/FriendsinLowPlacesUpgradeSheet.9fb3b9.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09060-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/FriendsinLowPlacesUpgradeSheet.9fb3b9.json
+++ b/objects/AllPlayerCards.15bb07/FriendsinLowPlacesUpgradeSheet.9fb3b9.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09060-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/FriendsinLowPlacesUpgradeSheet.9fb3b9.gmnotes",
   "GUID": "9fb3b9",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/GrizzledUpgradeSheet.ef8f08.gmnotes
+++ b/objects/AllPlayerCards.15bb07/GrizzledUpgradeSheet.ef8f08.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09101-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/GrizzledUpgradeSheet.ef8f08.json
+++ b/objects/AllPlayerCards.15bb07/GrizzledUpgradeSheet.ef8f08.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09101-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/GrizzledUpgradeSheet.ef8f08.gmnotes",
   "GUID": "ef8f08",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/HonedInstinctUpgradeSheet.ba0e34.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HonedInstinctUpgradeSheet.ba0e34.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09061-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/HonedInstinctUpgradeSheet.ba0e34.json
+++ b/objects/AllPlayerCards.15bb07/HonedInstinctUpgradeSheet.ba0e34.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09061-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/HonedInstinctUpgradeSheet.ba0e34.gmnotes",
   "GUID": "ba0e34",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/HuntersArmorUpgradeSheet.d2d01b.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HuntersArmorUpgradeSheet.d2d01b.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09021-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/HuntersArmorUpgradeSheet.d2d01b.json
+++ b/objects/AllPlayerCards.15bb07/HuntersArmorUpgradeSheet.d2d01b.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09021-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/HuntersArmorUpgradeSheet.d2d01b.gmnotes",
   "GUID": "d2d01b",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/HyperphysicalShotcasterUpgradeSheet.a4eec2.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HyperphysicalShotcasterUpgradeSheet.a4eec2.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09119-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/HyperphysicalShotcasterUpgradeSheet.a4eec2.json
+++ b/objects/AllPlayerCards.15bb07/HyperphysicalShotcasterUpgradeSheet.a4eec2.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09119-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/HyperphysicalShotcasterUpgradeSheet.a4eec2.gmnotes",
   "GUID": "a4eec2",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/LivingLinkUpgradeSheet.19a05b.gmnotes
+++ b/objects/AllPlayerCards.15bb07/LivingLinkUpgradeSheet.19a05b.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09079-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/LivingLinkUpgradeSheet.19a05b.json
+++ b/objects/AllPlayerCards.15bb07/LivingLinkUpgradeSheet.19a05b.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09079-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/LivingLinkUpgradeSheet.19a05b.gmnotes",
   "GUID": "19a05b",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/MakeshiftTrapUpgradeSheet.64dfce.gmnotes
+++ b/objects/AllPlayerCards.15bb07/MakeshiftTrapUpgradeSheet.64dfce.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09100-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/MakeshiftTrapUpgradeSheet.64dfce.json
+++ b/objects/AllPlayerCards.15bb07/MakeshiftTrapUpgradeSheet.64dfce.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09100-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/MakeshiftTrapUpgradeSheet.64dfce.gmnotes",
   "GUID": "64dfce",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/PocketMultiToolUpgradeSheet.d706e7.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PocketMultiToolUpgradeSheet.d706e7.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09099-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/PocketMultiToolUpgradeSheet.d706e7.json
+++ b/objects/AllPlayerCards.15bb07/PocketMultiToolUpgradeSheet.d706e7.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09099-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/PocketMultiToolUpgradeSheet.d706e7.gmnotes",
   "GUID": "d706e7",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/PowerWordUpgradeSheet.0d9481.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PowerWordUpgradeSheet.0d9481.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09081-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/PowerWordUpgradeSheet.0d9481.json
+++ b/objects/AllPlayerCards.15bb07/PowerWordUpgradeSheet.0d9481.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09081-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/PowerWordUpgradeSheet.0d9481.gmnotes",
   "GUID": "0d9481",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/RolandBanks.f8cea5.json
+++ b/objects/AllPlayerCards.15bb07/RolandBanks.f8cea5.json
@@ -24,7 +24,6 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"01501-m\",\n  \"type\": \"Minicard\",\n  \"traits\": \"\"\n}",
   "GMNotes_path": "AllPlayerCards.15bb07/RolandBanks.f8cea5.gmnotes",
   "GUID": "f8cea5",
   "Grid": true,

--- a/objects/AllPlayerCards.15bb07/RunicAxeUpgradeSheet.be427d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/RunicAxeUpgradeSheet.be427d.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09022-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/RunicAxeUpgradeSheet.be427d.json
+++ b/objects/AllPlayerCards.15bb07/RunicAxeUpgradeSheet.be427d.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09022-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/RunicAxeUpgradeSheet.be427d.gmnotes",
   "GUID": "be427d",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/SummonedServitorUpgradeSheet.5397a6.gmnotes
+++ b/objects/AllPlayerCards.15bb07/SummonedServitorUpgradeSheet.5397a6.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09080-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/SummonedServitorUpgradeSheet.5397a6.json
+++ b/objects/AllPlayerCards.15bb07/SummonedServitorUpgradeSheet.5397a6.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09080-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/SummonedServitorUpgradeSheet.5397a6.gmnotes",
   "GUID": "5397a6",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/TheRavenQuillUpgradeSheet.23b96a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/TheRavenQuillUpgradeSheet.23b96a.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "09042-c",
+  "type": "UpgradeSheet",
+  "traits": "",
+  "permanent": false,
+  "weakness": false
+}

--- a/objects/AllPlayerCards.15bb07/TheRavenQuillUpgradeSheet.23b96a.json
+++ b/objects/AllPlayerCards.15bb07/TheRavenQuillUpgradeSheet.23b96a.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"09042-c\",\n  \"traits\": \"\",\n  \"permanent\": false,\n  \"weakness\": false\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/TheRavenQuillUpgradeSheet.23b96a.gmnotes",
   "GUID": "23b96a",
   "Grid": true,
   "GridProjection": false,

--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -226,6 +226,9 @@ function maybeAddInvestigatorCards(deck, slots)
   end
 end
 
+-- Process the card list looking for the customizable cards, and add their upgrade sheets if needed
+---@param slots: The slot list for cards in this deck. Table key is the cardId, value is the number
+--     of those cards which will be spawned
 function maybeAddCustomizeUpgradeSheets(slots, configuration)
   local allCardsBag = getObjectFromGUID(configuration.card_bag_guid)
   for cardId, _ in pairs(slots) do
@@ -237,11 +240,15 @@ function maybeAddCustomizeUpgradeSheets(slots, configuration)
   end
 end
 
+-- Process the card list looking for the Summoned Servitor, and add its minicard to the list if
+-- needed
+---@param slots: The slot list for cards in this deck. Table key is the cardId, value is the number
+--     of those cards which will be spawned
 function maybeAddSummonedServitor(slots)
   for cardId, cardCount in pairs(slots) do
     -- spawn additional minicard for 'Summoned Servitor'
     if cardId == "09080" then
-      slots["09080-m"] = cardCount
+      slots["09080-m"] = 1
       return
     end
   end
@@ -299,7 +306,7 @@ end
 ---@param cardMetadata: Table of card metadata.  Metadata fields type and permanent are required; all others are optional.
 ---@return: Zone name such as "Deck", "SetAside1", etc. See Zones object documentation for a list of valid zones.
 function getDefaultCardZone(cardMetadata)
-  if (cardMetadata.id == "09080-m") then
+  if (cardMetadata.id == "09080-m") then -- Have to check the Servitor before other minicards
     return "SetAside6"
   elseif cardMetadata.type == "Investigator" then
     return "Investigator"
@@ -307,12 +314,13 @@ function getDefaultCardZone(cardMetadata)
     return "Minicard"
   elseif cardMetadata.type == "UpgradeSheet" then
     return "SetAside4"
+  elseif cardMetadata.startsInPlay then
+    return "BlankTop"
   elseif cardMetadata.permanent then
     return "SetAside1"
   elseif bondedList[cardMetadata.id] then
     return "SetAside2"
     -- SetAside3 is used for Ancestral Knowledge / Underworld Market
-    -- SetAside4 is used for upgrade sheets
   else
     return "Deck"
   end
@@ -353,7 +361,6 @@ function loadCards(slots, investigatorId, customizations, playerColor, commandMa
     -- TODO: Process commands for the cardsToSpawn list
 
     -- These should probably be commands, once the command handler is updated
-    handleStartsInPlay(cardsToSpawn)
     handleAncestralKnowledge(cardsToSpawn)
     handleUnderworldMarket(cardsToSpawn, playerColor)
     handleHunchDeck(investigatorId, cardsToSpawn, playerColor)
@@ -496,13 +503,6 @@ function handleAltInvestigatorCard(cardList, altVersionTag, configuration)
   end
 end
 
--- Place cards which start in play (Duke, Sophie) in the play area
-function handleStartsInPlay(cardList)
-  for _, card in ipairs(cardList) do
-    if card.metadata.startsInPlay then card.zone = "BlankTop" end
-  end
-end
-
 -- Check to see if the deck list has Ancestral Knowledge. If it does, move 5 random skills to SetAside3
 function handleAncestralKnowledge(cardList)
   local hasAncestralKnowledge = false
@@ -611,6 +611,10 @@ function handleHunchDeck(investigatorId, cardList, playerColor)
   end
 end
 
+-- For any customization upgrade cards in the card list, process the metadata from the deck to
+-- set the save state to show the correct checkboxes/text field values
+---@param cardList: Deck list being created
+---@param customizations: Deck's meta table, extracted from ArkhamDB's deck structure
 function handleCustomizableUpgrades(cardList, customizations)
   for _, card in ipairs(cardList) do
     if card.metadata.type == "UpgradeSheet" then

--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -147,6 +147,8 @@ local function onDeckResult(deck, playerColor, configuration)
   local slots = deck.slots
   maybeDrawRandomWeakness(slots, playerColor, configuration)
   maybeAddInvestigatorCards(deck, slots)
+  maybeAddCustomizeUpgradeSheets(slots, configuration)
+  maybeAddSummonedServitor(slots)
   extractBondedCards(slots, configuration)
   checkTaboos(deck.taboo_id, slots, playerColor, configuration)
 
@@ -171,8 +173,8 @@ local function onDeckResult(deck, playerColor, configuration)
   local customizations = {}
   if meta then customizations = JSON.decode(deck.meta) end
 
-  loadCards(slots, deck.investigator_code, playerColor, commandManager,
-    configuration, results.configuration, customizations)
+  loadCards(slots, deck.investigator_code, customizations, playerColor, commandManager,
+    configuration, results.configuration)
 end
 
 -- Checks to see if the slot list includes the random weakness ID. If it does,
@@ -221,6 +223,27 @@ function maybeAddInvestigatorCards(deck, slots)
       investigatorId = investigatorId .. "-pb"
     end
     slots[investigatorId] = 1
+  end
+end
+
+function maybeAddCustomizeUpgradeSheets(slots, configuration)
+  local allCardsBag = getObjectFromGUID(configuration.card_bag_guid)
+  for cardId, _ in pairs(slots) do
+    -- upgrade sheets for customizable cards
+    local upgradesheet = allCardsBag.call("getCardById", { id = cardId .. "-c" })
+    if upgradesheet ~= nil then
+      slots[cardId.."-c"] = 1
+    end
+  end
+end
+
+function maybeAddSummonedServitor(slots)
+  for cardId, cardCount in pairs(slots) do
+    -- spawn additional minicard for 'Summoned Servitor'
+    if cardId == "09080" then
+      slots["09080-m"] = cardCount
+      return
+    end
   end
 end
 
@@ -276,10 +299,14 @@ end
 ---@param cardMetadata: Table of card metadata.  Metadata fields type and permanent are required; all others are optional.
 ---@return: Zone name such as "Deck", "SetAside1", etc. See Zones object documentation for a list of valid zones.
 function getDefaultCardZone(cardMetadata)
-  if cardMetadata.type == "Investigator" then
+  if (cardMetadata.id == "09080-m") then
+    return "SetAside6"
+  elseif cardMetadata.type == "Investigator" then
     return "Investigator"
   elseif cardMetadata.type == "Minicard" then
     return "Minicard"
+  elseif cardMetadata.type == "UpgradeSheet" then
+    return "SetAside4"
   elseif cardMetadata.permanent then
     return "SetAside1"
   elseif bondedList[cardMetadata.id] then
@@ -300,10 +327,10 @@ end
 --     Investigator cards should already be added to the slots list if they
 --     should be spawned, but this value is separate to check for special
 --     handling for certain investigators
+---@param customizations: ArkhamDB data for customizations on customizable cards
 ---@param playerColor String Color name of the player mat to place this deck on (e.g. "Red")
 ---@param configuration: Loader configuration object
----@param customizations: ArkhamDB data for customizations on customizable cards
-function loadCards(slots, investigatorId, playerColor, commandManager, configuration, command_config, customizations)
+function loadCards(slots, investigatorId, customizations, playerColor, commandManager, configuration, command_config)
   function coinside()
     local allCardsBag = getObjectFromGUID(configuration.card_bag_guid)
     local yPos = {}
@@ -314,73 +341,6 @@ function loadCards(slots, investigatorId, playerColor, commandManager, configura
         local cardZone = getDefaultCardZone(card.metadata)
         for i = 1, cardCount do
           table.insert(cardsToSpawn, { data = card.data, metadata = card.metadata, zone = cardZone })
-        end
-
-        -- upgrade sheets for customizable cards
-        local upgradesheet = allCardsBag.call("getCardById", { id = cardId .. "-c" })
-        if upgradesheet ~= nil then
-
-          -- update metadata for spawned upgrade sheets
-          local upgrades = customizations["cus_" .. cardId]
-
-          if upgrades ~= nil then
-            -- initialize tables
-            -- markedBoxes: contains the amount of markedBoxes (left to right) per row (starting at row 1)
-            -- inputValues: contains the amount of inputValues per row (starting at row 0)
-            local markedBoxes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
-            local inputValues = {}
-            local index_xp    = {}
-
-            -- get the index and xp values (looks like this: X|X,X|X, ..)
-            for str in string.gmatch(customizations["cus_" .. cardId], "([^,]+)") do
-              table.insert(index_xp, str)
-            end
-
-            -- split each pair and assign it to the proper position in markedBoxes
-            if (customizationRowsWithFields[cardId] ~= nil) then
-              for i = 1, customizationRowsWithFields[cardId].inputCount do
-                table.insert(inputValues, "")
-              end
-            end
-            local inputCount = 0
-            for _, entry in ipairs(index_xp) do
-              local counter = 0
-              local index   = 0
-
-              -- if found number is 0, then only get inputvalue
-              for str in string.gmatch(entry, "([^|]+)") do
-                counter = counter + 1
-                if counter == 1 then
-                  index = tonumber(str) + 1
-                elseif counter == 2 then
-                  markedBoxes[index] = tonumber(str)
-                elseif counter == 3 and str ~= "" then
-                  if (cardId == "09042") then
-                    inputValues[customizationRowsWithFields[cardId].inputMap[index]] =
-                        convertRavenQuillSelections(str)
-                  else
-                    inputValues[customizationRowsWithFields[cardId].inputMap[index]] = str
-                  end
-                end
-              end
-            end
-
-            -- remove first entry in markedBoxes if row 0 has textbox
-            if customizationRowsWithFields[cardId] ~= nil
-                and customizationRowsWithFields[cardId].inputCount > 0 then
-              table.remove(markedBoxes, 1)
-            end
-
-            -- write the loaded values to the save_data of the sheets
-            upgradesheet.data["LuaScriptState"] = JSON.encode({ markedBoxes, inputValues })
-            table.insert(cardsToSpawn, { data = upgradesheet.data, metadata = upgradesheet.metadata, zone = "SetAside4" })
-          end
-        end
-
-        -- spawn additional minicard for 'Summoned Servitor'
-        if cardId == "09080" then
-          local servitor = allCardsBag.call("getCardById", { id = "09080-m" })
-          table.insert(cardsToSpawn, { data = servitor.data, metadata = servitor.metadata, zone = "SetAside6" })
         end
 
         slots[cardId] = 0
@@ -397,6 +357,7 @@ function loadCards(slots, investigatorId, playerColor, commandManager, configura
     handleAncestralKnowledge(cardsToSpawn)
     handleUnderworldMarket(cardsToSpawn, playerColor)
     handleHunchDeck(investigatorId, cardsToSpawn, playerColor)
+    handleCustomizableUpgrades(cardsToSpawn, customizations)
 
     -- Split the card list into separate lists for each zone
     local zoneDecks = buildZoneLists(cardsToSpawn)
@@ -646,6 +607,69 @@ function handleHunchDeck(investigatorId, cardList, playerColor)
         playerColor)
     else
       debugPrint("Built Joe's hunch deck", Priority.INFO, playerColor)
+    end
+  end
+end
+
+function handleCustomizableUpgrades(cardList, customizations)
+  for _, card in ipairs(cardList) do
+    if card.metadata.type == "UpgradeSheet" then
+      local baseId = string.sub(card.metadata.id, 1, 5)
+      local upgrades = customizations["cus_" .. baseId]
+      log(upgrades)
+      log(baseId)
+
+      if upgrades ~= nil then
+        -- initialize tables
+        -- markedBoxes: contains the amount of markedBoxes (left to right) per row (starting at row 1)
+        -- inputValues: contains the amount of inputValues per row (starting at row 0)
+        local markedBoxes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+        local inputValues = {}
+        local index_xp    = {}
+
+        -- get the index and xp values (looks like this: X|X,X|X, ..)
+        for str in string.gmatch(customizations["cus_" .. baseId], "([^,]+)") do
+          table.insert(index_xp, str)
+        end
+
+        -- split each pair and assign it to the proper position in markedBoxes
+        if (customizationRowsWithFields[baseId] ~= nil) then
+          for i = 1, customizationRowsWithFields[baseId].inputCount do
+            table.insert(inputValues, "")
+          end
+        end
+        local inputCount = 0
+        for _, entry in ipairs(index_xp) do
+          local counter = 0
+          local index   = 0
+
+          -- if found number is 0, then only get inputvalue
+          for str in string.gmatch(entry, "([^|]+)") do
+            counter = counter + 1
+            if counter == 1 then
+              index = tonumber(str) + 1
+            elseif counter == 2 then
+              markedBoxes[index] = tonumber(str)
+            elseif counter == 3 and str ~= "" then
+              if (baseId == "09042") then
+                inputValues[customizationRowsWithFields[baseId].inputMap[index]] =
+                    convertRavenQuillSelections(str)
+              else
+                inputValues[customizationRowsWithFields[baseId].inputMap[index]] = str
+              end
+            end
+          end
+        end
+
+        -- remove first entry in markedBoxes if row 0 has textbox
+        if customizationRowsWithFields[baseId] ~= nil
+            and customizationRowsWithFields[baseId].inputCount > 0 then
+          table.remove(markedBoxes, 1)
+        end
+
+        -- write the loaded values to the save_data of the sheets
+        card.data["LuaScriptState"] = JSON.encode({ markedBoxes, inputValues })
+      end
     end
   end
 end

--- a/src/playermat/Zones.ttslua
+++ b/src/playermat/Zones.ttslua
@@ -27,7 +27,7 @@ playerMatGuids["Green"]  = "383d8b"
 
 commonZones                 = {}
 commonZones["Investigator"] = { -1.17702, 0, 0.00209 }
-commonZones["Minicard"]     = { -0.4668214, 0, -1.222326 }
+commonZones["Minicard"]     = { -0.16, 0, -1.222326 }
 commonZones["Deck"]         = { -1.822724, 0, -0.02940192 }
 commonZones["Discard"]      = { -1.822451, 0, 0.6092291 }
 commonZones["Ally"]         = { -0.6157398, 0, 0.02435675 }


### PR DESCRIPTION
- Split upgrade sheets to follow the slots/data pattern
- Factor out methods to set selections on upgrade sheets
- Factor out method to add Summoned Servitor minicard
- Add type 'UpgradeSheet' to appropriate cards
- Remove handleStartsInPlay() method and detect it as a default zone