### PR TITLE
Option Panel: Part 6 - Addition of "load defaults" functionality

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
   },
   "Lighting_path": "Lighting.json",
   "LuaScript": "require(\"core/Global\")",
-  "LuaScriptState": "{\"optionPanel\":{\"showDrawButton\":false,\"showHandHelper\":[],\"useClueClickers\":false,\"useSnapTags\":true}}",
+  "LuaScriptState_path": "LuaScriptState.luascriptstate",
   "MusicPlayer_path": "MusicPlayer.json",
   "Note": "",
   "ObjectStates_order": [

--- a/objects/LuaScriptState.luascriptstate
+++ b/objects/LuaScriptState.luascriptstate
@@ -1,1 +1,1 @@
-{"optionPanel":{"showChaosBagManager":false,"showCleanUpHelper":false,"showDrawButton":false,"showHandHelper":false,"showNavigationOverlay":false,"showTokenArranger":false,"useClueClickers":false,"useSnapTags":true}}
+{"optionPanel":{"showChaosBagManager":false,"showCleanUpHelper":false,"showDrawButton":false,"showHandHelper":{},"showNavigationOverlay":false,"showTokenArranger":false,"useClueClickers":false,"useSnapTags":true}}

--- a/objects/LuaScriptState.luascriptstate
+++ b/objects/LuaScriptState.luascriptstate
@@ -1,0 +1,1 @@
+{"optionPanel":{"showChaosBagManager":false,"showCleanUpHelper":false,"showDrawButton":false,"showHandHelper":false,"showNavigationOverlay":false,"showTokenArranger":false,"useClueClickers":false,"useSnapTags":true}}

--- a/objects/Playermat1White.8b081b.json
+++ b/objects/Playermat1White.8b081b.json
@@ -273,7 +273,7 @@
   "IgnoreFoW": false,
   "LayoutGroupSortIndex": 0,
   "Locked": true,
-  "LuaScriptState": "{\"activeInvestigatorId\":\"00000\",\"playerColor\":\"White\",\"zoneID\":\"7af2cf\"}",
+  "LuaScriptState_path": "Playermat1White.8b081b.luascriptstate",
   "LuaScript_path": "Playermat1White.8b081b.ttslua",
   "MeasureMovement": false,
   "Name": "Custom_Tile",

--- a/objects/Playermat1White.8b081b.luascriptstate
+++ b/objects/Playermat1White.8b081b.luascriptstate
@@ -1,0 +1,1 @@
+{"activeInvestigatorId":"00000","isDrawButtonVisible":false,"playerColor":"White","zoneID":"7af2cf"}

--- a/objects/Playermat2Orange.bd0ff4.json
+++ b/objects/Playermat2Orange.bd0ff4.json
@@ -273,7 +273,7 @@
   "IgnoreFoW": false,
   "LayoutGroupSortIndex": 0,
   "Locked": true,
-  "LuaScriptState": "{\"activeInvestigatorId\":\"00000\",\"playerColor\":\"Orange\",\"zoneID\":\"b047f8\"}",
+  "LuaScriptState_path": "Playermat2Orange.bd0ff4.luascriptstate",
   "LuaScript_path": "Playermat2Orange.bd0ff4.ttslua",
   "MeasureMovement": false,
   "Name": "Custom_Tile",

--- a/objects/Playermat2Orange.bd0ff4.luascriptstate
+++ b/objects/Playermat2Orange.bd0ff4.luascriptstate
@@ -1,0 +1,1 @@
+{"activeInvestigatorId":"00000","isDrawButtonVisible":false,"playerColor":"Orange","zoneID":"b047f8"}

--- a/objects/Playermat3Green.383d8b.json
+++ b/objects/Playermat3Green.383d8b.json
@@ -273,7 +273,7 @@
   "IgnoreFoW": false,
   "LayoutGroupSortIndex": 0,
   "Locked": true,
-  "LuaScriptState": "{\"activeInvestigatorId\":\"00000\",\"playerColor\":\"Green\",\"zoneID\":\"fb28e1\"}",
+  "LuaScriptState_path": "Playermat3Green.383d8b.luascriptstate",
   "LuaScript_path": "Playermat3Green.383d8b.ttslua",
   "MeasureMovement": false,
   "Name": "Custom_Tile",

--- a/objects/Playermat3Green.383d8b.luascriptstate
+++ b/objects/Playermat3Green.383d8b.luascriptstate
@@ -1,0 +1,1 @@
+{"activeInvestigatorId":"00000","isDrawButtonVisible":false,"playerColor":"Green","zoneID":"fb28e1"}

--- a/objects/Playermat4Red.0840d5.json
+++ b/objects/Playermat4Red.0840d5.json
@@ -273,7 +273,7 @@
   "IgnoreFoW": false,
   "LayoutGroupSortIndex": 0,
   "Locked": true,
-  "LuaScriptState": "{\"activeInvestigatorId\":\"00000\",\"playerColor\":\"Red\",\"zoneID\":\"18538f\"}",
+  "LuaScriptState_path": "Playermat4Red.0840d5.luascriptstate",
   "LuaScript_path": "Playermat4Red.0840d5.ttslua",
   "MeasureMovement": false,
   "Name": "Custom_Tile",

--- a/objects/Playermat4Red.0840d5.luascriptstate
+++ b/objects/Playermat4Red.0840d5.luascriptstate
@@ -1,0 +1,1 @@
+{"activeInvestigatorId":"00000","isDrawButtonVisible":false,"playerColor":"Red","zoneID":"18538f"}

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -885,14 +885,22 @@ end
 ---@param name String Name of the object that should be copied
 ---@param position Position Desired position of the object
 function spawnHelperObject(name, position, rotation, color)
+  local barrel = getObjectFromGUID(BARREL_GUID)
+
+  -- error handling for missing barrel
+  if not barrel then
+    broadcastToAll("'Barrel' with fan-made accessories could not be found!", "Red")
+    return
+  end
+
   local spawnTable = {
     position = position,
     callback_function = function(object)
-          if name == "Hand Helper" then
-            Wait.time(function() object.call("externalColorChange", color) end, 1)
-          elseif name == "Token Arranger" then
-            Wait.time(function() object.call("layout") end, 1)
-          end
+      if name == "Hand Helper" then
+        Wait.time(function() object.call("externalColorChange", color) end, 0.1)
+      elseif name == "Token Arranger" then
+        Wait.time(function() object.call("layout") end, 0.1)
+      end
     end
   }
 
@@ -901,7 +909,7 @@ function spawnHelperObject(name, position, rotation, color)
     spawnTable.rotation = rotation
   end
 
-  for _, obj in ipairs(getObjectFromGUID(BARREL_GUID).getData().ContainedObjects) do
+  for _, obj in ipairs(barrel.getData().ContainedObjects) do
     if obj["Nickname"] == name then
       spawnTable.data = obj
       return spawnObjectData(spawnTable)
@@ -955,7 +963,7 @@ function onClick_defaultSettings()
     useClueClickers = false,
     showTokenArranger = false,
     showCleanUpHelper = false,
-    showHandHelper = false,
+    showHandHelper = {},
     showChaosBagManager = false,
     showNavigationOverlay = false
   }

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -787,11 +787,6 @@ end
 -- Option Panel related functionality
 ---------------------------------------------------------
 
