### PR TITLE
Add PlayArea API

### DIFF
--- a/objects/Fan-MadeAccessories.aa8b38/CleanUpHelper.26cf4b.ttslua
+++ b/objects/Fan-MadeAccessories.aa8b38/CleanUpHelper.26cf4b.ttslua
@@ -5,6 +5,8 @@
 --                  - puts everything on playmats and hands into respective trashcans
 --                  - use the IGNORE_TAG to exclude objects from tidying (default: "CleanUpHelper_Ignore")
 
+local playAreaApi = require("core/PlayAreaApi")
+
 -- enable this for debugging
 local SHOW_RAYS = false
 
@@ -207,10 +209,10 @@ function resetCounters()
   end
 
   -- reset doom on agenda
-  local doomcounter = getObjectFromGUID("85c4c6")
-  if doomcounter ~= nil then
-    doomcounter.call("setToZero")
-  end
+  -- local doomcounter = getObjectFromGUID("85c4c6")
+  -- if doomcounter ~= nil then
+  --   doomcounter.call("setToZero")
+  -- end
 
   for i, guid in ipairs(TRACKER_GUIDS) do
     local obj = getObjectFromGUID(guid)
@@ -300,10 +302,7 @@ function tidyPlaymatCoroutine()
     end
   end
 
-  local PLAYMAT = getObjectFromGUID('721ba2')
-  if PLAYMAT then
-    PLAYMAT.setTable("SPAWNED_LOCATION_GUIDS", {})
-  end
+  playAreaApi.resetSpawnedCards()
 
   printToAll("Tidying playermats and agenda mat...", "White")
   startLuaCoroutine(self, "tidyPlayerMatCoroutine")

--- a/objects/Fan-MadeAccessories.aa8b38/CustomPlaymatImages.004fe7.ttslua
+++ b/objects/Fan-MadeAccessories.aa8b38/CustomPlaymatImages.004fe7.ttslua
@@ -762,4 +762,3 @@ function removeImages()
     tile.destruct()
   end
 end
-

--- a/objects/Fan-MadeAccessories.aa8b38/DisplacementTool.0f1374.ttslua
+++ b/objects/Fan-MadeAccessories.aa8b38/DisplacementTool.0f1374.ttslua
@@ -1,15 +1,4 @@
-local excluded = {
-  ["b7b45b"] = true,
-  ["f182ee"] = true,
-  ["721ba2"] = true
-}
-
-local OFFSETS = {
-  left  = { x = 0.00, y = 0, z = 7.67 },
-  right = { x = 0.00, y = 0, z = -7.67 },
-  up    = { x = 6.54, y = 0, z = 0.00 },
-  down  = { x = -6.54, y = 0, z = 0.00 }
-}
+local playAreaApi = require("core/PlayAreaApi")
 
 local UI_offset = 1.15
 
@@ -46,24 +35,10 @@ function onLoad()
   self.createButton(buttonParamaters)
 end
 
-function shift_left(color) shift(color, "left") end
+function shift_left(color) playAreaApi.shiftContentsLeft(color) end
 
-function shift_right(color) shift(color, "right") end
+function shift_right(color) playAreaApi.shiftContentsRight(color) end
 
-function shift_up(color) shift(color, "up") end
+function shift_up(color) playAreaApi.shiftContentsUp(color) end
 
-function shift_down(color) shift(color, "down") end
-
-function shift(color, direction)
-  local zone = getObjectFromGUID("a2f932")
-  if not zone then
-    broadcastToColor("Scripting zone couldn't be found.", color, "Red")
-    return
-  end
-
-  for _, object in ipairs(zone.getObjects()) do
-    if not (excluded[object.getGUID()] or object.hasTag("displacement_excluded")) then
-      object.translate(OFFSETS[direction])
-    end
-  end
-end
+function shift_down(color) playAreaApi.shiftContentsDown(color) end

--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -1,5 +1,6 @@
 require("arkhamdb/LoaderUi")
 require("playercards/PlayerCardSpawner")
