### PR TITLE
Option Panel: Part 5 - Storing GUIDs for spawned helper objects to allow later removal at any position

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
   },
   "Lighting_path": "Lighting.json",
   "LuaScript": "require(\"core/Global\")",
-  "LuaScriptState": "{\"optionPanel\":{\"useSnapTags\":true,\"showDrawButton\":false,\"useClueClickers\":false,\"showTokenArranger\":false,\"showCleanUpHelper\":false,\"showHandHelper\":false}}",
+  "LuaScriptState": "{\"optionPanel\":{\"showDrawButton\":false,\"showHandHelper\":[],\"useClueClickers\":false,\"useSnapTags\":true}}",
   "MusicPlayer_path": "MusicPlayer.json",
   "Note": "",
   "ObjectStates_order": [

--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -75,13 +75,23 @@
     "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118466516005/113C19D37CFFA9E554394FD5B11B32967F846A62/"
   },
   {
-    "Name": "option_image1",
+    "Name": "option_header1",
     "Type": 0,
-    "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118468280563/911BA319CD7502258D570B23BD51B3D8DA8B2AC3/"
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321894443102/5727544F24E8C4546031F4DDE8BD4B45D93AC3FC/"
   },
   {
-    "Name": "option_image2",
+    "Name": "option_header2",
     "Type": 0,
-    "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118470839572/FB133C41A6D8915A44C138BCF947ECFE3D111813/"
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321894443022/3262DF2ABAE8D9A2BF64ECB74C1BB34B33814554/"
+  },
+  {
+    "Name": "option_on",
+    "Type": 0,
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321889555728/22ABD35CBB49A001F3A5318E4AFCFB22D24FEA39/"
+  },
+  {
+    "Name": "option_off",
+    "Type": 0,
+    "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321889555661/6643E5CC9160FF4624672C255D0DF7B313DA00A5/"
   }
 ]

--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -75,12 +75,12 @@
     "URL": "http://cloud-3.steamusercontent.com/ugc/2027213118466516005/113C19D37CFFA9E554394FD5B11B32967F846A62/"
   },
   {
-    "Name": "option_header1",
+    "Name": "header_core",
     "Type": 0,
     "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321894443102/5727544F24E8C4546031F4DDE8BD4B45D93AC3FC/"
   },
   {
-    "Name": "option_header2",
+    "Name": "header_acolyte",
     "Type": 0,
     "URL": "http://cloud-3.steamusercontent.com/ugc/2024962321894443022/3262DF2ABAE8D9A2BF64ECB74C1BB34B33814554/"
   },

--- a/objects/Fan-MadeAccessories.aa8b38/TokenArranger.022907.ttslua
+++ b/objects/Fan-MadeAccessories.aa8b38/TokenArranger.022907.ttslua
@@ -193,37 +193,22 @@ function layout(_, _, isRightClick)
     -- stop here if right-clicked
     if isRightClick then return end
 
