### PR TITLE
Token Manager: Re-enables tooltip and blanks the name for tokens

### DIFF
--- a/objects/TokenSource.124381/ClueDoom.a3fb6c.json
+++ b/objects/TokenSource.124381/ClueDoom.a3fb6c.json
@@ -40,7 +40,7 @@
   "Nickname": "ClueDoom",
   "Snap": false,
   "Sticky": true,
-  "Tooltip": false,
+  "Tooltip": true,
   "Transform": {
     "posX": 78.661,
     "posY": 2.398,

--- a/objects/TokenSource.124381/ClueDoom.a40a48.json
+++ b/objects/TokenSource.124381/ClueDoom.a40a48.json
@@ -40,7 +40,7 @@
   "Nickname": "ClueDoom",
   "Snap": false,
   "Sticky": true,
-  "Tooltip": false,
+  "Tooltip": true,
   "Transform": {
     "posX": 78.738,
     "posY": 2.287,

--- a/objects/TokenSource.124381/Resource.00d19a.json
+++ b/objects/TokenSource.124381/Resource.00d19a.json
@@ -40,7 +40,7 @@
   "Nickname": "Resource",
   "Snap": false,
   "Sticky": true,
-  "Tooltip": false,
+  "Tooltip": true,
   "Transform": {
     "posX": 78.848,
     "posY": 2.273,

--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -248,6 +248,8 @@ do
     else
       rot.y = 270
     end
+
+    tokenTemplate.Nickname = ""
     return spawnObjectData({
       data = tokenTemplate,
       position = position,


### PR DESCRIPTION
Disabling the tooltip for tokens also disables the displaying of count for stacked tokens - this re-enables the tooltip and blanks the name before spawning