### PR TITLE
Final Unified Player Card panel features

### DIFF
--- a/objects/PlayerCards.2d30ee.json
+++ b/objects/PlayerCards.2d30ee.json
@@ -53,5 +53,5 @@
     "scaleZ": 9.39
   },
   "Value": 0,
-  "XmlUI": "\u003cInclude src=\"ttslua/SCED/xml/playercards/PlayerCardPanel.xml\"/\u003e"
+  "XmlUI": "\u003cInclude src=\"playercards/PlayerCardPanel.xml\"/\u003e"
 }

--- a/objects/PlayerCards.2d30ee.json
+++ b/objects/PlayerCards.2d30ee.json
@@ -18,8 +18,8 @@
       "Type": 3
     },
     "ImageScalar": 1,
-    "ImageSecondaryURL": "https://i.imgur.com/dISlnEk.jpg",
-    "ImageURL": "https://i.imgur.com/dISlnEk.jpg",
+    "ImageSecondaryURL": "https://i.imgur.com/s5H1THb.jpg",
+    "ImageURL": "https://i.imgur.com/s5H1THb.jpg",
     "WidthScale": 0
   },
   "Description": "",
@@ -53,5 +53,5 @@
     "scaleZ": 9.39
   },
   "Value": 0,
-  "XmlUI": ""
+  "XmlUI": "\u003cInclude src=\"ttslua/SCED/xml/playercards/PlayerCardPanel.xml\"/\u003e"
 }

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -128,10 +128,12 @@ function buildSupplementalIndexes()
     if cardId == cardMetadata.id then
       -- Add card to the basic weakness list, if appropriate.  Some weaknesses have
       -- multiple copies, and are added multiple times
-      if cardMetadata.weakness and cardMetadata.basicWeaknessCount ~= nil then
+      if cardMetadata.weakness then
         table.insert(uniqueWeaknessList, cardMetadata.id)
-        for i = 1, cardMetadata.basicWeaknessCount do
-          table.insert(basicWeaknessList, cardMetadata.id)
+        if cardMetadata.basicWeaknessCount ~= nil then
+          for i = 1, cardMetadata.basicWeaknessCount do
+            table.insert(basicWeaknessList, cardMetadata.id)
+          end
         end
       end
 

--- a/src/playercards/PlayerCardPanel.ttslua
+++ b/src/playercards/PlayerCardPanel.ttslua
@@ -70,7 +70,10 @@ local CYCLE_LIST = {
   "Investigator Packs"
 }
 
+local excludedNonBasicWeaknesses
+
 local starterDeckMode = STARTER_DECK_MODE_CARDS_ONLY
+local helpVisibleToPlayers = { }
 
 function onSave()
   local saveState = {
@@ -87,10 +90,26 @@ function onLoad(savedData)
       spawnBag.loadFromSave(saveState.spawnBagState)
     end
   end
+  buildExcludedWeaknessList()
   createButtons()
 end
 
+-- Build a list of non-basic weaknesses which should be excluded from the last weakness set,
+-- including all signature cards and evolved weaknesses.
+function buildExcludedWeaknessList()
+  excludedNonBasicWeaknesses = { }
+  for _, investigator in pairs(INVESTIGATORS) do
+    for _, signatureId in ipairs(investigator.signatures) do
+      excludedNonBasicWeaknesses[signatureId] = true
+    end
+  end
+  for _, weaknessId in ipairs(EVOLVED_WEAKNESSES) do
+    excludedNonBasicWeaknesses[weaknessId] = true
+  end
+end
+
 function createButtons()
+  createHelpButton()
   createInvestigatorButtons()
   createLevelZeroButtons()
   createUpgradedButtons()
@@ -100,6 +119,19 @@ function createButtons()
   createClearButton()
   -- Create investigator mode buttons last so the indexes are set when we need to update them
   createInvestigatorModeButtons()
+end
+
+function createHelpButton()
+  self.createButton({
+    function_owner = self,
+    click_function = "toggleHelp",
+    position = Vector(0.845, 0.1, -0.855),
+    rotation = Vector(0, 0, 0),
+    height = 180,
+    width = 180,
+    scale = Vector(0.25, 1, 0.25),
+    color = TRANSPARENT,
+  })
 end
 
 function createInvestigatorButtons()
@@ -170,12 +202,12 @@ function createWeaknessButtons()
   }
   local buttonPos = WEAKNESS_ROW_START:copy()
   weaknessButtonParams.click_function = "spawnWeaknesses"