+local playAreaApi = require("core/PlayAreaApi")
 
 local zones = require("playermat/Zones")
 
@@ -32,8 +33,6 @@ customizationRowsWithFields["09101"].inputMap = {}
 customizationRowsWithFields["09101"].inputMap[1] = 1
 customizationRowsWithFields["09101"].inputMap[2] = 2
 customizationRowsWithFields["09101"].inputMap[3] = 3
-
-local PLAY_AREA_GUID = "721ba2"
 
 local RANDOM_WEAKNESS_ID = "01000"
 local tags = { configuration = "import_configuration_provider" }
@@ -260,9 +259,9 @@ end
 --     of those cards which will be spawned
 function maybeAddOnTheMend(slots)
   if slots["09006"] ~= nil then
-    local playArea = getObjectFromGUID(PLAY_AREA_GUID)
-    if playArea ~= nil then
-      slots["09006"] = playArea.call("getInvestigatorCount")
+    local investigatorCount = playAreaApi.getInvestigatorCount()
+    if investigatorCount ~= nil then
+      slots["09006"] = investigatorCount
     end
   end
 end

--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -151,7 +151,7 @@ local function onDeckResult(deck, playerColor, configuration)
   maybeAddInvestigatorCards(deck, slots)
   maybeAddCustomizeUpgradeSheets(slots, configuration)
   maybeAddSummonedServitor(slots)
-  maybeAddOnTheMend(slots)
+  maybeAddOnTheMend(slots, playerColor)
   extractBondedCards(slots, configuration)
   checkTaboos(deck.taboo_id, slots, playerColor, configuration)
 
@@ -257,11 +257,15 @@ end
 -- the count based on the investigator count
 ---@param slots: The slot list for cards in this deck. Table key is the cardId, value is the number
 --     of those cards which will be spawned
-function maybeAddOnTheMend(slots)
+---@param playerColor: Color name of the player this deck is being loaded for. Used for broadcast if an error occurs
+function maybeAddOnTheMend(slots, playerColor)
   if slots["09006"] ~= nil then
     local investigatorCount = playAreaApi.getInvestigatorCount()
     if investigatorCount ~= nil then
       slots["09006"] = investigatorCount
+    else
+      debugPrint("Something went wrong with the load, adding 4 copies of On the Mend", Priority.INFO, playerColor)
+      slots["09006"] = 4
     end
   end
 end

--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -8,7 +8,21 @@ DEBUG = false
 -- we use this to turn off collision handling until onLoad() is complete
 COLLISION_ENABLED = false
 
+local SHIFT_OFFSETS = {
+  left  = { x = 0.00, y = 0, z = 7.67 },
+  right = { x = 0.00, y = 0, z = -7.67 },
+  up    = { x = 6.54, y = 0, z = 0.00 },
+  down  = { x = -6.54, y = 0, z = 0.00 }
+}
+local SHIFT_EXCLUSION = {
+  ["b7b45b"] = true,
+  ["f182ee"] = true,
+  ["721ba2"] = true
+}
+
 local INVESTIGATOR_COUNTER_GUID = "f182ee"
+local PLAY_AREA_ZONE_GUID = "a2f932"
+
 local clueData = {}
 spawnedLocationGUIDs = {}
 
@@ -122,7 +136,60 @@ function onCollisionEnter(collision_info)
   end
 end
 
