### PR TITLE
Make Ancestral Knowledge only pull skills from the deck

### DIFF
--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -240,7 +240,7 @@ function handleAncestralKnowledge(cardList)
       hasAncestralKnowledge = true
       card.zone = "SetAside3"
     elseif (card.metadata.type == "Skill"
-        and card.metadata.bonded_to == nil
+        and card.zone == "Deck"
         and not card.metadata.weakness) then
       table.insert(skillList, i)
     end


### PR DESCRIPTION
This will keep it from pulling set-aside cards such as On the Mend or Essence of the Dream