### PR TITLE
Block chaos bag changes while the bag is being searched

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -26,6 +26,8 @@ local chaosTokens = {}
 local chaosTokensLastMat = nil
 local IS_RESHUFFLING = false
 
+local bagSearchers = { }
+
 ---------------------------------------------------------
 -- data for tokens
 ---------------------------------------------------------
@@ -140,6 +142,26 @@ function isDeck(x) return x.tag == 'Deck' end
 
 function isCardOrDeck(x) return x.tag == 'Card' or x.tag == 'Deck' end
 
+-- Event hook for any object search.  When chaos tokens are manipulated while the chaos bag
+-- container is being searched, a TTS bug can cause tokens to duplicate or vanish.  We lock the
+-- chaos bag during search operations to avoid this.
+function onObjectSearchStart(object, playerColor)
+  findChaosBag()
+  if object.getGUID() == chaosbag.getGUID() then
+    bagSearchers[playerColor] = true
+  end
+end
+
+-- Event hook for any object search.  When chaos tokens are manipulated while the chaos bag
+-- container is being searched, a TTS bug can cause tokens to duplicate or vanish.  We lock the
+-- chaos bag during search operations to avoid this.
+function onObjectSearchEnd(object, playerColor)
+  findChaosBag()
+  if object.getGUID() == chaosbag.getGUID() then
+    bagSearchers[playerColor] = nil
+  end
+end
+
 function drawEncountercard(params)
   local position = params[1]
   local rotation = params[2]
@@ -233,7 +255,27 @@ function returnChaosTokens()
   chaosTokens = {}
 end
 
+-- Checks to see if the chaos bag can be manipulated.  If a player is searching the bag when tokens
+-- are drawn or replaced a TTS bug can cause those tokens to vanish.  Any functions which change the
+-- contents of the bag should check this method before doing so.
+-- This method will broadcast a message to all players if the bag is being searched.
+-- @return Boolean.  True if the bag is manipulated, false if it should be blocked.
+function canTouchChaosTokens()
+  for color, searching in pairs(bagSearchers) do
+    if searching then
+      broadcastToAll("Someone is searching the chaos bag, can't touch the tokens", "Red")
+      return false
+    end
+  end
+
+  return true
+end
+
 function drawChaostoken(params)
+  if not canTouchChaosTokens() then
+    return
+  end
+
   local mat = params[1]
   local tokenOffset = params[2]
   local isRightClick = params[3]
@@ -347,7 +389,7 @@ function printChaosTokenStats()
 
     printToAll(playerName ..  " Stats", playerColour)
     printNonZeroTokenPairs(personalStats[matGUID])
-    
+
     if playerSquidCount > maxSquid then
       squidKing = playerName
       maxSquid = playerSquidCount

--- a/src/tokens/BlessCurseManager.ttslua
+++ b/src/tokens/BlessCurseManager.ttslua
@@ -248,6 +248,9 @@ end
 
 -- function that is called by click_functions 1+2 and calls the other functions
 function callFunctions(token, isRightClick)
+    if not Global.call("canTouchChaosTokens") then
+        return
+    end
     local success
     if not altState then
         if isRightClick then


### PR DESCRIPTION
A TTS bug can cause tokens to be lost or possibly duplicated if they are added to a container while that container is being searched.  This uses event listeners to block bag changes while it is being searched.

Steps to reproduce:
1. Search the bag
2. Add a token to the bag (bless/curse is easiest)
3. Remove a token from the bag using the search window
4. Close the search

The token supposedly added in #2 will be gone.