-    local chaos_bag = getChaosBag()
-    local chaos_bag_objects = chaos_bag.getObjects()
-
-    -- take each token out and clone it
-    for _, data in ipairs(chaos_bag_objects) do
-        chaos_bag.takeObject {
-            guid = data.guid,
-            smooth = false,
-            callback_function = function(tok)
-                chaos_bag.putObject(tok.clone())
-                tok.addTag("to_be_deleted")
-            end
-        }
-    end
-
-    -- wait until all tokens have finished spawning
-    Wait.condition(function() placeTokens() end, function() return #chaos_bag_objects == #getObjectsWithTag("to_be_deleted") end)
-end
-
--- position tokens sorted by value
-function placeTokens()
+    local chaosBag = getChaosBag()
     local data = {}
 
-    -- create table with tokens
-    for i, token in ipairs(getObjectsWithTag("to_be_deleted")) do
-        local name = token.getName() or ""
-        local value = tonumber(name)
-        local precedence = TOKEN_PRECEDENCE[name]
+    -- clone tokens from chaos bag (default position above trash can)
+    for i, obj in ipairs(chaosBag.getData().ContainedObjects) do
+        obj["Tags"] = { "to_be_deleted" }
+        local spawnedObj = spawnObjectData({
+            data = obj,
+            position = { 0.49, 3, 0 }
+        })
+
+        local value = tonumber(obj["Nickname"])
+        local precedence = TOKEN_PRECEDENCE[obj["Nickname"]]
 
         data[i] = {
-            token = token,
+            token = spawnedObj,
             value = value or precedence[1]
         }
 
@@ -237,11 +222,17 @@ function placeTokens()
     -- sort table by value (symbols last if same value)
     table.sort(data, token_value_comparator)
 
+    -- error handling for removal of token arranger
+    if self == nil then
+        for _, token in ipairs(getObjectsWithTag("to_be_deleted")) do token.destruct() end
+        return
+    end
+    
     -- laying out the tokens
     local pos           = self.getPosition() + Vector(3.55, -0.05, -3.95)
     local location      = { x = pos.x, y = pos.y, z = pos.z }
     local current_value = data[1].value
-
+    
     for _, item in ipairs(data) do
         if item.value ~= current_value then
             location.x = location.x - 1.75

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -857,6 +857,10 @@ function applyOptionPanelChange(id, state)
   -- option: Show chaos bag manager
   elseif id == "showChaosBagManager" then
     spawnOrRemoveHelper(state, "Chaos Bag Manager", {-67.8, 1.4, -49.5})
+
+  -- option: Show navigation overlay
+  elseif id == "showNavigationOverlay" then
+    spawnOrRemoveHelper(state, "jaqenZann's Navigation Overlay", {-11.7, 1.4, -15})
   end
 end
 

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -804,14 +804,15 @@ function onClick_toggleOption(_, id)
   end
 
   self.UI.setAttribute(id, "isOn", state)
-  optionPanel[id] = state
   applyOptionPanelChange(id, state)
 end
 
 -- sets the option panel to the correct state (corresponding to 'optionPanel')
 function updateOptionPanelState()
   for id, enabled in pairs(optionPanel) do
-    if enabled then
+    if (type(enabled) == "boolean" and enabled) or
+    (type(enabled) == "string" and enabled) or
+    (type(enabled) == "table" and #enabled ~= 0) then
       self.UI.setAttribute(id, "isOn", true)
     end
   end
@@ -824,14 +825,17 @@ function applyOptionPanelChange(id, state)
   -- option: Snap tags
   if id == "useSnapTags" then
     playmatAPI.setLimitSnapsByType(state, "All")
+    optionPanel[id] = state
 
   -- option: Draw 1 button
   elseif id == "showDrawButton" then
     playmatAPI.showDrawButton(state, "All")
+    optionPanel[id] = state
 
   -- option: Clickable clue counters
   elseif id == "useClueClickers" then
     playmatAPI.clickableClues(state, "All")
+    optionPanel[id] = state
 
     -- update master clue counter
     getObjectFromGUID("4a3aa4").setVar("useClickableCounters", state)
@@ -841,41 +845,42 @@ function applyOptionPanelChange(id, state)
     -- delete previously pulled out tokens
     for _, token in ipairs(getObjectsWithTag("to_be_deleted")) do token.destruct() end
 
-    spawnOrRemoveHelper(state, "Token Arranger", {-42.3, 1.4, -46.5})
+    optionPanel[id] = spawnOrRemoveHelper(state, "Token Arranger", {-42.3, 1.4, -46.5})
 
   -- option: Show clean up helper
   elseif id == "showCleanUpHelper" then
-    spawnOrRemoveHelper(state, "Clean Up Helper", {-68, 1.6, 35.5})
+    optionPanel[id] = spawnOrRemoveHelper(state, "Clean Up Helper", {-68, 1.6, 35.5})
   
   -- option: Show hand helper for each player
   elseif id == "showHandHelper" then
-    spawnOrRemoveHelper(state, "Hand Helper", {-50.84, 1.6, 7.02}, {0, 270, 0}, "White")
-    spawnOrRemoveHelper(state, "Hand Helper", {-50.90, 1.6, -25.10}, {0, 270, 0}, "Orange")
-    spawnOrRemoveHelper(state, "Hand Helper", {-34.38, 1.6, 22.44}, {0, 000, 0}, "Green")
-    spawnOrRemoveHelper(state, "Hand Helper", {-16.69, 1.6, -22.42}, {0, 180, 0}, "Red")
+    optionPanel[id][1] = spawnOrRemoveHelper(state, "Hand Helper", {-50.84, 1.6, 7.02}, {0, 270, 0}, "White")
+    optionPanel[id][2] = spawnOrRemoveHelper(state, "Hand Helper", {-50.90, 1.6, -25.10}, {0, 270, 0}, "Orange")
+    optionPanel[id][3] = spawnOrRemoveHelper(state, "Hand Helper", {-34.38, 1.6, 22.44}, {0, 000, 0}, "Green")
+    optionPanel[id][4] = spawnOrRemoveHelper(state, "Hand Helper", {-16.69, 1.6, -22.42}, {0, 180, 0}, "Red")
 
   -- option: Show chaos bag manager
   elseif id == "showChaosBagManager" then
-    spawnOrRemoveHelper(state, "Chaos Bag Manager", {-67.8, 1.4, -49.5})
+    optionPanel[id] = spawnOrRemoveHelper(state, "Chaos Bag Manager", {-67.8, 1.4, -49.5})
 
   -- option: Show navigation overlay
   elseif id == "showNavigationOverlay" then
-    spawnOrRemoveHelper(state, "jaqenZann's Navigation Overlay", {-11.7, 1.4, -15})
+    optionPanel[id] = spawnOrRemoveHelper(state, "jaqenZann's Navigation Overlay", {-11.7, 1.4, -15})
   end
 end
 
 -- handler for spawn / remove functions of helper objects
 ---@param state Boolean Contains the state of the option: true = spawn it, false = remove it
 ---@param name String Name of the helper object
----@param position Vector Position of the object (where it will spawn or where it will be removed from)
+---@param position Vector Position of the object (where it will spawn)
 ---@param rotation Vector Rotation of the object for spawning (default: {0, 270, 0})
 ---@param color Color This is only needed for correctly setting the color of the "Hand Helper"
+-- returns the GUID of the spawnedObj (or nil if object was removed)
 function spawnOrRemoveHelper(state, name, position, rotation, color)
   if state then
-    spawnHelperObject(name, position, rotation, color)
-    Player["White"].pingTable(position)
+    Player.getPlayers()[1].pingTable(position)
+    return spawnHelperObject(name, position, rotation, color).getGUID()
   else
-    removeHelperObject(name, position)
+    return removeHelperObject(name)
   end
 end
 
@@ -883,14 +888,12 @@ end
 ---@param name String Name of the object that should be copied
 ---@param position Position Desired position of the object
 function spawnHelperObject(name, position, rotation, color)
-  if rotation == nil then rotation = {0, 270, 0} end
-
   for _, obj in ipairs(getObjectFromGUID(BARREL_GUID).getData().ContainedObjects) do
     if obj["Nickname"] == name then
-      spawnObjectData({
+      return spawnObjectData({
         data = obj,
         position = position,
-        rotation = rotation,
+        rotation = rotation or {0, 270, 0},
         callback_function = function(object)
           if name == "Hand Helper" then
             Wait.time(function() object.call("externalColorChange", color) end, 1)
@@ -899,29 +902,34 @@ function spawnHelperObject(name, position, rotation, color)
           end
         end
       })
-      return
     end
   end
 end
 
--- removes the specified tool (by name) from the provided position
+-- removes the specified tool (by name)
 ---@param name String Name of the object that should be removed
----@param position Position Position of the object
-function removeHelperObject(name, position)
-  local search = Physics.cast({
-    direction    = { 0, 1, 0 },
-    max_distance = 1,
-    type         = 3,
-    size         = {1, 1, 1},
-    origin       = position,
-    orientation  = { 0, 270, 0 }
-  })
+function removeHelperObject(name)
+  -- links objects name to the respective option name (to grab the GUID for removal)
+  local referenceTable = {
+    ["Token Arranger"]                 = "showTokenArranger",
+    ["Clean Up Helper"]                = "showCleanUpHelper",
+    ["Hand Helper"]                    = "showHandHelper",
+    ["Chaos Bag Manager"]              = "showChaosBagManager",
+    ["jaqenZann's Navigation Overlay"] = "showNavigationOverlay"
+  }
   
-  for _, obj in ipairs(search) do
-    obj = obj.hit_object
-    if obj.getName() == name then
-      obj.destruct()
-      return
+  local data = optionPanel[referenceTable[name]]
+
+  -- if there is a GUID stored, remove that object
+  if type(data) == "string" then
+    local obj = getObjectFromGUID(data)
+    if obj then obj.destruct() end
+
+  -- if it is a table (e.g. for the "Hand Helper", remove all of them)
+  elseif type(data) == "table" then
+    for _, guid in pairs(data) do
+      local obj = getObjectFromGUID(guid)
+      if obj then obj.destruct() end
     end
   end
 end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -810,9 +810,9 @@ end
 -- sets the option panel to the correct state (corresponding to 'optionPanel')
 function updateOptionPanelState()
   for id, enabled in pairs(optionPanel) do
-    if (type(enabled) == "boolean" and enabled) or
-    (type(enabled) == "string" and enabled) or
-    (type(enabled) == "table" and #enabled ~= 0) then
+    if (type(enabled) == "boolean" and enabled)
+        or (type(enabled) == "string" and enabled)
+        or (type(enabled) == "table" and #enabled ~= 0) then
       self.UI.setAttribute(id, "isOn", true)
     end
   end

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -1,45 +1,105 @@
 <!-- Default formatting -->
 <Defaults>
   <!-- general Stuff -->
-  <Text color="white" fontSize="18"/>
-  <Button tooltipPosition="Left" color="clear"/>
+  <Text color="white"
+    fontSize="18"/>
+  <Button tooltipPosition="Left"
+    color="clear"/>
 
   <!-- Window -->
-  <HorizontalLayout class="headerLayout" height="75" padding="5"/>
-  <Button class="headerButton" minWidth="50" preferredWidth="50" flexibleWidth="0" color="clear"/>
-  <Text class="headerText" minWidth="200" flexibleWidth="100" fontSize="32" font="font_teutonic-arkham"/>
+  <HorizontalLayout class="headerLayout"
+    height="75"
+    padding="5"/>
+  <Button class="headerButton"
+    minWidth="50"
+    preferredWidth="50"
+    flexibleWidth="0"
+    color="clear"/>
+  <Text class="headerText"
+    minWidth="200"
+    flexibleWidth="100"
+    fontSize="32"
+    font="font_teutonic-arkham"/>
 </Defaults>
 
 <!-- Buttons in the bottom right of the screen -->
-<VerticalLayout visibility="Admin" color="#000000" outlineSize="1 1" outline="#303030" rectAlignment="LowerRight" width="35" height="215" offsetXY="-1 60" spacing="1">
-  <Button icon="cthulhu" tooltip="Campaigns" onClick="onClick_toggleUi(Campaigns)"/>
-  <Button icon="dark-cult" tooltip="Standalone Scenarios" onClick="onClick_toggleUi(Standalone Scenarios)"/>
-  <Button icon="yog-sothoth" tooltip="Extras" onClick="onClick_toggleUi(Extras)"/>
-  <Button icon="elder-sign" tooltip="Investigators" onClick="onClick_toggleUi(Investigators)"/>
-  <Button icon="devourer" tooltip="Community Content" onClick="onClick_toggleUi(Community Content)"/>
-  <Button icon="option-gear" tooltip="Options" onClick="onClick_toggleUi(Options)"/>
+<VerticalLayout visibility="Admin"
+  color="#000000"
+  outlineSize="1 1"
+  outline="#303030"
+  rectAlignment="LowerRight"
+  width="35"
+  height="215"
+  offsetXY="-1 60"
+  spacing="1">
+  <Button icon="cthulhu"
+    tooltip="Campaigns"
+    onClick="onClick_toggleUi(Campaigns)"/>
+  <Button icon="dark-cult"
+    tooltip="Standalone Scenarios"
+    onClick="onClick_toggleUi(Standalone Scenarios)"/>
+  <Button icon="yog-sothoth"
+    tooltip="Extras"
+    onClick="onClick_toggleUi(Extras)"/>
+  <Button icon="elder-sign"
+    tooltip="Investigators"
+    onClick="onClick_toggleUi(Investigators)"/>
+  <Button icon="devourer"
+    tooltip="Community Content"
+    onClick="onClick_toggleUi(Community Content)"/>
+  <Button icon="option-gear"
+    tooltip="Options"
+    onClick="onClick_toggleUi(Options)"/>
   <!--<Button icon="download" tooltip="ArkhamDB Deck Importer" onClick="onClick_toggleUi(Deck Importer)"/> -->
 </VerticalLayout>
 
 <!-- Basic UI that will be replaced based on title -->
-<VerticalLayout id="load_ui" visibility="Admin" color="black" active="false" width="700" height="780" outlineSize="1 1" outline="#303030">
+<VerticalLayout id="load_ui"
+  visibility="Admin"
+  color="black"
+  active="false"
+  width="700"
+  height="780"
+  outlineSize="1 1"
+  outline="#303030">
   <HorizontalLayout class="headerLayout">
-    <Button class="headerButton" icon="refresh" tooltip="Refresh List" tooltipPosition="Right" onClick="onClick_refreshList"/>
-    <Text id="title" class="headerText">Loadable Items</Text>
-    <Button class="headerButton" icon="close" tooltip="Close" onClick="onClick_toggleUi(Hidden)"/>
+    <Button class="headerButton"
+      icon="refresh"
+      tooltip="Refresh List"
+      tooltipPosition="Right"
+      onClick="onClick_refreshList"/>
+    <Text id="title"
+      class="headerText">Loadable Items</Text>
+    <Button class="headerButton"
+      icon="close"
+      tooltip="Close"
+      onClick="onClick_toggleUi(Hidden)"/>
   </HorizontalLayout>
-  <VerticalScrollView color="transparent" minHeight="100" flexibleHeight="100">
-    <Panel id="ui_update_height" height="24">
-      <VerticalLayout id="ui_update_point" padding="10">
+  <VerticalScrollView color="transparent"
+    minHeight="100"
+    flexibleHeight="100">
+    <Panel id="ui_update_height"
+      height="24">
+      <VerticalLayout id="ui_update_point"
+        padding="10">
         <Text>Please refresh to see available items.</Text>
       </VerticalLayout>
     </Panel>
   </VerticalScrollView>
-  <Panel color="rgb(0,0,0)" minHeight="50" preferredHeight="50" flexibleHeight="0">
-    <Button id="load_button" active="false" onClick="onClick_load">Load:</Button>
+  <Panel color="rgb(0,0,0)"
+    minHeight="50"
+    preferredHeight="50"
+    flexibleHeight="0">
+    <Button id="load_button"
+      active="false"
+      onClick="onClick_load">Load:</Button>
     <HorizontalLayout id="progress_display">
-      <ProgressBar id="download_progress" percentage="0" color="#000000" fillImageColor="#333333"/>
-      <Button onClick="onClick_cancel" active="false">Cancel</Button>
+      <ProgressBar id="download_progress"
+        percentage="0"
+        color="#000000"
+        fillImageColor="#333333"/>
+      <Button onClick="onClick_cancel"
+        active="false">Cancel</Button>
     </HorizontalLayout>
   </Panel>
 </VerticalLayout>

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -47,7 +47,7 @@
           <!-- Group: playermat settings -->
           <Row class="group-header">
             <Cell class="group-header">
-              <Panel class="group-header" image="option_header1">
+              <Panel class="group-header" image="header_core">
                 <Text class="group-header">PLAYERMAT SETTINGS</Text>
               </Panel>
             </Cell>
@@ -95,7 +95,7 @@
           <!-- Group: fan-made accessories -->
           <Row class="group-header">
             <Cell class="group-header">
-              <Panel class="group-header" image="option_header2">
+              <Panel class="group-header" image="header_acolyte">
                 <Text class="group-header">FAN-MADE ACCESSORIES</Text>
               </Panel>
             </Cell>

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -1,40 +1,84 @@
 <!-- Default formatting -->
 <Defaults>
-  <Text color="#FFFFFF" alignment="MiddleLeft"/>
-  <Toggle isOn="False" rectAlignment="MiddleRight"/>
-  <Cell dontUseTableCellBackground="true" outlineSize="0 1" outline="grey"/>
+  <Text color="#FFFFFF"
+    alignment="MiddleLeft" />
+
+  <Toggle isOn="False"
+    rectAlignment="MiddleRight" />
+
+  <Cell dontUseTableCellBackground="true"
+    outlineSize="0 1"
+    outline="grey" />
 
   <!-- main window -->
-  <TableLayout class="window" width="500" height="700" active="false" color="#000000" outlineSize="2 2" outline="grey" showAnimation="SlideIn_Right" hideAnimation="SlideOut_Right" animationDuration="0.1"/>
+  <TableLayout class="window"
+    width="500"
+    height="700"
+    active="false"
+    color="#000000"
+    outlineSize="2 2"
+    outline="grey"
+    showAnimation="SlideIn_Right"
+    hideAnimation="SlideOut_Right"
+    animationDuration="0.1" />
 
   <!-- group headers -->
-  <Row class="group-header" preferredHeight="60"/>
-  <Cell class="group-header" columnSpan="2" color="#222222"/>
-  <Panel class="group-header" padding="5 0 0 0"/>
-  <Text class="group-header" fontSize="28" font="font_teutonic-arkham"/>
+  <Row class="group-header"
+    preferredHeight="60" />
+  <Cell class="group-header"
+    columnSpan="2"
+    color="#222222" />
+  <Panel class="group-header"
+    padding="5 0 0 0" />
+  <Text class="group-header"
+    fontSize="28"
+    font="font_teutonic-arkham" />
 
   <!-- options -->
-  <Row class="option-text" preferredHeight="85"/>
-  <Cell class="option-text" color="#333333"/>
-  <Cell class="option-button" color="#333333"/>
-  <VerticalLayout class="text-column" padding="10 0 0 0" spacing="5"/>
-  <Text class="option-header" fontSize="20" font="font_teutonic-arkham"/>
-  <Text class="description" fontSize="12"/>
+  <Row class="option-text"
+    preferredHeight="85"/>
+  <Cell class="option-text"
+    color="#333333"/>
+  <Cell class="option-button"
+    color="#333333"/>
+  <VerticalLayout class="text-column"
+    padding="10 0 0 0"
+    spacing="5"/>
+  <Text class="option-header"
+    fontSize="20"
+    font="font_teutonic-arkham"/>
+  <Text class="description"
+    fontSize="12"/>
 
   <!-- buttons at the bottom -->
-  <Button class="bottomButtons" hoverClass="hover" pressClass="press" selectClass="select" color="#888888" minHeight="35" fontSize="24" font="font_teutonic-arkham"/>
-  <Button class="hover" color="grey"/>
-  <Button class="press" color="white"/>
-  <Button class="select" color="white"/>
+  <Button class="bottomButtons"
+    hoverClass="hover"
+    pressClass="press"
+    selectClass="select"
+    color="#888888"
+    minHeight="35"
+    fontSize="24"
+    font="font_teutonic-arkham"/>
+  <Button class="hover"
+    color="grey"/>
+  <Button class="press"
+    color="white"/>
+  <Button class="select"
+    color="white"/>
 </Defaults>
 
 <!-- Option Panel -->
-<TableLayout id="optionPanel" class="window" active="false" rectAlignment="LowerRight" offsetXY="-50 60">
+<TableLayout id="optionPanel"
+  class="window"
+  active="false"
+  rectAlignment="LowerRight"
+  offsetXY="-50 60">
   <!-- Header: Options -->
   <Row preferredHeight="60">
     <Cell>
       <Panel padding="10 0 0 0">
-        <Text font="font_teutonic-arkham" fontSize="35">Options</Text>
+        <Text font="font_teutonic-arkham"
+          fontSize="35">Options</Text>
       </Panel>
     </Cell>
   </Row>
@@ -43,11 +87,14 @@
   <Row>
     <Cell>
       <VerticalScrollView horizontalScrollbarVisibility="AutohideAndExpandViewport">
-        <TableLayout columnWidths="0 75" autoCalculateHeight="1" cellPadding="10 0 8 8">
+        <TableLayout columnWidths="0 75"
+          autoCalculateHeight="1"
+          cellPadding="10 0 8 8">
           <!-- Group: playermat settings -->
           <Row class="group-header">
             <Cell class="group-header">
-              <Panel class="group-header" image="header_core">
+              <Panel class="group-header"
+                image="header_core">
                 <Text class="group-header">PLAYERMAT SETTINGS</Text>
               </Panel>
             </Cell>
@@ -62,7 +109,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="useSnapTags" onValueChanged="onClick_toggleOption(useSnapTags)"/>
+              <Toggle id="useSnapTags"
+                onValueChanged="onClick_toggleOption(useSnapTags)"/>
             </Cell>
           </Row>
 
@@ -75,7 +123,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="showDrawButton" onValueChanged="onClick_toggleOption(showDrawButton)"/>
+              <Toggle id="showDrawButton"
+                onValueChanged="onClick_toggleOption(showDrawButton)"/>
             </Cell>
           </Row>
 
@@ -88,14 +137,16 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="useClueClickers" onValueChanged="onClick_toggleOption(useClueClickers)"/>
+              <Toggle id="useClueClickers"
+                onValueChanged="onClick_toggleOption(useClueClickers)"/>
             </Cell>
           </Row>
 
           <!-- Group: fan-made accessories -->
           <Row class="group-header">
             <Cell class="group-header">
-              <Panel class="group-header" image="header_acolyte">
+              <Panel class="group-header"
+                image="header_acolyte">
                 <Text class="group-header">FAN-MADE ACCESSORIES</Text>
               </Panel>
             </Cell>
@@ -110,7 +161,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="showTokenArranger" onValueChanged="onClick_toggleOption(showTokenArranger)"/>
+              <Toggle id="showTokenArranger"
+                onValueChanged="onClick_toggleOption(showTokenArranger)"/>
             </Cell>
           </Row>
 
@@ -123,7 +175,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="showCleanUpHelper" onValueChanged="onClick_toggleOption(showCleanUpHelper)"/>
+              <Toggle id="showCleanUpHelper"
+                onValueChanged="onClick_toggleOption(showCleanUpHelper)"/>
             </Cell>
           </Row>
 
@@ -136,7 +189,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="showHandHelper" onValueChanged="onClick_toggleOption(showHandHelper)"/>
+              <Toggle id="showHandHelper"
+                onValueChanged="onClick_toggleOption(showHandHelper)"/>
             </Cell>
           </Row>
 
@@ -149,7 +203,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="showChaosBagManager" onValueChanged="onClick_toggleOption(showChaosBagManager)"/>
+              <Toggle id="showChaosBagManager"
+                onValueChanged="onClick_toggleOption(showChaosBagManager)"/>
             </Cell>
           </Row>
 
@@ -162,7 +217,8 @@
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
-              <Toggle id="showNavigationOverlay" onValueChanged="onClick_toggleOption(showNavigationOverlay)"/>
+              <Toggle id="showNavigationOverlay"
+                onValueChanged="onClick_toggleOption(showNavigationOverlay)"/>
             </Cell>
           </Row>
         </TableLayout>
@@ -173,9 +229,14 @@
   <!-- Buttons: Defaults and Close -->
   <Row preferredHeight="50">
     <Cell>
-      <HorizontalLayout minHeight="55" flexibleHeight="0" padding="10 10 5 10" spacing="225">
-        <Button class="bottomButtons" onClick="onClick_defaultSettings">Load defaults</Button>
-        <Button class="bottomButtons" onClick="onClick_toggleUi(Hidden)">Close</Button>
+      <HorizontalLayout minHeight="55"
+        flexibleHeight="0"
+        padding="10 10 5 10"
+        spacing="225">
+        <Button class="bottomButtons"
+          onClick="onClick_defaultSettings">Load defaults</Button>
+        <Button class="bottomButtons"
+          onClick="onClick_toggleUi(Hidden)">Close</Button>
       </HorizontalLayout>
     </Cell>
   </Row>

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -1,18 +1,27 @@
 <!-- Default formatting -->
 <Defaults>
-  <Text color="white" alignment="MiddleLeft"/>
+  <Text color="#FFFFFF" alignment="MiddleLeft"/>
   <Toggle isOn="False" rectAlignment="MiddleRight"/>
+  <Cell dontUseTableCellBackground="true" outlineSize="0 1" outline="grey"/>
 
-  <VerticalLayout class="window" visibility="Admin" active="false" color="black" width="500" height="700" outlineSize="1 1" outline="grey" showAnimation="SlideIn_Right" hideAnimation="SlideOut_Right" animationDuration="0.1"/>
-  <VerticalLayout class="group" visibility="Admin" outlineSize="1 1" outline="grey" color="#222222" padding="10" spacing="5"/>
-  <VerticalLayout class="text-column" visibility="Admin" padding="5 20 0 0"/>
+  <!-- main window -->
+  <TableLayout class="window" width="500" height="700" active="false" color="#000000" outlineSize="2 2" outline="grey" showAnimation="SlideIn_Right" hideAnimation="SlideOut_Right" animationDuration="0.1"/>
 
-  <HorizontalLayout class="group-content" visibility="Admin" color="#444444" padding="5" spacing="5"/>
+  <!-- group headers -->
+  <Row class="group-header" preferredHeight="60"/>
+  <Cell class="group-header" columnSpan="2" color="#222222"/>
+  <Panel class="group-header" padding="5 0 0 0"/>
+  <Text class="group-header" fontSize="28" font="font_teutonic-arkham"/>
 
-  <Text class="group-header" fontSize="24" font="font_teutonic-arkham"/>
-  <Text class="option-header" fontSize="18" font="font_teutonic-arkham"/>
+  <!-- options -->
+  <Row class="option-text" preferredHeight="85"/>
+  <Cell class="option-text" color="#333333"/>
+  <Cell class="option-button" color="#333333"/>
+  <VerticalLayout class="text-column" padding="10 0 0 0" spacing="5"/>
+  <Text class="option-header" fontSize="20" font="font_teutonic-arkham"/>
   <Text class="description" fontSize="12"/>
 
+  <!-- buttons at the bottom -->
   <Button class="bottomButtons" hoverClass="hover" pressClass="press" selectClass="select" color="#888888" minHeight="35" fontSize="24" font="font_teutonic-arkham"/>
   <Button class="hover" color="grey"/>
   <Button class="press" color="white"/>
@@ -20,89 +29,154 @@
 </Defaults>
 
 <!-- Option Panel -->
-<VerticalLayout id="optionPanel" class="window" rectAlignment="LowerRight" offsetXY="-50 60">
-  <Panel minHeight="45" flexibleHeight="0" padding="10 10 0 0">
-    <Text font="font_teutonic-arkham" fontSize="35">Options</Text>
-  </Panel>
-  <VerticalLayout>
-    <!-- Group: playermat settings -->
-    <VerticalLayout class="group">
-      <Panel minHeight="44" image="option_image1" padding="5 0 0 0">
-        <Text class="group-header">PLAYERMAT SETTINGS</Text>
+<TableLayout id="optionPanel" class="window" active="false" rectAlignment="LowerRight" offsetXY="-50 60">
+  <!-- Header: Options -->
+  <Row preferredHeight="60">
+    <Cell>
+      <Panel padding="10 0 0 0">
+        <Text font="font_teutonic-arkham" fontSize="35">Options</Text>
       </Panel>
+    </Cell>
+  </Row>
 
-      <!-- Option: enable snap tags -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Enable snap tags</Text>
-          <Text class="description">Only cards with the tag "Asset" will snap (official cards are supported by default).&#xA;Disable this if you are having issues with custom content.</Text>
-        </VerticalLayout>
-        <Toggle id="useSnapTags" onValueChanged="onClick_toggleOption(useSnapTags)" />
-      </HorizontalLayout>
+  <!-- Scrollable part with options -->
+  <Row>
+    <Cell>
+      <VerticalScrollView>
+        <TableLayout columnWidths="0 75" autoCalculateHeight="1" cellPadding="10 0 8 8">
+          <!-- Group: playermat settings -->
+          <Row class="group-header">
+            <Cell class="group-header">
+              <Panel class="group-header" image="option_header1">
+                <Text class="group-header">PLAYERMAT SETTINGS</Text>
+              </Panel>
+            </Cell>
+          </Row>
 
-      <!-- Option: show draw 1 button -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Draw 1" button</Text>
-          <Text class="description">Displays a button below the "Upkeep" button that draws a card from your deck. Useful for multi-handed solo play.</Text>
-        </VerticalLayout>
-        <Toggle id="showDrawButton" onValueChanged="onClick_toggleOption(showDrawButton)"/>
-      </HorizontalLayout>
+          <!-- Option: enable snap tags -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Enable snap tags</Text>
+                <Text class="description">Only cards with the tag "Asset" will snap (official cards are supported by default).&#xA;Disable this if you are having issues with custom content.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="useSnapTags" onValueChanged="onClick_toggleOption(useSnapTags)"/>
+            </Cell>
+          </Row>
 
-      <!-- Option: use clickable clue-counters -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Use clickable clue-counters</Text>
-          <Text class="description">Instead of automatically counting clues in the respective area on your playermat, this displays a clickable counter for clues.</Text>
-        </VerticalLayout>
-        <Toggle id="useClueClickers" onValueChanged="onClick_toggleOption(useClueClickers)"/>
-      </HorizontalLayout>
-    </VerticalLayout>
+          <!-- Option: show draw 1 button -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Draw 1" button</Text>
+                <Text class="description">Displays a button below the "Upkeep" button that draws a card from your deck. Useful for multi-handed solo play.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showDrawButton" onValueChanged="onClick_toggleOption(showDrawButton)"/>
+            </Cell>
+          </Row>
 
-    <!-- Group: fan-made accessories -->
-    <VerticalLayout class="group">
-      <Panel minHeight="44" image="option_image2" padding="5 0 0 0">
-        <Text class="group-header">FAN-MADE ACCESSORIES</Text>
-      </Panel>
-      <!-- Option: show token arranger -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Token Arranger"</Text>
-          <Text class="description">See the contents of the chaos bag at a glance! This tool displays a sorted table of the tokens to allow easier guessing of your odds.</Text>
-        </VerticalLayout>
-        <Toggle id="showTokenArranger" onValueChanged="onClick_toggleOption(showTokenArranger)"/>
-      </HorizontalLayout>
+          <!-- Option: use clickable clue-counters -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Use clickable clue-counters</Text>
+                <Text class="description">Instead of automatically counting clues in the respective area on your playermat, this displays a clickable counter for clues.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="useClueClickers" onValueChanged="onClick_toggleOption(useClueClickers)"/>
+            </Cell>
+          </Row>
 
-      <!-- Option: show clean up helper -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Clean Up Helper"</Text>
-          <Text class="description">Useful for campaign-play: It resets play areas to allow continuous gameplay in the same savegame.</Text>
-        </VerticalLayout>
-        <Toggle id="showCleanUpHelper" onValueChanged="onClick_toggleOption(showCleanUpHelper)"/>
-      </HorizontalLayout>
+          <!-- Group: fan-made accessories -->
+          <Row class="group-header">
+            <Cell class="group-header">
+              <Panel class="group-header" image="option_header2">
+                <Text class="group-header">FAN-MADE ACCESSORIES</Text>
+              </Panel>
+            </Cell>
+          </Row>
 
-      <!-- Option: show hand helper -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Hand Helper"</Text>
-          <Text class="description">Never count your hand cards again! This tool does that for you and can even take "Dream-Enhancing Serum" into account. Also includes a button for randomly discard a card.</Text>
-        </VerticalLayout>
-        <Toggle id="showHandHelper" onValueChanged="onClick_toggleOption(showHandHelper)"/>
-      </HorizontalLayout>
+          <!-- Option: show token arranger -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Token Arranger"</Text>
+                <Text class="description">See the contents of the chaos bag at a glance! This tool displays a sorted table of the tokens to allow easier guessing of your odds.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showTokenArranger" onValueChanged="onClick_toggleOption(showTokenArranger)"/>
+            </Cell>
+          </Row>
 
-      <!-- Option: show chaos bag manager -->
-      <HorizontalLayout class="group-content">
-        <VerticalLayout class="text-column">
-          <Text class="option-header">Show "Chaos Bag Manager"</Text>
-          <Text class="description">Panel for easy addition or removal of chaos tokens to the bag - very useful for EotE because of Frost tokens!</Text>
-        </VerticalLayout>
-        <Toggle id="showChaosBagManager" onValueChanged="onClick_toggleOption(showChaosBagManager)"/>
+          <!-- Option: show clean up helper -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Clean Up Helper"</Text>
+                <Text class="description">Useful for campaign-play: It resets play areas to allow continuous gameplay in the same savegame.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showCleanUpHelper" onValueChanged="onClick_toggleOption(showCleanUpHelper)"/>
+            </Cell>
+          </Row>
+
+          <!-- Option: show hand helper -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Hand Helper"</Text>
+                <Text class="description">Never count your hand cards again! This tool does that for you and can even take "Dream-Enhancing Serum" into account. Also includes a button for randomly discard a card.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showHandHelper" onValueChanged="onClick_toggleOption(showHandHelper)"/>
+            </Cell>
+          </Row>
+
+          <!-- Option: show chaos bag manager -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Chaos Bag Manager"</Text>
+                <Text class="description">Panel for easy addition or removal of chaos tokens to the bag - very useful for EotE because of Frost tokens!</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showChaosBagManager" onValueChanged="onClick_toggleOption(showChaosBagManager)"/>
+            </Cell>
+          </Row>
+
+          <!-- Option: show navigation overlay -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show "Navigation Overlay"</Text>
+                <Text class="description">This enables an overlay for quickly navigating to various points on the table.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showNavigationOverlay" onValueChanged="onClick_toggleOption(showNavigationOverlay)"/>
+            </Cell>
+          </Row>
+        </TableLayout>
+      </VerticalScrollView>
+    </Cell>
+  </Row>
+
+  <!-- Buttons: Defaults and Close -->
+  <Row preferredHeight="50">
+    <Cell>
+      <HorizontalLayout minHeight="50" flexibleHeight="0" padding="5" spacing="5">
+        <Button class="bottomButtons" onClick="onClick_defaultSettings">Load defaults</Button>
+        <Button class="bottomButtons" onClick="onClick_toggleUi(Hidden)">Close</Button>
       </HorizontalLayout>
-    </VerticalLayout>
-  </VerticalLayout>
-  <HorizontalLayout minHeight="50" flexibleHeight="0" padding="5" spacing="5">
-    <Button class="bottomButtons" onClick="onClick_defaultSettings">Load defaults</Button>
-    <Button class="bottomButtons" onClick="onClick_toggleUi(Hidden)">Close</Button>
-  </HorizontalLayout>
-</VerticalLayout>
+    </Cell>
+  </Row>
+</TableLayout>

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -105,7 +105,7 @@
           <Row class="option-text">
             <Cell class="option-text">
               <VerticalLayout class="text-column">
-                <Text class="option-header">Show "Token Arranger"</Text>
+                <Text class="option-header">Token Arranger</Text>
                 <Text class="description">See the contents of the chaos bag at a glance! This tool displays a sorted table of the tokens to allow easier guessing of your odds.</Text>
               </VerticalLayout>
             </Cell>
@@ -118,7 +118,7 @@
           <Row class="option-text">
             <Cell class="option-text">
               <VerticalLayout class="text-column">
-                <Text class="option-header">Show "Clean Up Helper"</Text>
+                <Text class="option-header">Clean Up Helper</Text>
                 <Text class="description">Useful for campaign-play: It resets play areas to allow continuous gameplay in the same savegame.</Text>
               </VerticalLayout>
             </Cell>
@@ -131,7 +131,7 @@
           <Row class="option-text">
             <Cell class="option-text">
               <VerticalLayout class="text-column">
-                <Text class="option-header">Show "Hand Helper"</Text>
+                <Text class="option-header">Hand Helper</Text>
                 <Text class="description">Never count your hand cards again! This tool does that for you and can even take "Dream-Enhancing Serum" into account. Also includes a button for randomly discard a card.</Text>
               </VerticalLayout>
             </Cell>
@@ -144,7 +144,7 @@
           <Row class="option-text">
             <Cell class="option-text">
               <VerticalLayout class="text-column">
-                <Text class="option-header">Show "Chaos Bag Manager"</Text>
+                <Text class="option-header">Chaos Bag Manager</Text>
                 <Text class="description">Panel for easy addition or removal of chaos tokens to the bag - very useful for EotE because of Frost tokens!</Text>
               </VerticalLayout>
             </Cell>
@@ -157,8 +157,8 @@
           <Row class="option-text">
             <Cell class="option-text">
               <VerticalLayout class="text-column">
-                <Text class="option-header">Show "Navigation Overlay"</Text>
-                <Text class="description">This enables an overlay for quickly navigating to various points on the table.</Text>
+                <Text class="option-header">Navigation Overlay</Text>
+                <Text class="description">This enables an overlay for quickly moving the camera to various points on the table.</Text>
               </VerticalLayout>
             </Cell>
             <Cell class="option-button">
@@ -173,7 +173,7 @@
   <!-- Buttons: Defaults and Close -->
   <Row preferredHeight="50">
     <Cell>
-      <HorizontalLayout minHeight="50" flexibleHeight="0" padding="5" spacing="5">
+      <HorizontalLayout minHeight="55" flexibleHeight="0" padding="10 10 5 10" spacing="225">
         <Button class="bottomButtons" onClick="onClick_defaultSettings">Load defaults</Button>
         <Button class="bottomButtons" onClick="onClick_toggleUi(Hidden)">Close</Button>
       </HorizontalLayout>

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -42,7 +42,7 @@
   <!-- Scrollable part with options -->
   <Row>
     <Cell>
-      <VerticalScrollView>
+      <VerticalScrollView horizontalScrollbarVisibility="AutohideAndExpandViewport">
         <TableLayout columnWidths="0 75" autoCalculateHeight="1" cellPadding="10 0 8 8">
           <!-- Group: playermat settings -->
           <Row class="group-header">


### PR DESCRIPTION
- save GUIDs of spawned helper object to allow later removal even after moving them
- removed horizontal scrollbar
- removed "show" for fan-made accessories
- made buttons at the bottom smaller
- fixed XML formatting to use new lines

(This is built on top of Part 4).

Snapshot of UI:

![image](https://user-images.githubusercontent.com/97286811/209030161-6f269f1d-bda8-4dab-ac1c-acd3028bb1fd.png)