### PR TITLE
added a scenario name splash on placing down scenarios and setting to toggle it

### DIFF
--- a/objects/LuaScriptState.luascriptstate
+++ b/objects/LuaScriptState.luascriptstate
@@ -1,1 +1,1 @@
-{"optionPanel":{"showChaosBagManager":false,"showCleanUpHelper":false,"showDrawButton":false,"showHandHelper":[],"showNavigationOverlay":false,"showTokenArranger":false,"useClueClickers":false,"useSnapTags":true}}
+{"optionPanel":{"showChaosBagManager":false,"showCleanUpHelper":false,"showDrawButton":false,"showHandHelper":[],"showNavigationOverlay":false,"showTokenArranger":false,"useClueClickers":false,"useSnapTags":true,"showTitleSplash":true}}

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -818,7 +818,7 @@ function applyOptionPanelChange(id, state)
     -- update master clue counter
     getObjectFromGUID("4a3aa4").setVar("useClickableCounters", state)
 
-  -- option: Clickable clue counters
+  -- option: Show Title on placing scenarios
   elseif id == "showTitleSplash" then
     optionPanel[id] = state
 

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -818,6 +818,10 @@ function applyOptionPanelChange(id, state)
     -- update master clue counter
     getObjectFromGUID("4a3aa4").setVar("useClickableCounters", state)
 
+  -- option: Clickable clue counters
+  elseif id == "showTitleSplash" then
+    optionPanel[id] = state
+
   -- option: Show token arranger
   elseif id == "showTokenArranger" then
     -- delete previously pulled out tokens
@@ -931,7 +935,7 @@ function onClick_defaultSettings()
   for id, _ in pairs(optionPanel) do
     local state = false
     -- override for settings that are enabled by default
-    if id == "useSnapTags" then
+    if id == "useSnapTags" or id == "showTitleSplash" then
       state = true
     end
     applyOptionPanelChange(id, state)
@@ -942,6 +946,7 @@ function onClick_defaultSettings()
     useSnapTags = true,
     showDrawButton = false,
     useClueClickers = false,
+    showTitleSplash = true,
     showTokenArranger = false,
     showCleanUpHelper = false,
     showHandHelper = {},
@@ -951,4 +956,27 @@ function onClick_defaultSettings()
 
   -- update UI
   updateOptionPanelState()
+end
+
+-- splash scenario title on setup
+titleSplashId = nil
+function titleSplash(params)
+  if self.UI.getAttribute('showTitleSplash', "isOn") == "True" then
+
+    -- if there's any ongoing title being displayed, hide it and cancel the waiting function
+    if titleSplashId then
+      Wait.stop(titleSplashId)
+      titleSplashId = nil
+      UI.setAttribute('title_splash', 'active', false)
+    end
+
+    -- display scenario name and set a 4 seconds (2 seconds animation and 2 seconds on screen)
+    -- wait timer to hide the scenario name
+    UI.setValue('title_splash', params.scenarioName)
+    UI.show('title_splash')
+    titleSplashId = Wait.time(function()
+      UI.hide('title_splash')
+      titleSplashId = nil
+    end, 4)
+  end
 end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -34,6 +34,7 @@ local chaosTokens = {}
 local chaosTokensLastMat = nil
 local IS_RESHUFFLING = false
 local bagSearchers = {}
+local hideTitleSplashWaitFunctionId = nil
 local playmatAPI = require("playermat/PlaymatApi")
 
 ---------------------------------------------------------
@@ -959,24 +960,23 @@ function onClick_defaultSettings()
 end
 
 -- splash scenario title on setup
-titleSplashId = nil
-function titleSplash(params)
-  if self.UI.getAttribute('showTitleSplash', "isOn") == "True" then
+function titleSplash(scenarioName)
+  if optionPanel['showTitleSplash'] then
 
     -- if there's any ongoing title being displayed, hide it and cancel the waiting function
-    if titleSplashId then
-      Wait.stop(titleSplashId)
-      titleSplashId = nil
+    if hideTitleSplashWaitFunctionId then
+      Wait.stop(hideTitleSplashWaitFunctionId)
+      hideTitleSplashWaitFunctionId = nil
       UI.setAttribute('title_splash', 'active', false)
     end
 
     -- display scenario name and set a 4 seconds (2 seconds animation and 2 seconds on screen)
     -- wait timer to hide the scenario name
