### PR TITLE
SCED Intro Tour, tweaks and fixes

### DIFF
--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -107,12 +107,12 @@
   {
     "Name": "NextArrow",
     "Type": 0,
-    "URL": "https://i.imgur.com/gXRiKmu.png"
+    "URL": "https://i.imgur.com/MztSQis.png"
   },
   {
     "Name": "Exit",
     "Type": 0,
-    "URL": "https://i.imgur.com/i0VMjPD.png"
+    "URL": "https://i.imgur.com/8qmTXwt.png"
   },
   {
     "Name": "Inv-Mandy",

--- a/src/core/tour/TourCard.ttslua
+++ b/src/core/tour/TourCard.ttslua
@@ -6,8 +6,8 @@ tourCardTemplate = {
   tag = "Panel",
   attributes = {
     id = "tourCard",
-    height = 195,
-    width = 300,
+    height = 215,
+    width = 330,
     rotation = "0 0 0",
     position = "0 300 30",
     showAnimation = "FadeIn",
@@ -19,10 +19,10 @@ tourCardTemplate = {
       tag = "Image",
       attributes = {
         id = "tourNarratorImageLeft",
-        height=75,
-        width=50,
+        height=120,
+        width=80,
         rectAlignment="UpperLeft",
-        offsetXY = "-50 0",
+        offsetXY = "-80 0",
         -- Image will be set when the card is updated
       }
     },
@@ -31,10 +31,10 @@ tourCardTemplate = {
       attributes = {
         id = "tourNarratorImageRight",
         active = false,
-        height=75,
-        width=50,
+        height=125,
+        width=80,
         rectAlignment="UpperRight",
-        offsetXY = "50 0"
+        offsetXY = "80 0"
         -- Image will be set when the card is updated
       }
     },
@@ -43,8 +43,8 @@ tourCardTemplate = {
       attributes = {
         id = "tourSpeechBubble",
         color = "#F5F5DC",
-        height = 195,
-        width = 300,
+        height = 215,
+        width = 330,
         rectAlignment = "MiddleCenter",
         image = "SpeechBubble",
       },
@@ -53,35 +53,37 @@ tourCardTemplate = {
       tag = "Text",
       attributes = {
         id = "tourText",
-        height = 165,
-        width = 230,
+        -- Everything on this is double-sized and scaled down to keep the text sharps
+        height = 370,
+        width = 520,
+        scale = "0.5 0.5 1",
         rectAlignment = "UpperCenter",
         offsetXY = "15 -15",
         resizeTextForBestFit = true,
-        resizeTextMinSize = 10,
-        resizeTextMaxSize = 16,
+        resizeTextMinSize = 20,
+        resizeTextMaxSize = 32,
         color = "#050505",
         alignment = "UpperLeft",
         horizontalOverflow = "wrap",
       }
     },
     {
-      tag = "Button",
+      tag = "Image",
       attributes = {
         id = "tourNext",
-        height = 40,
-        width = 40,
+        height = 45,
+        width = 45,
         rectAlignment = "LowerRight",
         offsetXY = "-5 -45",
         image = "NextArrow"
       },
     },
     {
-      tag = "Button",
+      tag = "Image",
       attributes = {
         id = "tourStop",
-        height = 40,
-        width = 40,
+        height = 45,
+        width = 45,
         rectAlignment = "LowerLeft",
         offsetXY = "35 -45",
         image = "Exit"

--- a/src/core/tour/TourManager.ttslua
+++ b/src/core/tour/TourManager.ttslua
@@ -36,10 +36,14 @@ do
     east = "600 0 0",
     west = "-600 0 0",
     south = "0 -300 0",
-    northwest = "-600 300 0",
+    -- Northwest is only used by the Mandy card, move it a little right than standard so it's
+    -- closer to the importer
+    northwest = "-500 300 0",
     northeast = "600 300 0",
     southwest = "-600 -300 0",
-    southeast = "600 -300 0"
+    -- Used by the Diana and Wini cards referencing the bottom-right global controls, moved a little
+    -- closer to them
+    southeast = "730 -365 0"
   }
 
   -- Tracks the current state of the tours.  Keyed by player color to keep each player's tour
@@ -264,7 +268,6 @@ do
   ---@param playerColor String.  String color of the player to make this visible for
   internal.setDeepVisibility = function(xmlUi, playerColor)
     xmlUi.attributes.visibility = "" .. playerColor
-    log(xmlUi.attributes.id)
     if xmlUi.children ~= nil then
       for _, child in ipairs(xmlUi.children) do
         internal.setDeepVisibility(child, playerColor)

--- a/src/core/tour/TourScript.ttslua
+++ b/src/core/tour/TourScript.ttslua
@@ -8,7 +8,7 @@ TOUR_SCRIPT = {
   },
   {
     narrator = "Darrell",
-    text = "Cameras can be tricky things.  Best you leave handling it to the professionals during the tour.  Don't try to move the camera until the tour is complete.\n\nOnce we're done, remmeber you can use the 'p' key to switch back to third-person mode, and the spacebar to reset the position.",
+    text = "Cameras can be tricky things.  Best you leave handling it to the professionals during the tour.  Don't try to move the camera until the tour is complete.\n\nOnce we're done, remember you can use the 'p' key to switch back to third-person mode, and the spacebar to reset the position.",
     position = "center",
     speakerSide = "right",
   },
@@ -25,7 +25,7 @@ TOUR_SCRIPT = {
     text = "To survive what's coming you'll need a deck.  If it's safely hidden away on ArkhamDB you can load it here, and even find the newest version after an upgrade without changing the ID.\n\nNo need to publish all your decks, use 'Private' and you can see it.  Just make sure to select 'Make your decks public' in ArkhamDB.",
     showObj = "a28140",
     distanceFromObj = -10,
-    position = "west",
+    position = "northwest",
   },
   {
     narrator = "Daniela",
@@ -83,7 +83,7 @@ TOUR_SCRIPT = {
   },
   {
     narrator = "Preston",
-    text = "I can afford to buy what I need, but for those less well-off we've provided an endless pool of tokens to track your game.  Simply drag one out of the pools here.\n\nResources are my favorite, of course, but damage and horror are as inevitable as taxes, though I leave those to my bookkeeper.  Those tokens can work like counters, use the number keys to change the value.",
+    text = "I can afford to buy what I need, but for those less well-off we've provided an endless pool of tokens to track your game.  Simply drag one out of the pools here.\n\nResources are my favorite of course, but damage and horror are as inevitable as taxes.  I leave those to my bookkeeper though.  Those tokens can work like counters, use the number keys to change the value.",
     showObj = "9fadf9",
     position = "north",
     skipCentering = true,


### PR DESCRIPTION
Contains a variety of small adjustments to the tour:
- Fixed a typo in Darrell's card
- Increased overall size by 10%
- Increased investigator images by about 50%
- Moved some of the card positions slightly to line up with their specific uses
- Updated button images to a smaller base image (because TTS's image scaling is crap)