### PR TITLE
Chaos Bag: Stop shuffling onLoad()

### DIFF
--- a/src/chaosbag/ChaosBag.ttslua
+++ b/src/chaosbag/ChaosBag.ttslua
@@ -1,13 +1,9 @@
+-- automatically add correct names to tokens that enter the chaos bag
 function filterObjectEnter(obj)
     local props = obj.getCustomObject()
     if props ~= nil and props.image ~= nil then
-        obj.setName(Global.call("getTokenName", { url=props.image }))
+        obj.setName(Global.call("getTokenName", { url = props.image }))
     end
     return true
 end
 
-function onCollisionEnter(collision_info)
-    self.shuffle()
-    self.shuffle()
-    self.shuffle()
-end


### PR DESCRIPTION
Removed the chaos bag shuffling because this does clutter every commit after decomposing...

It's not needed because chaos token drawing does pull random tokens anyway.