-  weaknessButtonParams.tooltip = "Basic Weaknesses"
+  weaknessButtonParams.tooltip = "All Weaknesses"
   weaknessButtonParams.position = buttonPos
   self.createButton(weaknessButtonParams)
   buttonPos.x = buttonPos.x + MISC_BUTTONS_X_OFFSET
   weaknessButtonParams.click_function = "spawnRandomWeakness"
-  weaknessButtonParams.tooltip = "Random Weakness"
+  weaknessButtonParams.tooltip = "Random Basic Weakness"
   weaknessButtonParams.position = buttonPos
   self.createButton(weaknessButtonParams)
 end
@@ -285,6 +317,29 @@ function createInvestigatorModeButtons()
     font_color = { 0, 0, 0 },
     color = { 1, 1, 1 }
   })
+end
+
+function toggleHelp(_, playerColor, _)
+  if helpVisibleToPlayers[playerColor] then
+    helpVisibleToPlayers[playerColor] = nil
+  else
+    helpVisibleToPlayers[playerColor] = true
+  end
+  updateHelpVisibility()
+end
+
+function updateHelpVisibility()
+  local visibility = ""
+  for player, _ in pairs(helpVisibleToPlayers) do
+    if string.len(visibility) > 0 then
+      visibility = visibility .. "|" .. player
+    else
+      visibility = player
+    end
+  end
+  self.UI.setAttribute("helpText", "visibility", visibility)
+  self.UI.setAttribute("helpPanel", "visibility", visibility)
+  self.UI.setAttribute("helpPanel", "active", string.len(visibility) > 0)
 end
 
 function setStarterDeckMode()
@@ -584,23 +639,38 @@ function spawnWeaknesses()
     return
   end
   local weaknessIdList = allCardsBag.call("getUniqueWeaknesses")
-  local copiedList = { }
+  local basicWeaknessList = { }
+  local campaignWeaknessList = { }
   for i, id in ipairs(weaknessIdList) do
-    copiedList[i] = id
+    local cardMetadata = allCardsBag.call("getCardById", { id = id }).metadata
+    if cardMetadata.basicWeaknessCount ~= nil and cardMetadata.basicWeaknessCount > 0 then
+      table.insert(basicWeaknessList, id)
+    elseif excludedNonBasicWeaknesses[id] == nil then
+      table.insert(campaignWeaknessList, id)
+    end
   end
   local groupPos = Vector(START_POSITIONS.classCards)
   spawnBag.spawn({
-    name = "weaknesses",
-    cards = copiedList,
+    name = "basicWeaknesses",
+    cards = basicWeaknessList,
     globalPos = groupPos,
     rotation = FACE_UP_ROTATION,
     spread = true,
     spreadCols = 20
   })
