### PR TITLE
Playmats: coordinate variable fixing

### DIFF
--- a/objects/Playermat1White.8b081b.ttslua
+++ b/objects/Playermat1White.8b081b.ttslua
@@ -3,8 +3,8 @@
 ---------------------------------------------------------
 
 PLAYER_COLOR          = "White"
-PLAY_ZONE_POSITION    = { x = -54.5, y = 4, z = 21 }
-PLAY_ZONE_SCALE       = { x = 36, y = 5.1, z = 14.5 }
+PLAY_ZONE_POSITION    = { x = -54.5, y = 4, z = 19 }
+PLAY_ZONE_SCALE       = { x = 32, y = 5, z = 12 }
 DRAW_DECK_POSITION    = { x = -54.8, y = 2.5, z = 4.29 }
 DISCARD_PILE_POSITION = { x = -58.9, y = 4, z = 4.29 }
 

--- a/objects/Playermat2Orange.bd0ff4.ttslua
+++ b/objects/Playermat2Orange.bd0ff4.ttslua
@@ -3,8 +3,8 @@
 ---------------------------------------------------------
 
 PLAYER_COLOR          = "Orange"
-PLAY_ZONE_POSITION    = { x = -54.5, y = 4, z = -21 }
-PLAY_ZONE_SCALE       = { x = 36, y = 5.1, z = 14.5 }
+PLAY_ZONE_POSITION    = { x = -54.5, y = 4, z = -19 }
+PLAY_ZONE_SCALE       = { x = 32, y = 5, z = 12 }
 DRAW_DECK_POSITION    = { x = -54.86, y = 2.5, z = -27.82 }
 DISCARD_PILE_POSITION = { x = -58.96, y = 4, z = -27.82 }
 

--- a/objects/Playermat3Green.383d8b.ttslua
+++ b/objects/Playermat3Green.383d8b.ttslua
@@ -3,10 +3,10 @@
 ---------------------------------------------------------
 
 PLAYER_COLOR          = "Green"
-PLAY_ZONE_POSITION    = { x = -25, y = 4, z = 27 }
-PLAY_ZONE_SCALE       = { x = 30, y = 5, z = 14.5 }
-DRAW_DECK_POSITION    = { x = -37.26, y = 2.5, z = 26.4 }
-DISCARD_PILE_POSITION = { x = -37.26, y = 4, z = 30.50 }
+PLAY_ZONE_POSITION    = { x = -26.5, y = 4, z = 26.5 }
+PLAY_ZONE_SCALE       = { x = 32, y = 5, z = 12 }
+DRAW_DECK_POSITION    = { x = -42.04, y = 2.5, z = 26.45 }
+DISCARD_PILE_POSITION = { x = -42.04, y = 4, z = 30.55 }
 
 TRASHCAN_GUID         = "5f896a"
 STAT_TRACKER_GUID     = "af7ed7"

--- a/objects/Playermat4Red.0840d5.ttslua
+++ b/objects/Playermat4Red.0840d5.ttslua
@@ -3,10 +3,10 @@
 ---------------------------------------------------------
 
 PLAYER_COLOR          = "Red"
-PLAY_ZONE_POSITION    = { x = -25, y = 4, z = -27 }
-PLAY_ZONE_SCALE       = { x = 30, y = 5, z = 14.5 }
-DRAW_DECK_POSITION    = { x = -13.78, y = 2.5, z = -26.37 }
-DISCARD_PILE_POSITION = { x = -13.78, y = 4, z = -30.48 }
+PLAY_ZONE_POSITION    = { x = -26.5, y = 4, z = -26.5 }
+PLAY_ZONE_SCALE       = { x = 32, y = 5, z = 12 }
+DRAW_DECK_POSITION    = { x = -18.64, y = 2.5, z = -26.45 }
+DISCARD_PILE_POSITION = { x = -18.64, y = 4, z = -30.55 }
 
 TRASHCAN_GUID         = "4b8594"
 STAT_TRACKER_GUID     = "e74881"


### PR DESCRIPTION
Mainly needed for green/red playmat because of the recent downwards moved, coordinates for white/orange change to better reflect the actual size of the playarea (and don't overshoot into the play area)