### PR TITLE
Playermat: Handle deleted small action token

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -600,7 +600,9 @@ function maybeUpdateActiveInvestigator(card)
     ["08016"]    = 14  -- Bob Jenkins
   }
 
-  setObjectState(smallToken, SPECIAL_ACTIONS[activeInvestigatorId] or STATE_TABLE[class])
+  if smallToken ~= nil then
+    setObjectState(smallToken, SPECIAL_ACTIONS[activeInvestigatorId] or STATE_TABLE[class])
+  end
 end
 
 function setObjectState(obj, stateId)


### PR DESCRIPTION
Implements a nil check for the small action token before trying to change its state (incase someone has it removed because they play an investigator where it does not make sense)