### PR TITLE
Add Norman's old promo ArkhamDB ID as an alternate

### DIFF
--- a/objects/AllPlayerCards.15bb07/NormanWithers.a5d9bb.gmnotes
+++ b/objects/AllPlayerCards.15bb07/NormanWithers.a5d9bb.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "08004-m",
+  "alternate_ids": [
+    "98007-m"
+  ],
+  "type": "Minicard"
+}

--- a/objects/AllPlayerCards.15bb07/NormanWithers.a5d9bb.json
+++ b/objects/AllPlayerCards.15bb07/NormanWithers.a5d9bb.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\n  \"id\": \"08004-m\",\n  \"type\": \"Minicard\"\n}",
+  "GMNotes_path": "AllPlayerCards.15bb07/NormanWithers.a5d9bb.gmnotes",
   "GUID": "a5d9bb",
   "Grid": true,
   "GridProjection": false,

--- a/objects/AllPlayerCards.15bb07/NormanWithers.e0a155.gmnotes
+++ b/objects/AllPlayerCards.15bb07/NormanWithers.e0a155.gmnotes
@@ -1,5 +1,8 @@
 {
   "id": "08004",
+  "alternate_ids": [
+    "98007"
+  ],
   "type": "Investigator",
   "class": "Seeker",
   "traits": "Miskatonic.",


### PR DESCRIPTION
This will load old ArkhamDB decks with the promo investigator as the standard card, but planned work to merge alternate art will make it available again to all.