+-- Move all contents on the play area (cards, tokens, etc) one row up.  Certain fixed objects will
+-- be ignored, as will anything the player has tagged with 'displacement_excluded'
+---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+---    message in the unlikely case that the scripting zone has been deleted
+function shiftContentsUp(playerColor)
+  shiftContents(playerColor, "up")
+end
+
+-- Move all contents on the play area (cards, tokens, etc) one row down.  Certain fixed objects
+-- will be ignored, as will anything the player has tagged with 'displacement_excluded'
+---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+---    message in the unlikely case that the scripting zone has been deleted
+function shiftContentsDown(playerColor)
+  shiftContents(playerColor, "down")
+end
+
+-- Move all contents on the play area (cards, tokens, etc) one column left.  Certain fixed objects
+-- will be ignored, as will anything the player has tagged with 'displacement_excluded'
+---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+---    message in the unlikely case that the scripting zone has been deleted
+function shiftContentsLeft(playerColor)
+  shiftContents(playerColor, "left")
+end
+
+-- Move all contents on the play area (cards, tokens, etc) one column right.  Certain fixed
+-- objects will be ignored, as will anything the player has tagged with 'displacement_excluded'
+---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+---    message in the unlikely case that the scripting zone has been deleted
+function shiftContentsRight(playerColor)
+  shiftContents(playerColor, "right")
+end
+
+function shiftContents(playerColor, direction)
+  local zone = getObjectFromGUID(PLAY_AREA_ZONE_GUID)
+  if not zone then
+    broadcastToColor("Scripting zone couldn't be found.", playerColor, "Red")
+    return
+  end
+
+  for _, object in ipairs(zone.getObjects()) do
+    if not (SHIFT_EXCLUSION[object.getGUID()] or object.hasTag("displacement_excluded")) then
+      object.translate(SHIFT_OFFSETS[direction])
+    end
+  end
+end
+
+-- Returns the current value of the investigator counter from the playmat
+---@return Integer.  Number of investigators currently set on the counter
 function getInvestigatorCount()
-  local investigatorCounter = getObjectFromGUID('f182ee')
+  local investigatorCounter = getObjectFromGUID("f182ee")
   return investigatorCounter.getVar("val")
+end
+
+-- Reset the play area's tracking of which cards have had tokens spawned.
+function resetSpawnedCards()
+  spawnedLocationGUIDs = {}
 end

--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -136,34 +136,23 @@ function onCollisionEnter(collision_info)
   end
 end
 
--- Move all contents on the play area (cards, tokens, etc) one row up.  Certain fixed objects will
--- be ignored, as will anything the player has tagged with 'displacement_excluded'
+-- Move all contents on the play area (cards, tokens, etc) one slot in the given direction.  Certain
+-- fixed objects will be ignored, as will anything the player has tagged with
+-- 'displacement_excluded'
 ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
 ---    message in the unlikely case that the scripting zone has been deleted
 function shiftContentsUp(playerColor)
   shiftContents(playerColor, "up")
 end
 
--- Move all contents on the play area (cards, tokens, etc) one row down.  Certain fixed objects
--- will be ignored, as will anything the player has tagged with 'displacement_excluded'
----@param playerColor Color of the player requesting the shift.  Used solely to send an error
----    message in the unlikely case that the scripting zone has been deleted
 function shiftContentsDown(playerColor)
   shiftContents(playerColor, "down")
 end
 
--- Move all contents on the play area (cards, tokens, etc) one column left.  Certain fixed objects
--- will be ignored, as will anything the player has tagged with 'displacement_excluded'
----@param playerColor Color of the player requesting the shift.  Used solely to send an error
----    message in the unlikely case that the scripting zone has been deleted
 function shiftContentsLeft(playerColor)
   shiftContents(playerColor, "left")
 end
 
--- Move all contents on the play area (cards, tokens, etc) one column right.  Certain fixed
--- objects will be ignored, as will anything the player has tagged with 'displacement_excluded'
----@param playerColor Color of the player requesting the shift.  Used solely to send an error
----    message in the unlikely case that the scripting zone has been deleted
 function shiftContentsRight(playerColor)
   shiftContents(playerColor, "right")
 end

