### PR TITLE
Fix bug with deck loader since trait removal

### DIFF
--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -540,7 +540,7 @@ function handleUnderworldMarket(cardList, playerColor)
       -- Underworld Market found
       hasMarket = true
       card.zone = "SetAside3"
-    elseif (string.find(card.metadata.traits, "Illicit", 1, true)
+    elseif (card.metadata.traits ~= nil and string.find(card.metadata.traits, "Illicit", 1, true)
         and card.metadata.bonded_to == nil
         and not card.metadata.weakness) then
       table.insert(illicitList, i)
@@ -583,6 +583,7 @@ function handleHunchDeck(investigatorId, cardList, playerColor)
     local insightList = {}
     for i, card in ipairs(cardList) do
       if (card.metadata.type == "Event"
+          and card.metadata.traits ~= nil
           and string.match(card.metadata.traits, "Insight")
           and card.metadata.bonded_to == nil) then
         table.insert(insightList, i)


### PR DESCRIPTION
Since traits are now an optional field in the metadata, add nil checks when using them