### PR TITLE
Attachment Helper: Error handling for non-cards

### DIFF
--- a/objects/Fan-MadeAccessories.aa8b38/AttachmentHelper.d45664.ttslua
+++ b/objects/Fan-MadeAccessories.aa8b38/AttachmentHelper.d45664.ttslua
@@ -1,13 +1,4 @@
--- Attachment Helper
--- updated by:      Chr1Z
--- original by:     bankey
--- description:     displays cards in it with cost/skill icons
-local information = {
-  version = "1.7",
-  last_updated = "24.11.2022"
-}
-
-local option_text = {
+local OPTION_TEXT = {
   "Ancestral Knowledge",
   "Astronomical Atlas",
   "Crystallizer of Dreams",
@@ -17,7 +8,7 @@ local option_text = {
   "Wooden Sledge"
 }
 
-local imageList = {
+local IMAGE_LIST = {
   -- Ancestral Knowledge
   "http://cloud-3.steamusercontent.com/ugc/1915746489207287888/2F9F6F211ED0F98E66C9D35D93221E4C7FB6DD3C/",
   -- Astronomical Atlas
@@ -38,11 +29,11 @@ local imageList = {
 function onSave() return JSON.encode({ cardsInBag, showCost, showIcons }) end
 
 -- load variables and create context menu
-function onLoad(saved_data)
-  local loaded_data = JSON.decode(saved_data)
-  cardsInBag        = loaded_data[1] or {}
-  showCost          = loaded_data[2] or true
-  showIcons         = loaded_data[3] or true
+function onLoad(savedData)
+  local loadedData = JSON.decode(savedData)
+  cardsInBag       = loadedData[1] or {}
+  showCost         = loadedData[2] or true
+  showIcons        = loadedData[3] or true
 
   recreateButtons()
 
@@ -61,16 +52,15 @@ function onLoad(saved_data)
 
   self.addContextMenuItem("More Information", function()
     printToAll("------------------------------", "White")
-    printToAll("Attachment Helper v" .. information["version"] .. " by Chr1Z", "Orange")
-    printToAll("original by: bankey", "White")
-    printToAll("last updated: " .. information["last_updated"], "White")
+    printToAll("Attachment Helper by Chr1Z", "Orange")
+    printToAll("original by bankey", "White")
   end)
 end
 
 function selectImage(color)
-  Player[color].showOptionsDialog("Select image:", option_text, 1, function(_, option_index)
+  Player[color].showOptionsDialog("Select image:", OPTION_TEXT, 1, function(_, option_index)
     local customInfo = self.getCustomObject()
-    customInfo.diffuse = imageList[option_index]
+    customInfo.diffuse = IMAGE_LIST[option_index]
     self.setCustomObject(customInfo)
     self.reload()
   end)
@@ -79,7 +69,12 @@ end
 -- called for every card that enters
 function onObjectEnterContainer(container, object)
   if container == self then
-    findCard(object.getGUID(), object.getName(), object.getGMNotes())
+    if object.tag ~= "Card" then
+      broadcastToAll("The 'Attachment Helper' is meant to be used for single cards.", "White")
+    else
+      findCard(object.getGUID(), object.getName(), object.getGMNotes())
+    end
+    -- TODO: implement splitting of decks that get thrown in here
     recreateButtons()
   end
 end
@@ -181,7 +176,7 @@ function recreateButtons()
     verticalPosition = verticalPosition - 0.5
   end
 
-  local countLabel = '\nAttachment\nHelper\n' .. information["version"]
+  local countLabel = "Attachment\nHelper"
   if #cardsInBag ~= 0 then countLabel = #cardsInBag end
 
   self.createButton({


### PR DESCRIPTION
- added error-handling for non-cards (e.g. decks or other objects)
- removed `information` that was used for "last updated" date