-  groupPos.x = groupPos.x - math.ceil(#copiedList / 20) * CARD_ROW_OFFSET - CARD_GROUP_OFFSET
+  groupPos.x = groupPos.x - math.ceil(#basicWeaknessList / 20) * CARD_ROW_OFFSET - CARD_GROUP_OFFSET
   spawnBag.spawn({
     name = "evolvedWeaknesses",
     cards = EVOLVED_WEAKNESSES,
+    globalPos = groupPos,
+    rotation = FACE_UP_ROTATION,
+    spread = true,
+    spreadCols = 20
+  })
+  groupPos.x = groupPos.x - math.ceil(#EVOLVED_WEAKNESSES / 20) * CARD_ROW_OFFSET - CARD_GROUP_OFFSET
+  spawnBag.spawn({
+    name = "campaignWeaknesses",
+    cards = campaignWeaknessList,
     globalPos = groupPos,
     rotation = FACE_UP_ROTATION,
     spread = true,

--- a/src/playercards/PlayerCardPanel.ttslua
+++ b/src/playercards/PlayerCardPanel.ttslua
@@ -640,13 +640,13 @@ function spawnWeaknesses()
   end
   local weaknessIdList = allCardsBag.call("getUniqueWeaknesses")
   local basicWeaknessList = { }
-  local campaignWeaknessList = { }
+  local otherWeaknessList = { }
   for i, id in ipairs(weaknessIdList) do
     local cardMetadata = allCardsBag.call("getCardById", { id = id }).metadata
     if cardMetadata.basicWeaknessCount ~= nil and cardMetadata.basicWeaknessCount > 0 then
       table.insert(basicWeaknessList, id)
     elseif excludedNonBasicWeaknesses[id] == nil then
-      table.insert(campaignWeaknessList, id)
+      table.insert(otherWeaknessList, id)
     end
   end
   local groupPos = Vector(START_POSITIONS.classCards)
@@ -669,8 +669,8 @@ function spawnWeaknesses()
   })
   groupPos.x = groupPos.x - math.ceil(#EVOLVED_WEAKNESSES / 20) * CARD_ROW_OFFSET - CARD_GROUP_OFFSET
   spawnBag.spawn({
-    name = "campaignWeaknesses",
-    cards = campaignWeaknessList,
+    name = "otherWeaknesses",
+    cards = otherWeaknessList,
     globalPos = groupPos,
     rotation = FACE_UP_ROTATION,
     spread = true,

--- a/src/playercards/PlayerCardPanelData.ttslua
+++ b/src/playercards/PlayerCardPanelData.ttslua
@@ -38,45 +38,488 @@ EVOLVED_WEAKNESSES = {
   "04039",
   "04041",
   "04042",
+  "53014",
+  "53015",
 }
 
 ------------------ START INVESTIGATOR DATA DEFINITION ------------------
 INVESTIGATOR_GROUPS = {
-  Guardian = {
+  ["Guardian"] = {
     "Roland Banks",
+  	"Zoey Samaras",
+  	"Mark Harrigan",
+  	"Leo Anderson",
+  	"Carolyn Fern",
+  	"Tommy Muldoon",
+  	"Nathaniel Cho",
+  	"Sister Mary",
+  	"Daniela Reyes",
+  	"Carson Sinclair"
   },
-  Seeker = {
+  ["Seeker"] = {
     "Daisy Walker",
+  	"Rex Murphy",
+  	"Minh Thi Phan",
+  	"Ursula Downs",
+  	"Joe Diamond",
+  	"Mandy Thompson",
+  	"Harvey Walters",
+  	"Amanda Sharpe",
+  	"Norman Withers",
+  	"Vincent Lee"
   },
-  Core = {
+  ["Rogue"] = {
+  	"\"Skids\" O'Toole",
+  	"Jenny Barnes",
+  	"Sefina Rousseau",
+  	"Finn Edwards",
+  	"Preston Fairmont",
+  	"Tony Morgan",
+  	"Winifred Habbamock",
+  	"Trish Scarborough",
+  	"Monterey Jack",
+  	"Kymani Jones"
+  },
+  ["Mystic"] = {
+  	"Agnes Baker",
+  	"Jim Culver",
+  	"Akachi Onyele",
+  	"Father Mateo",
+  	"Diana Stanley",
+  	"Marie Lambeau",
+  	"Luke Robinson",
+  	"Jacqueline Fine",
+  	"Dexter Drake",
+  	"Lily Chen",
+  	"Amina Zidane",
+  	"Gloria Goldberg"
+  },
+  ["Survivor"] = {
+  	"Wendy Adams",
+  	"\"Ashcan\" Pete",
+  	"William Yorick",
+  	"Calvin Wright",
+  	"Rita Young",
+  	"Patrice Hathaway",
+  	"Stella Clark",
+  	"Silas Marsh",
+  	"Bob Jenkins",
+  	"Darrell Simmons"
+  },
+  ["Neutral"] = {
+  	"Lola Hayes",
+  	"Charlie Kane"
+  },
+  ["Core"] = {
     "Roland Banks",
     "Daisy Walker",
-    "R2",
-    "D2",
-    "R3",
-    "D3",
+    "\"Skids\" O'Toole",
+    "Agnes Baker",
+    "Wendy Adams"
   },
+  ["The Dunwich Legacy"] = {
+  	"Zoey Samaras",
+  	"Rex Murphy",
+  	"Jenny Barnes",
+  	"Jim Culver",
+  	"\"Ashcan\" Pete"
+  },
+  ["The Path to Carcosa"] = {
+  	"Mark Harrigan",
+  	"Minh Thi Phan",
+  	"Sefina Rousseau",
+  	"Akachi Onyele",
+  	"William Yorick",
+  	"Lola Hayes"
+  },
+  ["The Forgotten Age"] = {
+  	"Leo Anderson",
+  	"Ursula Downs",
+  	"Finn Edwards",
+  	"Father Mateo",
+  	"Calvin Wright"
+  },
+  ["The Circle Undone"] = {
+  	"Carolyn Fern",
+  	"Joe Diamond",
+  	"Preston Fairmont",
+  	"Diana Stanley",
+  	"Rita Young",
+  	"Marie Lambeau"
+  },
+  ["The Dream-Eaters"] = {
+  	"Tommy Muldoon",
+  	"Mandy Thompson",
+  	"Tony Morgan",
+  	"Luke Robinson",
+  	"Patrice Hathaway"
+  },
+  ["Investigator Packs"] = {
+  	"Nathaniel Cho",
+  	"Harvey Walters",
+  	"Winifred Habbamock",
+  	"Jacqueline Fine",
+  	"Stella Clark",
+  	"Gloria Goldberg"
+  },
+  ["The Innsmouth Conspiracy"] = {
+  	"Sister Mary",
+  	"Amanda Sharpe",
+  	"Trish Scarborough",
+  	"Dexter Drake",
+  	"Silas Marsh"
+  },
+  ["Edge of the Earth"] = {
+  	"Daniela Reyes",
+  	"Norman Withers",
+  	"Monterey Jack",
+  	"Lily Chen",
+  	"Bob Jenkins"
+  },
+  ["The Scarlet Keys"] = {
+  	"Carson Sinclair",
+  	"Vincent Lee",
+  	"Kymani Jones",
+  	"Amina Zidane",
+  	"Darrell Simmons",
+  	"Charlie Kane"
+  }
 }
 
 INVESTIGATORS = { }
+--Core--
 INVESTIGATORS["Roland Banks"] = {
-  cards = { "01001", "01001-promo", "01001-p", "01001-pf", "01001-pb", },
-  minicards = { "01001-m", "01001-promo-m", },
-  signatures = { "01006", "01007", "90030", "90031", },
-  starterDeck = "2624931",
+  cards = { "01001", "01001-p", "01001-pf", "01001-pb" },
+  minicards = { "01001-m" },
+  signatures = { "01006", "01007", "90030", "90031", "98005", "98006" },
+  starterDeck = "2624931"
 }
 INVESTIGATORS["Daisy Walker"] = {
-  cards = { "01002", "01002-p", "01002-pf", "01002-pb", },
-  minicards = { "01002-m", },
+  cards = { "01002", "01002-p", "01002-pf", "01002-pb" },
+  minicards = { "01002-m" },
   signatures = { "01008", "01009", "90002", "90003" },
-  starterDeck = "2624938",
+  starterDeck = "2624938"
+}
+INVESTIGATORS["\"Skids\" O'Toole"] = {
+	cards = { "01003", "01003-p", "01003-pf", "01003-pb" },
+	minicards = { "01003-m" },
+	signatures = { "01010", "01011", "90009", "90010" },
+	starterDeck = "2624940"
+}
+INVESTIGATORS["Agnes Baker"] = {
+	cards = { "01004", "01004-p", "01004-pf", "01004-pb" },
+	minicards = { "01004-m" },
+	signatures = { "01012", "01013", "90018", "90019" },
+	starterDeck = "2624944"
+}
+INVESTIGATORS["Wendy Adams"] = {
+	cards = { "01005", "01005-p", "01005-pf", "01005-pb"},
+	minicards = { "01005-m" },
+	signatures = { "01014", "01015", "01515", "90039", "90040" },
+	starterDeck = "2624949"
+}
+--Dunwich--
+INVESTIGATORS["Zoey Samaras"] = {
+	cards = { "02001" },
+	minicards = { "02001-m" },
+	signatures = { "02006", "02007" },
+	starterDeck = "2624950"
+}
+INVESTIGATORS["Rex Murphy"] = {
+	cards = { "02002", "02002-t" },
+	minicards = { "02002-m" },
+	signatures = { "02008", "02009" },
+	starterDeck = "2624958"
+}
+INVESTIGATORS["Jenny Barnes"] = {
+	cards = { "02003" },
+	minicards = { "02003-m" },
+	signatures = { "02010", "02011", "98002", "98003" },
+	starterDeck = "2624961"
+}
+INVESTIGATORS["Jim Culver"] = {
+	cards = { "02004" },
+	minicards = { "02004-m" },
+	signatures = { "02012", "02013" },
+	starterDeck = "2624965"
+}
+INVESTIGATORS["\"Ashcan\" Pete"] = {
+	cards = { "02005" },
+	minicards = { "02005-m" },
+	signatures = { "02014", "02015" },
+	starterDeck = "2624969"
+}
+--Carcosa--
+INVESTIGATORS["Mark Harrigan"] = {
+	cards = { "03001" },
+	minicards = { "03001-m" },
+	signatures = { "03007", "03008", "03009" },
+	starterDeck = "2624975"
+}
+INVESTIGATORS["Minh Thi Phan"] = {
+	cards = { "03002" },
+	minicards = { "03002-m" },
+	signatures = { "03010", "03011" },
+	starterDeck = "2624979"
+}
+INVESTIGATORS["Sefina Rousseau"] = {
+	cards = { "03003" },
+	minicards = { "03003-m" },
+	signatures = { "03012", "03013" }, --Unsure how to specify 3x of 03012
+	starterDeck = "2624981"
+}
+INVESTIGATORS["Akachi Onyele"] = {
+	cards = { "03004" },
+	minicards = { "03004-m" },
+	signatures = { "03014", "03015" },
+	starterDeck = "2624984"
+}
+INVESTIGATORS["William Yorick"] = {
+	cards = { "03005" },
+	minicards = { "03005-m" },
+	signatures = { "03016", "03017" },
+	starterDeck = "2624988"
+}
+INVESTIGATORS["Lola Hayes"] = {
+	cards = { "03006", "03006-t" },
+	minicards = { "03006-m" },
+	signatures = { "03018", "03019", "03019-t" },
+	starterDeck = "2624990"
+}
+--Forgotten--
+INVESTIGATORS["Leo Anderson"] = {
+	cards = { "04001" },
+	minicards = { "04001-m" },
+	signatures = { "04006", "04007" },
+	starterDeck = "2624994"
+}
+INVESTIGATORS["Ursula Downs"] = {
+	cards = { "04002" },
+	minicards = { "04002-m" },
+	signatures = { "04008", "04009" },
+	starterDeck = "2625000"
+}
+INVESTIGATORS["Finn Edwards"] = {
+	cards = { "04003" },
+	minicards = { "04003-m" },
+	signatures = { "04010", "04011", "04012" },
+	starterDeck = "2625003"
+}
+INVESTIGATORS["Father Mateo"] = {
+	cards = { "04004" },
+	minicards = { "04004-m" },
+	signatures = { "04013", "04014" },
+	starterDeck = "2625005"
+}
+INVESTIGATORS["Calvin Wright"] = {
+	cards = { "04005" },
+	minicards = { "04005-m" },
+	signatures = { "04015", "04016" },
+	starterDeck = "2625007"
+}
+--Circle--
+INVESTIGATORS["Carolyn Fern"] = {
+	cards = { "05001" },
+	minicards = { "05001-m" },
+	signatures = { "05007", "05008", "98011", "98012" },
+	starterDeck = "2626342"
+}
+INVESTIGATORS["Joe Diamond"] = {
+	cards = { "05002" },
+	minicards = { "05002-m" },
+	signatures = { "05009", "05010" },
+	starterDeck = "2626347"
+}
+INVESTIGATORS["Preston Fairmont"] = {
+	cards = { "05003" },
+	minicards = { "05003-m" },
+	signatures = { "05011", "05012" },
+	starterDeck = "2626365"
+}
+INVESTIGATORS["Diana Stanley"] = {
+	cards = { "05004" },
+	minicards = { "05004-m" },
+	signatures = { "05013", "05014", "05015" },
+	starterDeck = "2626385"
+}
+INVESTIGATORS["Rita Young"] = {
+	cards = { "05005" },
+	minicards = { "05005-m" },
+	signatures = { "05016", "05017" },
+	starterDeck = "2626387"
+}
+INVESTIGATORS["Marie Lambeau"] = {
+	cards = { "05006" },
+	minicards = { "05006-m" },
+	signatures = { "05018", "05019" },
+	starterDeck = "2626395"
+}
+--Dream--
+INVESTIGATORS["Tommy Muldoon"] = {
+	cards = { "06001" },
+	minicards = { "06001-m" },
+	signatures = { "06006", "06007" },
+	starterDeck = "2626402"
+}
+INVESTIGATORS["Mandy Thompson"] = {
+	cards = { "06002", "06002-t" },
+	minicards = { "06002-m" },
+	signatures = { "06008", "06009" },
+	starterDeck = "2626410"
+}
+INVESTIGATORS["Tony Morgan"] = {
+	cards = { "06003" },
+	minicards = { "06003-m" },
+	signatures = { "06010", "06011", "06012" },
+	starterDeck = "2626446"
+}
+INVESTIGATORS["Luke Robinson"] = {
+	cards = { "06004" },
+	minicards = { "06004-m" },
+	signatures = { "06013", "06014", "06015" },
+	starterDeck = "2626452"
+}
+INVESTIGATORS["Patrice Hathaway"] = {
+	cards = { "06005" },
+	minicards = { "06005-m" },
+	signatures = { "06016", "06017" },
+	starterDeck = "2626461"
+}
+--Starter--
+INVESTIGATORS["Nathaniel Cho"] = {
+	cards = { "60101" },
+	minicards = { "60101-m" },
+	signatures = { "60102", "60103" },
+	starterDeck = "2643925"
+}
+INVESTIGATORS["Harvey Walters"] = {
+	cards = { "60201" },
+	minicards = { "60201-m" },
+	signatures = { "60202", "60203" },
+	starterDeck = "2643928"
+}
+INVESTIGATORS["Winifred Habbamock"] = {
+	cards = { "60301" },
+	minicards = { "60301-m" },
+	signatures = { "60302", "60303" },
+	starterDeck = "2643931"
+}
+INVESTIGATORS["Jacqueline Fine"] = {
+	cards = { "60401" },
+	minicards = { "60401-m" },
+	signatures = { "60402", "60403" },
+	starterDeck = "2643932"
+}
+INVESTIGATORS["Stella Clark"] = {
+	cards = { "60501" },
+	minicards = { "60501-m" },
+	signatures = { "60502", "60503" },
+	starterDeck = "2643934"
+}
+--Innsmouth--
+INVESTIGATORS["Sister Mary"] = {
+	cards = { "07001" },
+	minicards = { "07001-m" },
+	signatures = { "07006", "07007" },
+	starterDeck = "2626464"
+}
+INVESTIGATORS["Amanda Sharpe"] = {
+	cards = { "07002" },
+	minicards = { "07002-m" },
+	signatures = { "07008", "07009" },
+	starterDeck = "2626469"
+}
+INVESTIGATORS["Trish Scarborough"] = {
+	cards = { "07003" },
+	minicards = { "07003-m" },
+	signatures = { "07010", "07011" },
+	starterDeck = "2626479"
+}
+INVESTIGATORS["Dexter Drake"] = {
+	cards = { "07004" },
+	minicards = { "07004-m" },
+	signatures = { "07012", "07013", "98017", "98018" },
+	starterDeck = "2626672"
+}
+INVESTIGATORS["Silas Marsh"] = {
+	cards = { "07005" },
+	minicards = { "07005-m" },
+	signatures = { "07014", "07015", "07016", "98014", "98015" },
+	starterDeck = "2626685"
+}
+--Edge--
+INVESTIGATORS["Daniela Reyes"] = {
+	cards = { "08001" },
+	minicards = { "08001-m" },
+	signatures = {"08002", "08003" },
+	starterDeck = "2634588"
+}
+INVESTIGATORS["Norman Withers"] = {
+	cards = { "08004" },
+	minicards = { "08004-m" },
+	signatures = { "08005", "08006", "98008", "98009" },
+	starterDeck = "2634603"
+}
+INVESTIGATORS["Monterey Jack"] = {
+	cards = { "08007" },
+	minicards = { "08007-m" },
+	signatures = { "08008", "08009" },
+	starterDeck = "2634652"
+}
+INVESTIGATORS["Lily Chen"] = {
+	cards = { "08010" },
+	minicards = { "08010-m" },
+	signatures = { "08011", "08012", "08013", "08014", "08015" },
+	starterDeck = "2634658"
+}
+INVESTIGATORS["Bob Jenkins"] = {
+	cards = { "08016" },
+	minicards = { "08016-m" },
+	signatures = { "08017", "08018" },
+	starterDeck = "2634643"
+}
+--Scarlet--
+INVESTIGATORS["Carson Sinclair"] = {
+	cards = { "09001" },
+	minicards = { "09001-m" },
+	signatures = { "09002", "09003" },
+	starterDeck = "2634667	"
+}
+INVESTIGATORS["Vincent Lee"] = {
+	cards = { "09004" },
+	minicards = { "09004-m" },
+	signatures = { "09005", "09006", "09007" },
+	starterDeck = "2634675"
+}
+INVESTIGATORS["Kymani Jones"] = {
+	cards = { "09008" },
+	minicards = { "09008-m" },
+	signatures = { "09009", "09010" },
+	starterDeck = "2634701"
+}
+INVESTIGATORS["Amina Zidane"] = {
+	cards = { "09011" },
+	minicards = { "09011-m" },
+	signatures = { "09012", "09013", "09014" },
+	starterDeck = "2634697"
+}
+INVESTIGATORS["Darrell Simmons"] = {
+	cards = { "09015" },
+	minicards = { "09015-m" },
+	signatures = { "09016", "09017" },
+	starterDeck = "2634757		"
+}
+INVESTIGATORS["Charlie Kane"] = {
+	cards = { "09018" },
+	minicards = { "09018-m" },
+	signatures = { "09019", "09020" },
+	starterDeck = "2634706"
+}
+--Promo--
+INVESTIGATORS["Gloria Goldberg"] = {
+	cards = { "98019" },
+	minicards = { "98019-m" },
+	signatures = { "98020", "98021" },
+	starterDeck = "2636199"
 }
 ------------------ END INVESTIGATOR DATA DEFINITION ------------------
-INVESTIGATORS["R2"] = INVESTIGATORS["Roland Banks"]
-INVESTIGATORS["R3"] = INVESTIGATORS["Roland Banks"]
-INVESTIGATORS["R4"] = INVESTIGATORS["Roland Banks"]
-INVESTIGATORS["R5"] = INVESTIGATORS["Roland Banks"]
-INVESTIGATORS["D2"] = INVESTIGATORS["Daisy Walker"]
-INVESTIGATORS["D3"] = INVESTIGATORS["Daisy Walker"]
-INVESTIGATORS["D4"] = INVESTIGATORS["Daisy Walker"]
-INVESTIGATORS["D5"] = INVESTIGATORS["Daisy Walker"]

--- a/xml/playercards/PlayerCardPanel.xml
+++ b/xml/playercards/PlayerCardPanel.xml
@@ -1,0 +1,24 @@
+<Panel
+  active="false"
+  id="helpPanel"
+  position="-165 -60 -2"
+  rotation="0 0 180"
+  height="55"
+  width="107"
+  color="#00000099">
+  <Text
+    id="helpText"
+    rectAlignment="MiddleCenter"
+    height="490"
+    width="1000"
+    scale="0.1 0.1 1"
+    fontSize="66"
+    color="#F5F5F5"
+    backgroundColor="#FF0000"
+    alignment="UpperLeft"
+    horizontalOverflow="wrap">
+• Select a group to place cards
+• Copy the cards you want for your deck
+• Select a new group to clear the placed cards and see new ones
+• Clear to remove all cards</Text>
+</Panel>


### PR DESCRIPTION
- Integrates investigator data
- Adds a third weakness block to place non-basic weaknesses.  This was always intended but it wasn't possible to distinguish those from signature weaknesses without the investigator data.
- Change weakness button tooltips to reflect the new functionality
- Adds Fine Print and Sell Your Soul to the evolved weakness list
- Add a help popup
- Updates the image with the help button and a few minor changes (Level 1+ becomes Level 1-5, removed clipped rivets at the corners)