--- loads the default options
-function onClick_defaultSettings()
-  print("Dummy: Load default settings")
-end
-
 -- called by toggling an option
 function onClick_toggleOption(_, id)
   local state = self.UI.getAttribute(id, "isOn")
@@ -814,6 +809,8 @@ function updateOptionPanelState()
         or (type(enabled) == "string" and enabled)
         or (type(enabled) == "table" and #enabled ~= 0) then
       self.UI.setAttribute(id, "isOn", true)
+    else
+      self.UI.setAttribute(id, "isOn", "False")
     end
   end
 end
@@ -888,26 +885,32 @@ end
 ---@param name String Name of the object that should be copied
 ---@param position Position Desired position of the object
 function spawnHelperObject(name, position, rotation, color)
-  for _, obj in ipairs(getObjectFromGUID(BARREL_GUID).getData().ContainedObjects) do
-    if obj["Nickname"] == name then
-      return spawnObjectData({
-        data = obj,
-        position = position,
-        rotation = rotation or {0, 270, 0},
-        callback_function = function(object)
+  local spawnTable = {
+    position = position,
+    callback_function = function(object)
           if name == "Hand Helper" then
             Wait.time(function() object.call("externalColorChange", color) end, 1)
           elseif name == "Token Arranger" then
             Wait.time(function() object.call("layout") end, 1)
           end
-        end
-      })
+    end
+  }
+
+  -- only overrride rotation if there is one provided (object's rotation used instead)
+  if rotation then
+    spawnTable.rotation = rotation
+  end
+
+  for _, obj in ipairs(getObjectFromGUID(BARREL_GUID).getData().ContainedObjects) do
+    if obj["Nickname"] == name then
+      spawnTable.data = obj
+      return spawnObjectData(spawnTable)
     end
   end
 end
 
 -- removes the specified tool (by name)
----@param name String Name of the object that should be removed
+---@param name String Object that should be removed
 function removeHelperObject(name)
   -- links objects name to the respective option name (to grab the GUID for removal)
   local referenceTable = {
@@ -932,4 +935,31 @@ function removeHelperObject(name)
       if obj then obj.destruct() end
     end
   end
+end
+
+-- loads the default options
+function onClick_defaultSettings()
+  for id, _ in pairs(optionPanel) do
+    local state = false
+    -- override for settings that are enabled by default
+    if id == "useSnapTags" then
+      state = true
+    end
+    applyOptionPanelChange(id, state)
+  end
+
+  -- clean reset of variable
+  optionPanel = {
+    useSnapTags = true,
+    showDrawButton = false,
+    useClueClickers = false,
+    showTokenArranger = false,
+    showCleanUpHelper = false,
+    showHandHelper = false,
+    showChaosBagManager = false,
+    showNavigationOverlay = false
+  }
+
+  -- update UI
+  updateOptionPanelState()
 end


### PR DESCRIPTION
- "Load Defaults"-button will reset everything to off (except for SnapTags) and reverse any changes that were made by enabling options
- only override rotation for spawned objects if there is a value for rotation provided (and keep objects rotation otherwise)
- because there is now an additional variable for playermats (showDrawButton) the MM splits the luascriptstate to separate files