--- a/src/core/PlayAreaApi.ttslua
+++ b/src/core/PlayAreaApi.ttslua
@@ -1,0 +1,50 @@
+do
+  local PlayAreaApi = { }
+
+  local PLAY_AREA_GUID = "721ba2"
+
+  -- Returns the current value of the investigator counter from the playmat
+  ---@return Integer.  Number of investigators currently set on the counter
+  PlayAreaApi.getInvestigatorCount = function()
+    return getObjectFromGUID(PLAY_AREA_GUID).call("getInvestigatorCount")
+  end
+
+  -- Move all contents on the play area (cards, tokens, etc) one row up.  Certain fixed objects will
+  -- be ignored, as will anything the player has tagged with 'displacement_excluded'
+  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+  ---    message in the unlikely case that the scripting zone has been deleted
+  PlayAreaApi.shiftContentsUp = function(playerColor)
+    return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsUp", playerColor)
+  end
+
+  -- Move all contents on the play area (cards, tokens, etc) one row down.  Certain fixed objects
+  -- will be ignored, as will anything the player has tagged with 'displacement_excluded'
+  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+  ---    message in the unlikely case that the scripting zone has been deleted
+  PlayAreaApi.shiftContentsDown = function(playerColor)
+    return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsDown", playerColor)
+  end
+
+  -- Move all contents on the play area (cards, tokens, etc) one column left.  Certain fixed objects
+  -- will be ignored, as will anything the player has tagged with 'displacement_excluded'
+  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+  ---    message in the unlikely case that the scripting zone has been deleted
+  PlayAreaApi.shiftContentsLeft = function(playerColor)
+    return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsLeft", playerColor)
+  end
+
+  -- Move all contents on the play area (cards, tokens, etc) one column right.  Certain fixed
+  -- objects will be ignored, as will anything the player has tagged with 'displacement_excluded'
+  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
+  ---    message in the unlikely case that the scripting zone has been deleted
+  PlayAreaApi.shiftContentsRight = function(playerColor)
+    return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsRight", playerColor)
+  end
+
+  -- Reset the play area's tracking of which cards have had tokens spawned.
+  PlayAreaApi.resetSpawnedCards = function()
+    return getObjectFromGUID(PLAY_AREA_GUID).call("resetSpawnedCards")
+  end
+
+  return PlayAreaApi
+end

--- a/src/core/PlayAreaApi.ttslua
+++ b/src/core/PlayAreaApi.ttslua
@@ -9,34 +9,23 @@ do
     return getObjectFromGUID(PLAY_AREA_GUID).call("getInvestigatorCount")
   end
 
-  -- Move all contents on the play area (cards, tokens, etc) one row up.  Certain fixed objects will
-  -- be ignored, as will anything the player has tagged with 'displacement_excluded'
+  -- Move all contents on the play area (cards, tokens, etc) one slot in the given direction.  Certain
+  -- fixed objects will be ignored, as will anything the player has tagged with
+  -- 'displacement_excluded'
   ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
   ---    message in the unlikely case that the scripting zone has been deleted
   PlayAreaApi.shiftContentsUp = function(playerColor)
     return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsUp", playerColor)
   end
 
-  -- Move all contents on the play area (cards, tokens, etc) one row down.  Certain fixed objects
-  -- will be ignored, as will anything the player has tagged with 'displacement_excluded'
-  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
-  ---    message in the unlikely case that the scripting zone has been deleted
   PlayAreaApi.shiftContentsDown = function(playerColor)
     return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsDown", playerColor)
   end
 
-  -- Move all contents on the play area (cards, tokens, etc) one column left.  Certain fixed objects
-  -- will be ignored, as will anything the player has tagged with 'displacement_excluded'
-  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
-  ---    message in the unlikely case that the scripting zone has been deleted
   PlayAreaApi.shiftContentsLeft = function(playerColor)
     return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsLeft", playerColor)
   end
 
-  -- Move all contents on the play area (cards, tokens, etc) one column right.  Certain fixed
-  -- objects will be ignored, as will anything the player has tagged with 'displacement_excluded'
-  ---@param playerColor Color of the player requesting the shift.  Used solely to send an error
-  ---    message in the unlikely case that the scripting zone has been deleted
   PlayAreaApi.shiftContentsRight = function(playerColor)
     return getObjectFromGUID(PLAY_AREA_GUID).call("shiftContentsRight", playerColor)
   end


### PR DESCRIPTION
Creates an API object for the PlayArea, and moves most references to the PlayArea to use the API instead.

Image swapper is excluded on this, as I'm not completely sure how TTS will handle having an object rebuild itself.