-    UI.setValue('title_splash', params.scenarioName)
+    UI.setValue('title_splash', scenarioName)
     UI.show('title_splash')
-    titleSplashId = Wait.time(function()
+    hideTitleSplashWaitFunctionId = Wait.time(function()
       UI.hide('title_splash')
-      titleSplashId = nil
+      hideTitleSplashWaitFunctionId = nil
     end, 4)
   end
 end

--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -55,6 +55,7 @@ function resetTokensIfInDeckZone(container, object)
 end
 
 function fireScenarioChangedEvent()
+  Global.call('titleSplash', {scenarioName = currentScenario})
   playArea.onScenarioChanged(currentScenario)
 end
 

--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -55,7 +55,7 @@ function resetTokensIfInDeckZone(container, object)
 end
 
 function fireScenarioChangedEvent()
-  Global.call('titleSplash', {scenarioName = currentScenario})
+  Global.call('titleSplash', currentScenario)
   playArea.onScenarioChanged(currentScenario)
 end
 

--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -130,4 +130,5 @@ end
 
 function onScenarioChanged(scenarioName)
   currentScenario = scenarioName
+  Global.call('titleSplash', {scenarioName = scenarioName})
 end

--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -130,5 +130,4 @@ end
 
 function onScenarioChanged(scenarioName)
   currentScenario = scenarioName
-  Global.call('titleSplash', {scenarioName = scenarioName})
 end

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -114,7 +114,8 @@
   showAnimation='FadeIn'
   hideAnimation='FadeOut'
   active='false'
-  animationDuration='2'>
+  animationDuration='2'
+  horizontalOverflow="Wrap">
 </Text>
 
 <Include src="OptionPanel.xml"/>

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -106,7 +106,6 @@
 
 <!-- Title Splash when starting a scenario -->
 <Text id="title_splash"
-  position="0 0 0"
   fontSize="150"
   font="font_teutonic-arkham"
   outline="black"

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -105,16 +105,16 @@
 </VerticalLayout>
 
 <!-- Title Splash when starting a scenario -->
-<Text id='title_splash'
-  position='0 0 0'
+<Text id="title_splash"
+  position="0 0 0"
   fontSize="150"
   font="font_teutonic-arkham"
   outline="black"
   outlineSize="3 -3"
-  showAnimation='FadeIn'
-  hideAnimation='FadeOut'
-  active='false'
-  animationDuration='2'
+  showAnimation="FadeIn"
+  hideAnimation="FadeOut"
+  active="false"
+  animationDuration="2"
   horizontalOverflow="Wrap">
 </Text>
 

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -104,4 +104,17 @@
   </Panel>
 </VerticalLayout>
 
+<!-- Title Splash when starting a scenario -->
+<Text id='title_splash'
+  position='0 0 0'
+  fontSize="150"
+  font="font_teutonic-arkham"
+  outline="black"
+  outlineSize="3 -3"
+  showAnimation='FadeIn'
+  hideAnimation='FadeOut'
+  active='false'
+  animationDuration='2'>
+</Text>
+
 <Include src="OptionPanel.xml"/>

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -142,6 +142,20 @@
             </Cell>
           </Row>
 
+          <!-- Option: splash scenario name on setup -->
+          <Row class="option-text">
+            <Cell class="option-text">
+              <VerticalLayout class="text-column">
+                <Text class="option-header">Show Scenario Title on Setup</Text>
+                <Text class="description">Fade in the name of the scenario for 2 seconds when placing down a scenario.</Text>
+              </VerticalLayout>
+            </Cell>
+            <Cell class="option-button">
+              <Toggle id="showTitleSplash"
+                onValueChanged="onClick_toggleOption(showTitleSplash)"/>
+            </Cell>
+          </Row>
+
           <!-- Group: fan-made accessories -->
           <Row class="group-header">
             <Cell class="group-header">


### PR DESCRIPTION
Whenever a scenario is placed down, if the Scenario Card's name is populated under description, it will display the title on screen for 2 seconds with a 2 seconds fade in and 2 seconds fade out animation.

Also added a setting in the options panel to enable/disable this feature.