### PR TITLE
Option Panel: Part 4 - Rebuilding UI for scrollview // Token Arranger: Bugfix

### DIFF
--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -75,13 +75,23 @@
     "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118466516005/113C19D37CFFA9E554394FD5B11B32967F846A62/"
   },
   {
-    "Name": "option_image1",
+    "Name": "option_header1",
     "Type": 0,
-    "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118468280563/911BA319CD7502258D570B23BD51B3D8DA8B2AC3/"
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321894443102/5727544F24E8C4546031F4DDE8BD4B45D93AC3FC/"
   },
   {
-    "Name": "option_image2",
+    "Name": "option_header2",
     "Type": 0,
-    "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118470839572/FB133C41A6D8915A44C138BCF947ECFE3D111813/"
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321894443022/3262DF2ABAE8D9A2BF64ECB74C1BB34B33814554/"
+  },
+  {
+    "Name": "option_on",
+    "Type": 0,
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321889555728/22ABD35CBB49A001F3A5318E4AFCFB22D24FEA39/"
+  },
+  {
+    "Name": "option_off",
+    "Type": 0,
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321889555661/6643E5CC9160FF4624672C255D0DF7B313DA00A5/"
   }
 ]

--- a/objects/Fan-MadeAccessories.aa8b38/TokenArranger.022907.ttslua
+++ b/objects/Fan-MadeAccessories.aa8b38/TokenArranger.022907.ttslua
@@ -193,37 +193,22 @@ function layout(_, _, isRightClick)
     -- stop here if right-clicked
     if isRightClick then return end
 
