### PR TITLE
Deck Importer: Account for taboo versions of bonded cards

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -271,6 +271,8 @@ do
           bondedCards[bond.id] = bond.count
           -- We need to know which cards are bonded to determine their position, remember them
           bondedList[bond.id] = true
+          -- Also adding taboo versions of bonded cards to the list
+          bondedList[bond.id .. "-t"] = true
         end
       end
     end


### PR DESCRIPTION
This fixes the placement of taboo versions of bonded card (previously in your deck, now correctly set aside).