### PR TITLE
Dynamic playmat snap point tagging

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -1,5 +1,5 @@
 -- set true to enable debug logging and show Physics.cast()
-local DEBUG = true
+local DEBUG = false
 
 -- we use this to turn off collision handling until onLoad() is complete
 local COLLISION_ENABLED = false
@@ -655,11 +655,6 @@ end
 -- @param matchTypes Boolean.  Whether snap points should only snap for the matching card types.
 function setLimitSnapsByType(params)
   local matchTypes = params.matchTypes
-  if matchTypes then
-    log("Set true")
-  else
-    log("Set false")
-  end
   local snaps = self.getSnapPoints()
   for i, snap in ipairs(snaps) do
     local snapPos = snap.position
@@ -691,7 +686,12 @@ function setLimitSnapsByType(params)
   self.setSnapPoints(snaps)
 end
 
-function inArea(point, bounds)
+-- Simple method to check if the given point is in a specified area.  Local use only,
+-- @param point Vector.  Point to check, only x and z values are relevant
+-- @param bounds Table.  Defined area to see if the point is within.  See MAIN_PLAY_AREA for sample
+--     bounds definition.
+-- @return Boolean.  True if the point is in the area defined by bounds
+local function inArea(point, bounds)
   return (point.x < bounds.upperLeft.x
       and point.x > bounds.lowerRight.x
       and point.z < bounds.upperLeft.z

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -1,5 +1,5 @@
 -- set true to enable debug logging and show Physics.cast()
-local DEBUG = false
+local DEBUG = true
 
 -- we use this to turn off collision handling until onLoad() is complete
 local COLLISION_ENABLED = false
@@ -14,6 +14,27 @@ local DISCARD_BUTTON_OFFSETS = {
   {0, 0.1, -0.945},
   {0.455, 0.1, -0.945},
   {0.91, 0.1, -0.945}
+}
+
+local MAIN_PLAY_AREA = {
+  upperLeft = {
+    x = 1.98,
+    z = 0.736,
+  },
+  lowerRight = {
+    x = -0.79,
+    z = -0.39,
+  }
+}
+local INVESTIGATOR_AREA = {
+  upperLeft = {
+    x = -1.084,
+    z = 0.06517
+  },
+  lowerRight = {
+    x = -1.258,
+    z = -0.0805,
+  }
 }
 
 local PLAY_ZONE_ROTATION = self.getRotation()
@@ -625,6 +646,56 @@ end
 
 function spawnToken(position, tokenType)
   Global.call('spawnToken', {position, tokenType, PLAY_ZONE_ROTATION})
+end
+
+-- Sets this playermat's snap points to limit snapping to matching card types or not.  If matchTypes
+-- is true, the main card slot snap points will only snap assets, while the investigator area point
+-- will only snap Investigators.  If matchTypes is false, snap points will be reset to snap all
+-- cards.
+-- @param matchTypes Boolean.  Whether snap points should only snap for the matching card types.
+function setLimitSnapsByType(params)
+  local matchTypes = params.matchTypes
+  if matchTypes then
+    log("Set true")
+  else
+    log("Set false")
+  end
+  local snaps = self.getSnapPoints()
+  for i, snap in ipairs(snaps) do
+    local snapPos = snap.position
+    if inArea(snapPos, MAIN_PLAY_AREA) then
+      local snapTags = snaps[i].tags
+      if matchTypes then
+        if snapTags == nil then
+          snaps[i].tags = { "Asset" }
+        else
+          table.insert(snaps[i].tags, "Asset")
+        end
+      else
+        snaps[i].tags = nil
+      end
+    end
+    if inArea(snapPos, INVESTIGATOR_AREA) then
+      local snapTags = snaps[i].tags
+      if matchTypes then
+        if snapTags == nil then
+          snaps[i].tags = { "Investigator" }
+        else
+          table.insert(snaps[i].tags, "Investigator")
+        end
+      else
+        snaps[i].tags = nil
+      end
+    end
+  end
+  self.setSnapPoints(snaps)
+end
+
+function inArea(point, bounds)
+  return (point.x < bounds.upperLeft.x
+      and point.x > bounds.lowerRight.x
+      and point.z < bounds.upperLeft.z
+      and point.z > bounds.lowerRight.z)
 end
 
 -- called by custom data helpers to add player card data

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -653,8 +653,7 @@ end
 -- will only snap Investigators.  If matchTypes is false, snap points will be reset to snap all
 -- cards.
 -- @param matchTypes Boolean.  Whether snap points should only snap for the matching card types.
-function setLimitSnapsByType(params)
-  local matchTypes = params.matchTypes
+function setLimitSnapsByType(matchTypes)
   local snaps = self.getSnapPoints()
   for i, snap in ipairs(snaps) do
     local snapPos = snap.position
@@ -691,7 +690,7 @@ end
 -- @param bounds Table.  Defined area to see if the point is within.  See MAIN_PLAY_AREA for sample
 --     bounds definition.
 -- @return Boolean.  True if the point is in the area defined by bounds
-local function inArea(point, bounds)
+function inArea(point, bounds)
   return (point.x < bounds.upperLeft.x
       and point.x > bounds.lowerRight.x
       and point.z < bounds.upperLeft.z

--- a/src/playermat/PlaymatApi.ttslua
+++ b/src/playermat/PlaymatApi.ttslua
@@ -1,0 +1,48 @@
+do
+  local PlaymatApi = { }
+  local internal = { }
+
+  local WHITE_MAT_GUID = "8b081b"
+  local ORANGE_MAT_GUID = "bd0ff4"
+  local GREEN_MAT_GUID = "383d8b"
+  local RED_MAT_GUID = "0840d5"
+
+  -- Sets the requested playermat's snap points to limit snapping to matching card types or not.  If
+  -- matchTypes is true, the main card slot snap points will only snap assets, while the
+  -- investigator area point will only snap Investigators.  If matchTypes is false, snap points will
+  -- be reset to snap all cards.
+  -- @param matchTypes Boolean.  Whether snap points should only snap for the matching card types.
+  -- @param matColor String for one of the active player colors - White, Orange, Green, Red.  Also
+  --     accepts "All" as a special value which will apply the setting to all four mats.
+  PlaymatApi.setLimitSnapsByType = function(matchCardTypes, matColor)
+    for _, mat in ipairs(internal.getMatForColor(matColor)) do
+      mat.call("setLimitSnapsByType", { matchTypes = matchCardTypes })
+    end
+  end
+
+  -- Convenience function to look up a mat's object by color, or get all mats.
+  -- @param matColor String for one of the active player colors - White, Orange, Green, Red.  Also
+  --     accepts "All" as a special value which will return all four mats.
+  -- @return Array of playermat objects.  If a single mat is requested, will return a single-element
+  --     array to simplify processing by consumers.
+  internal.getMatForColor = function(matColor)
+    if matColor == "White" then
+      return { getObjectFromGUID(WHITE_MAT_GUID) }
+    elseif matColor == "Orange" then
+      return { getObjectFromGUID(ORANGE_MAT_GUID) }
+    elseif matColor == "Green" then
+      return { getObjectFromGUID(GREEN_MAT_GUID) }
+    elseif matColor == "Red" then
+      return { getObjectFromGUID(RED_MAT_GUID) }
+    elseif matColor == "All" then
+      return {
+        getObjectFromGUID(WHITE_MAT_GUID),
+        getObjectFromGUID(ORANGE_MAT_GUID),
+        getObjectFromGUID(GREEN_MAT_GUID),
+        getObjectFromGUID(RED_MAT_GUID),
+      }
+    end
+  end
+
+  return PlaymatApi
+end

--- a/src/playermat/PlaymatApi.ttslua
+++ b/src/playermat/PlaymatApi.ttslua
@@ -11,7 +11,8 @@ do
   -- matchTypes is true, the main card slot snap points will only snap assets, while the
   -- investigator area point will only snap Investigators.  If matchTypes is false, snap points will
   -- be reset to snap all cards.
-  -- @param matchTypes Boolean.  Whether snap points should only snap for the matching card types.
+  -- @param matchCardTypes Boolean.  Whether snap points should only snap for the matching card
+  --     types.
   -- @param matColor String for one of the active player colors - White, Orange, Green, Red.  Also
   --     accepts "All" as a special value which will apply the setting to all four mats.
   PlaymatApi.setLimitSnapsByType = function(matchCardTypes, matColor)

--- a/src/playermat/PlaymatApi.ttslua
+++ b/src/playermat/PlaymatApi.ttslua
@@ -2,10 +2,12 @@ do
   local PlaymatApi = { }
   local internal = { }
 
-  local WHITE_MAT_GUID = "8b081b"
-  local ORANGE_MAT_GUID = "bd0ff4"
-  local GREEN_MAT_GUID = "383d8b"
-  local RED_MAT_GUID = "0840d5"
+  local MAT_IDS = {
+    White = "8b081b",
+    Orange = "bd0ff4",
+    Green = "383d8b",
+    Red = "0840d5",
+  }
 
   -- Sets the requested playermat's snap points to limit snapping to matching card types or not.  If
   -- matchTypes is true, the main card slot snap points will only snap assets, while the
@@ -17,7 +19,7 @@ do
   --     accepts "All" as a special value which will apply the setting to all four mats.
   PlaymatApi.setLimitSnapsByType = function(matchCardTypes, matColor)
     for _, mat in ipairs(internal.getMatForColor(matColor)) do
-      mat.call("setLimitSnapsByType", { matchTypes = matchCardTypes })
+      mat.call("setLimitSnapsByType", matchCardTypes)
     end
   end
 
@@ -27,20 +29,16 @@ do
   -- @return Array of playermat objects.  If a single mat is requested, will return a single-element
   --     array to simplify processing by consumers.
   internal.getMatForColor = function(matColor)
-    if matColor == "White" then
-      return { getObjectFromGUID(WHITE_MAT_GUID) }
-    elseif matColor == "Orange" then
-      return { getObjectFromGUID(ORANGE_MAT_GUID) }
-    elseif matColor == "Green" then
-      return { getObjectFromGUID(GREEN_MAT_GUID) }
-    elseif matColor == "Red" then
-      return { getObjectFromGUID(RED_MAT_GUID) }
-    elseif matColor == "All" then
+    local targetMatGuid = MAT_IDS[matColor]
+    if targetMatGuid != nil then
+      return { getObjectFromGUID(targetMatGuid) }
+    end
+    if matColor == "All" then
       return {
-        getObjectFromGUID(WHITE_MAT_GUID),
-        getObjectFromGUID(ORANGE_MAT_GUID),
-        getObjectFromGUID(GREEN_MAT_GUID),
-        getObjectFromGUID(RED_MAT_GUID),
+        getObjectFromGUID(MAT_IDS.White),
+        getObjectFromGUID(MAT_IDS.Orange),
+        getObjectFromGUID(MAT_IDS.Green),
+        getObjectFromGUID(MAT_IDS.Red),
       }
     end
   end


### PR DESCRIPTION
Adds an interface to control whether playermat snap points will be tagged for the card types.

This uses a new API pattern with an object which can be included via require() and provides indirect access to other objects in the mod.