-    local chaos_bag = getChaosBag()
-    local chaos_bag_objects = chaos_bag.getObjects()
-
-    -- take each token out and clone it
-    for _, data in ipairs(chaos_bag_objects) do
-        chaos_bag.takeObject {
-            guid = data.guid,
-            smooth = false,
-            callback_function = function(tok)
-                chaos_bag.putObject(tok.clone())
-                tok.addTag("to_be_deleted")
-            end
-        }
-    end
-
-    -- wait until all tokens have finished spawning
-    Wait.condition(function() placeTokens() end, function() return #chaos_bag_objects == #getObjectsWithTag("to_be_deleted") end)
-end
-
--- position tokens sorted by value
-function placeTokens()
+    local chaosBag = getChaosBag()
     local data = {}
 
-    -- create table with tokens
-    for i, token in ipairs(getObjectsWithTag("to_be_deleted")) do
-        local name = token.getName() or ""
-        local value = tonumber(name)
-        local precedence = TOKEN_PRECEDENCE[name]
+    -- clone tokens from chaos bag (default position above trash can)
+    for i, obj in ipairs(chaosBag.getData().ContainedObjects) do
+        obj["Tags"] = { "to_be_deleted" }
+        local spawnedObj = spawnObjectData({
+            data = obj,
+            position = { 0.49, 3, 0 }
+        })
+
+        local value = tonumber(obj["Nickname"])
+        local precedence = TOKEN_PRECEDENCE[obj["Nickname"]]
 
         data[i] = {
-            token = token,
+            token = spawnedObj,
             value = value or precedence[1]
         }
 
@@ -237,11 +222,17 @@ function placeTokens()
     -- sort table by value (symbols last if same value)
     table.sort(data, token_value_comparator)
 
+    -- error handling for removal of token arranger
+    if self == nil then
+        for _, token in ipairs(getObjectsWithTag("to_be_deleted")) do token.destruct() end
+        return
+    end
+    
     -- laying out the tokens
     local pos           = self.getPosition() + Vector(3.55, -0.05, -3.95)
     local location      = { x = pos.x, y = pos.y, z = pos.z }
     local current_value = data[1].value
-
+    
     for _, item in ipairs(data) do
         if item.value ~= current_value then
             location.x = location.x - 1.75

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -857,6 +857,10 @@ function applyOptionPanelChange(id, state)
   -- option: Show chaos bag manager
   elseif id == "showChaosBagManager" then
     spawnOrRemoveHelper(state, "Chaos Bag Manager", {-67.8, 1.4, -49.5})
+
+  -- option: Show navigation overlay
+  elseif id == "showNavigationOverlay" then
+    spawnOrRemoveHelper(state, "jaqenZann's Navigation Overlay", {-11.7, 1.4, -15})
   end
 end
 

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -1,18 +1,27 @@
 <!-- Default formatting -->
 <Defaults>
-  <Text color="white" alignment="MiddleLeft"/>
+  <Text color="#FFFFFF" alignment="MiddleLeft"/>
   <Toggle isOn="False" rectAlignment="MiddleRight"/>
+  <Cell dontUseTableCellBackground="true" outlineSize="0 1" outline="grey"/>
 
-  <VerticalLayout class="window" visibility="Admin" active="false" color="black" width="500" height="700" outlineSize="1 1" outline="grey" showAnimation="SlideIn_Right" hideAnimation="SlideOut_Right" animationDuration="0.1"/>
-  <VerticalLayout class="group" visibility="Admin" outlineSize="1 1" outline="grey" color="#222222" padding="10" spacing="5"/>
-  <VerticalLayout class="text-column" visibility="Admin" padding="5 20 0 0"/>
+  <!-- main window -->
+  <TableLayout class="window" width="500" height="700" active="false" color="#000000" outlineSize="2 2" outline="grey" showAnimation="SlideIn_Right" hideAnimation="SlideOut_Right" animationDuration="0.1"/>
 
-  <HorizontalLayout class="group-content" visibility="Admin" color="#444444" padding="5" spacing="5"/>
+  <!-- group headers -->
+  <Row class="group-header" preferredHeight="60"/>
+  <Cell class="group-header" columnSpan="2" color="#222222"/>
+  <Panel class="group-header" padding="5 0 0 0"/>
+  <Text class="group-header" fontSize="28" font="font_teutonic-arkham"/>
 
-  <Text class="group-header" fontSize="24" font="font_teutonic-arkham"/>
-  <Text class="option-header" fontSize="18" font="font_teutonic-arkham"/>
+  <!-- options -->
+  <Row class="option-text" preferredHeight="85"/>
+  <Cell class="option-text" color="#333333"/>
+  <Cell class="option-button" color="#333333"/>
+  <VerticalLayout class="text-column" padding="10 0 0 0" spacing="5"/>
+  <Text class="option-header" fontSize="20" font="font_teutonic-arkham"/>
   <Text class="description" fontSize="12"/>
 
+  <!-- buttons at the bottom -->
   <Button class="bottomButtons" hoverClass="hover" pressClass="press" selectClass="select" color="#888888" minHeight="35" fontSize="24" font="font_teutonic-arkham"/>
   <Button class="hover" color="grey"/>
   <Button class="press" color="white"/>
@@ -20,89 +29,154 @@
 </Defaults>
 
 <!-- Option Panel -->
-<VerticalLayout id="optionPanel" class="window" rectAlignment="LowerRight" offsetXY="-50 60">
-  <Panel minHeight="45" flexibleHeight="0" padding="10 10 0 0">
-    <Text font="font_teutonic-arkham" fontSize="35">Options</Text>
-  </Panel>
-  <VerticalLayout>
-    <!-- Group: playermat settings -->
-    <VerticalLayout class="group">
-      <Panel minHeight="44" image="option_image1" padding="5 0 0 0">
-        <Text class="group-header">PLAYERMAT SETTINGS</Text>
+<TableLayout id="optionPanel" class="window" active="false" rectAlignment="LowerRight" offsetXY="-50 60">
+  <!-- Header: Options -->
+  <Row preferredHeight="60">
+    <Cell>
+      <Panel padding="10 0 0 0">
+        <Text font="font_teutonic-arkham" fontSize="35">Options</Text>
       </Panel>
+    </Cell>
+  </Row>
 
-      <!-- Option: enable snap tags -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Enable snap tags</Text>
-          <Text class="description">Only cards with the tag "Asset" will snap (official cards are supported by default).&#xA;Disable this if you are having issues with custom content.</Text>
-        </VerticalLayout>
-        <Toggle id="useSnapTags" onValueChanged="onClick_toggleOption(useSnapTags)" />
-      </HorizontalLayout>
+  <!-- Scrollable part with options -->
+  <Row>
+    <Cell>
+      <VerticalScrollView>
+        <TableLayout columnWidths="0 75" autoCalculateHeight="1" cellPadding="10 0 8 8">
+          <!-- Group: playermat settings -->
+          <Row class="group-header">
+            <Cell class="group-header">
+              <Panel class="group-header" image="option_header1">
+                <Text class="group-header">PLAYERMAT SETTINGS</Text>
+              </Panel>
+            </Cell>
+          </Row>
 
-      <!-- Option: show draw 1 button -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Draw 1" button</Text>
-          <Text class="description">Displays a button below the "Upkeep" button that draws a card from your deck. Useful for multi-handed solo play.</Text>
-        </VerticalLayout>
-        <Toggle id="showDrawButton" onValueChanged="onClick_toggleOption(showDrawButton)"/>
-      </HorizontalLayout>
+          <!-- Option: enable snap tags -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Enable snap tags</Text>
+                <Text class="description">Only cards with the tag "Asset" will snap (official cards are supported by default).&#xA;Disable this if you are having issues with custom content.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="useSnapTags" onValueChanged="onClick_toggleOption(useSnapTags)"/>
+            </Cell>
+          </Row>
 
-      <!-- Option: use clickable clue-counters -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Use clickable clue-counters</Text>
-          <Text class="description">Instead of automatically counting clues in the respective area on your playermat, this displays a clickable counter for clues.</Text>
-        </VerticalLayout>
-        <Toggle id="useClueClickers" onValueChanged="onClick_toggleOption(useClueClickers)"/>
-      </HorizontalLayout>
-    </VerticalLayout>
+          <!-- Option: show draw 1 button -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Draw 1" button</Text>
+                <Text class="description">Displays a button below the "Upkeep" button that draws a card from your deck. Useful for multi-handed solo play.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showDrawButton" onValueChanged="onClick_toggleOption(showDrawButton)"/>
+            </Cell>
+          </Row>
 
-    <!-- Group: fan-made accessories -->
-    <VerticalLayout class="group">
-      <Panel minHeight="44" image="option_image2" padding="5 0 0 0">
-        <Text class="group-header">FAN-MADE ACCESSORIES</Text>
-      </Panel>
-      <!-- Option: show token arranger -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Token Arranger"</Text>
-          <Text class="description">See the contents of the chaos bag at a glance! This tool displays a sorted table of the tokens to allow easier guessing of your odds.</Text>
-        </VerticalLayout>
-        <Toggle id="showTokenArranger" onValueChanged="onClick_toggleOption(showTokenArranger)"/>
-      </HorizontalLayout>
+          <!-- Option: use clickable clue-counters -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Use clickable clue-counters</Text>
+                <Text class="description">Instead of automatically counting clues in the respective area on your playermat, this displays a clickable counter for clues.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="useClueClickers" onValueChanged="onClick_toggleOption(useClueClickers)"/>
+            </Cell>
+          </Row>
 
-      <!-- Option: show clean up helper -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Clean Up Helper"</Text>
-          <Text class="description">Useful for campaign-play: It resets play areas to allow continuous gameplay in the same savegame.</Text>
-        </VerticalLayout>
-        <Toggle id="showCleanUpHelper" onValueChanged="onClick_toggleOption(showCleanUpHelper)"/>
-      </HorizontalLayout>
+          <!-- Group: fan-made accessories -->
+          <Row class="group-header">
+            <Cell class="group-header">
+              <Panel class="group-header" image="option_header2">
+                <Text class="group-header">FAN-MADE ACCESSORIES</Text>
+              </Panel>
+            </Cell>
+          </Row>
 
-      <!-- Option: show hand helper -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Hand Helper"</Text>
-          <Text class="description">Never count your hand cards again! This tool does that for you and can even take "Dream-Enhancing Serum" into account. Also includes a button for randomly discard a card.</Text>
-        </VerticalLayout>
-        <Toggle id="showHandHelper" onValueChanged="onClick_toggleOption(showHandHelper)"/>
-      </HorizontalLayout>
+          <!-- Option: show token arranger -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Token Arranger"</Text>
+                <Text class="description">See the contents of the chaos bag at a glance! This tool displays a sorted table of the tokens to allow easier guessing of your odds.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showTokenArranger" onValueChanged="onClick_toggleOption(showTokenArranger)"/>
+            </Cell>
+          </Row>
 
-      <!-- Option: show chaos bag manager -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Chaos Bag Manager"</Text>
-          <Text class="description">Panel for easy addition or removal of chaos tokens to the bag - very useful for EotE because of Frost tokens!</Text>
-        </VerticalLayout>
-        <Toggle id="showChaosBagManager" onValueChanged="onClick_toggleOption(showChaosBagManager)"/>
+          <!-- Option: show clean up helper -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Clean Up Helper"</Text>
+                <Text class="description">Useful for campaign-play: It resets play areas to allow continuous gameplay in the same savegame.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showCleanUpHelper" onValueChanged="onClick_toggleOption(showCleanUpHelper)"/>
+            </Cell>
+          </Row>
+
+          <!-- Option: show hand helper -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Hand Helper"</Text>
+                <Text class="description">Never count your hand cards again! This tool does that for you and can even take "Dream-Enhancing Serum" into account. Also includes a button for randomly discard a card.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showHandHelper" onValueChanged="onClick_toggleOption(showHandHelper)"/>
+            </Cell>
+          </Row>
+
+          <!-- Option: show chaos bag manager -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Chaos Bag Manager"</Text>
+                <Text class="description">Panel for easy addition or removal of chaos tokens to the bag - very useful for EotE because of Frost tokens!</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showChaosBagManager" onValueChanged="onClick_toggleOption(showChaosBagManager)"/>
+            </Cell>
+          </Row>
+
+          <!-- Option: show navigation overlay -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Navigation Overlay"</Text>
+                <Text class="description">This enables an overlay for quickly navigating to various points on the table.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showNavigationOverlay" onValueChanged="onClick_toggleOption(showNavigationOverlay)"/>
+            </Cell>
+          </Row>
+        </TableLayout>
+      </VerticalScrollView>
+    </Cell>
+  </Row>
+
+  <!-- Buttons: Defaults and Close -->
+  <Row preferredHeight="50">
+    <Cell>
+      <HorizontalLayout minHeight="50" flexibleHeight="0" padding="5" spacing="5">
+        <Button class="bottomButtons" onClick="onClick_defaultSettings">Load defaults</Button>
+        <Button class="bottomButtons" onClick="onClick_toggleUi(Hidden)">Close</Button>
       </HorizontalLayout>
-    </VerticalLayout>
-  </VerticalLayout>
-  <HorizontalLayout minHeight="50" flexibleHeight="0" padding="5" spacing="5">
-    <Button class="bottomButtons" onClick="onClick_defaultSettings">Load defaults</Button>
-    <Button class="bottomButtons" onClick="onClick_toggleUi(Hidden)">Close</Button>
-  </HorizontalLayout>
-</VerticalLayout>
+    </Cell>
+  </Row>
+</TableLayout>


### PR DESCRIPTION
- option panel UI had to be rebuilt to use a scrollview
- added toggle switch images (not yet used in UI)
- header images from `img` folder are used
- navigation overlay added as option (will just spawn the bag with instructions at the top right of the play area)
- Token Arranger: Since the option allows to quickly place it and then remove it, I had to add some error handling for removal during the placement
- Snapshot of UI:
![image](https://user-images.githubusercontent.com/97286811/208690423-23657b68-7c53-4655-8571-fd057e3604a1.png)
