### PR TITLE
Removing "Extras" and "Investigators" from bottom menu

### DIFF
--- a/config.json
+++ b/config.json
@@ -189,7 +189,10 @@
     "TableDivider.75937e",
     "TableDivider.8646eb",
     "Community-CreatedPlayerCardsInvestigators.ed4ca7",
-    "Fan-MadeScenariosCampaignsMiscellany.66e97c"
+    "Fan-MadeScenariosCampaignsMiscellany.66e97c",
+    "Decoration-Ammo.0a3b03",
+    "Decoration-Ammo.b43845",
+    "Decoration-Ammo.d35ee9"
   ],
   "PlayArea": 1,
   "PlayerCounts": [

--- a/objects/ArkhamDBDeckImporter.a28140.json
+++ b/objects/ArkhamDBDeckImporter.a28140.json
@@ -44,7 +44,7 @@
   "Transform": {
     "posX": -17.5,
     "posY": 1.481,
-    "posZ": 70,
+    "posZ": 71,
     "rotX": 0,
     "rotY": 270,
     "rotZ": 0,

--- a/objects/Decoration-Ammo.0a3b03.json
+++ b/objects/Decoration-Ammo.0a3b03.json
@@ -1,0 +1,68 @@
+{
+  "AltLookAngle": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "Autoraise": true,
+  "ColorDiffuse": {
+    "b": 0.14106,
+    "g": 0.14106,
+    "r": 0.14106
+  },
+  "CustomMesh": {
+    "CastShadows": true,
+    "ColliderURL": "",
+    "Convex": true,
+    "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765629/74DEC33718157E37D77E0777715B452F9015A07F/",
+    "MaterialIndex": 2,
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765079/4F3634374EEC02E5D2DAED88F5D8F0956B6292B8/",
+    "NormalURL": "",
+    "TypeIndex": 0
+  },
+  "Description": "",
+  "DragSelectable": true,
+  "GMNotes": "",
+  "GUID": "0a3b03",
+  "Grid": false,
+  "GridProjection": false,
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "IgnoreFoW": false,
+  "LayoutGroupSortIndex": 0,
+  "Locked": true,
+  "LuaScript": "",
+  "LuaScriptState": "",
+  "MeasureMovement": false,
+  "Name": "Custom_Model",
+  "Nickname": "Decoration - Ammo",
+  "PhysicsMaterial": {
+    "BounceCombine": 0,
+    "Bounciness": 0,
+    "DynamicFriction": 0,
+    "FrictionCombine": 0,
+    "StaticFriction": 0
+  },
+  "Rigidbody": {
+    "AngularDrag": 0,
+    "Drag": 0,
+    "Mass": 500,
+    "UseGravity": true
+  },
+  "Snap": false,
+  "Sticky": true,
+  "Tooltip": false,
+  "Transform": {
+    "posX": -66.517,
+    "posY": 1.644,
+    "posZ": -83.303,
+    "rotX": 8,
+    "rotY": 176,
+    "rotZ": 267,
+    "scaleX": 0.2,
+    "scaleY": 0.3,
+    "scaleZ": 0.2
+  },
+  "Value": 0,
+  "XmlUI": ""
+}

--- a/objects/Decoration-Ammo.b43845.json
+++ b/objects/Decoration-Ammo.b43845.json
@@ -1,0 +1,68 @@
+{
+  "AltLookAngle": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "Autoraise": true,
+  "ColorDiffuse": {
+    "b": 0.14106,
+    "g": 0.14106,
+    "r": 0.14106
+  },
+  "CustomMesh": {
+    "CastShadows": true,
+    "ColliderURL": "",
+    "Convex": true,
+    "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765629/74DEC33718157E37D77E0777715B452F9015A07F/",
+    "MaterialIndex": 2,
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765079/4F3634374EEC02E5D2DAED88F5D8F0956B6292B8/",
+    "NormalURL": "",
+    "TypeIndex": 0
+  },
+  "Description": "",
+  "DragSelectable": true,
+  "GMNotes": "",
+  "GUID": "b43845",
+  "Grid": false,
+  "GridProjection": false,
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "IgnoreFoW": false,
+  "LayoutGroupSortIndex": 0,
+  "Locked": true,
+  "LuaScript": "",
+  "LuaScriptState": "",
+  "MeasureMovement": false,
+  "Name": "Custom_Model",
+  "Nickname": "Decoration - Ammo",
+  "PhysicsMaterial": {
+    "BounceCombine": 0,
+    "Bounciness": 0,
+    "DynamicFriction": 0,
+    "FrictionCombine": 0,
+    "StaticFriction": 0
+  },
+  "Rigidbody": {
+    "AngularDrag": 0,
+    "Drag": 0,
+    "Mass": 500,
+    "UseGravity": true
+  },
+  "Snap": false,
+  "Sticky": true,
+  "Tooltip": false,
+  "Transform": {
+    "posX": -65.826,
+    "posY": 1.571,
+    "posZ": -81.108,
+    "rotX": 290,
+    "rotY": 59,
+    "rotZ": 268,
+    "scaleX": 0.2,
+    "scaleY": 0.3,
+    "scaleZ": 0.2
+  },
+  "Value": 0,
+  "XmlUI": ""
+}

--- a/objects/Decoration-Ammo.d35ee9.json
+++ b/objects/Decoration-Ammo.d35ee9.json
@@ -1,0 +1,68 @@
+{
+  "AltLookAngle": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "Autoraise": true,
+  "ColorDiffuse": {
+    "b": 0.14106,
+    "g": 0.14106,
+    "r": 0.14106
+  },
+  "CustomMesh": {
+    "CastShadows": true,
+    "ColliderURL": "",
+    "Convex": true,
+    "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765629/74DEC33718157E37D77E0777715B452F9015A07F/",
+    "MaterialIndex": 2,
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765079/4F3634374EEC02E5D2DAED88F5D8F0956B6292B8/",
+    "NormalURL": "",
+    "TypeIndex": 0
+  },
+  "Description": "",
+  "DragSelectable": true,
+  "GMNotes": "",
+  "GUID": "d35ee9",
+  "Grid": false,
+  "GridProjection": false,
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "IgnoreFoW": false,
+  "LayoutGroupSortIndex": 0,
+  "Locked": true,
+  "LuaScript": "",
+  "LuaScriptState": "",
+  "MeasureMovement": false,
+  "Name": "Custom_Model",
+  "Nickname": "Decoration - Ammo",
+  "PhysicsMaterial": {
+    "BounceCombine": 0,
+    "Bounciness": 0,
+    "DynamicFriction": 0,
+    "FrictionCombine": 0,
+    "StaticFriction": 0
+  },
+  "Rigidbody": {
+    "AngularDrag": 0,
+    "Drag": 0,
+    "Mass": 500,
+    "UseGravity": true
+  },
+  "Snap": false,
+  "Sticky": true,
+  "Tooltip": false,
+  "Transform": {
+    "posX": -66.507,
+    "posY": 1.598,
+    "posZ": -88.119,
+    "rotX": 0,
+    "rotY": 161,
+    "rotZ": 90,
+    "scaleX": 0.2,
+    "scaleY": 0.3,
+    "scaleZ": 0.2
+  },
+  "Value": 0,
+  "XmlUI": ""
+}

--- a/objects/Detailedphasereference.68fe54.json
+++ b/objects/Detailedphasereference.68fe54.json
@@ -45,7 +45,7 @@
   "Transform": {
     "posX": -62,
     "posY": 1.495,
-    "posZ": 72,
+    "posZ": 71,
     "rotX": 0,
     "rotY": 270,
     "rotZ": 0,

--- a/objects/EncounterSets.304ffc.json
+++ b/objects/EncounterSets.304ffc.json
@@ -5,218 +5,9 @@
     "z": 0
   },
   "Autoraise": true,
-  "Bag": {
-    "Order": 0
-  },
-  "ChildObjects": [
-    {
-      "AltLookAngle": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "Autoraise": true,
-      "ColorDiffuse": {
-        "b": 0.141059875,
-        "g": 0.141059875,
-        "r": 0.141059875
-      },
-      "CustomMesh": {
-        "CastShadows": true,
-        "ColliderURL": "",
-        "Convex": true,
-        "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765629/74DEC33718157E37D77E0777715B452F9015A07F/",
-        "MaterialIndex": 2,
-        "MeshURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765079/4F3634374EEC02E5D2DAED88F5D8F0956B6292B8/",
-        "NormalURL": "",
-        "TypeIndex": 0
-      },
-      "Description": "",
-      "DragSelectable": true,
-      "GMNotes": "",
-      "GUID": "0a3b03",
-      "Grid": false,
-      "GridProjection": false,
-      "Hands": false,
-      "HideWhenFaceDown": false,
-      "IgnoreFoW": false,
-      "LayoutGroupSortIndex": 0,
-      "Locked": false,
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "MeasureMovement": false,
-      "Name": "Custom_Model",
-      "Nickname": "Ammo",
-      "PhysicsMaterial": {
-        "BounceCombine": 0,
-        "Bounciness": 0,
-        "DynamicFriction": 0,
-        "FrictionCombine": 0,
-        "StaticFriction": 0
-      },
-      "Rigidbody": {
-        "AngularDrag": 0,
-        "Drag": 0,
-        "Mass": 500,
-        "UseGravity": true
-      },
-      "Snap": false,
-      "Sticky": true,
-      "Tooltip": true,
-      "Transform": {
-        "posX": -0.8431477,
-        "posY": 0.0594902448,
-        "posZ": 0.08813342,
-        "rotX": -0.00000607416268,
-        "rotY": 0.000005999793,
-        "rotZ": 164.445618,
-        "scaleX": 0.06666666,
-        "scaleY": 0.099999994,
-        "scaleZ": 0.06666667
-      },
-      "Value": 0,
-      "XmlUI": ""
-    },
-    {
-      "AltLookAngle": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "Autoraise": true,
-      "ColorDiffuse": {
-        "b": 0.141059875,
-        "g": 0.141059875,
-        "r": 0.141059875
-      },
-      "CustomMesh": {
-        "CastShadows": true,
-        "ColliderURL": "",
-        "Convex": true,
-        "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765629/74DEC33718157E37D77E0777715B452F9015A07F/",
-        "MaterialIndex": 2,
-        "MeshURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765079/4F3634374EEC02E5D2DAED88F5D8F0956B6292B8/",
-        "NormalURL": "",
-        "TypeIndex": 0
-      },
-      "Description": "",
-      "DragSelectable": true,
-      "GMNotes": "",
-      "GUID": "0c05e4",
-      "Grid": false,
-      "GridProjection": false,
-      "Hands": false,
-      "HideWhenFaceDown": false,
-      "IgnoreFoW": false,
-      "LayoutGroupSortIndex": 0,
-      "Locked": false,
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "MeasureMovement": false,
-      "Name": "Custom_Model",
-      "Nickname": "Ammo",
-      "PhysicsMaterial": {
-        "BounceCombine": 0,
-        "Bounciness": 0,
-        "DynamicFriction": 0,
-        "FrictionCombine": 0,
-        "StaticFriction": 0
-      },
-      "Rigidbody": {
-        "AngularDrag": 0,
-        "Drag": 0,
-        "Mass": 500,
-        "UseGravity": true
-      },
-      "Snap": false,
-      "Sticky": true,
-      "Tooltip": true,
-      "Transform": {
-        "posX": -0.5932517,
-        "posY": -0.413039148,
-        "posZ": 0.088135004,
-        "rotX": 30.4455643,
-        "rotY": 270.000122,
-        "rotZ": 180.0001,
-        "scaleX": 0.06666667,
-        "scaleY": 0.09999998,
-        "scaleZ": 0.0666666552
-      },
-      "Value": 0,
-      "XmlUI": ""
-    },
-    {
-      "AltLookAngle": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "Autoraise": true,
-      "ColorDiffuse": {
-        "b": 0.141059875,
-        "g": 0.141059875,
-        "r": 0.141059875
-      },
-      "CustomMesh": {
-        "CastShadows": true,
-        "ColliderURL": "",
-        "Convex": true,
-        "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765629/74DEC33718157E37D77E0777715B452F9015A07F/",
-        "MaterialIndex": 2,
-        "MeshURL": "http://cloud-3.steamusercontent.com/ugc/780750188124765079/4F3634374EEC02E5D2DAED88F5D8F0956B6292B8/",
-        "NormalURL": "",
-        "TypeIndex": 0
-      },
-      "Description": "",
-      "DragSelectable": true,
-      "GMNotes": "",
-      "GUID": "b486bd",
-      "Grid": false,
-      "GridProjection": false,
-      "Hands": false,
-      "HideWhenFaceDown": false,
-      "IgnoreFoW": false,
-      "LayoutGroupSortIndex": 0,
-      "Locked": false,
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "MeasureMovement": false,
-      "Name": "Custom_Model",
-      "Nickname": "Ammo",
-      "PhysicsMaterial": {
-        "BounceCombine": 0,
-        "Bounciness": 0,
-        "DynamicFriction": 0,
-        "FrictionCombine": 0,
-        "StaticFriction": 0
-      },
-      "Rigidbody": {
-        "AngularDrag": 0,
-        "Drag": 0,
-        "Mass": 500,
-        "UseGravity": true
-      },
-      "Snap": false,
-      "Sticky": true,
-      "Tooltip": true,
-      "Transform": {
-        "posX": -0.0928746462,
-        "posY": 1.08934021,
-        "posZ": 0.08813286,
-        "rotX": 0.000100743171,
-        "rotY": 180.000122,
-        "rotZ": 96.55444,
-        "scaleX": 0.0666666552,
-        "scaleY": 0.09999998,
-        "scaleZ": 0.0666666552
-      },
-      "Value": 0,
-      "XmlUI": ""
-    }
-  ],
   "ColorDiffuse": {
     "b": 1,
-    "g": 0.99216,
+    "g": 1,
     "r": 1
   },
   "CustomMesh": {
@@ -237,11 +28,11 @@
     "MaterialIndex": 1,
     "MeshURL": "http://cloud-3.steamusercontent.com/ugc/863978359495064406/50966C05FB8C4D41BA069EB5E0E19E95BF3A9963/",
     "NormalURL": "",
-    "TypeIndex": 6
+    "TypeIndex": 0
   },
-  "Description": "Use the download menu at the bottom right to spawn encounter sets here.",
+  "Description": "Use the context menu to download the encounter sets by cycle.",
   "DragSelectable": true,
-  "GMNotes": "",
+  "GMNotes": "extras/encounter_sets.json",
   "GUID": "304ffc",
   "Grid": true,
   "GridProjection": false,
@@ -250,14 +41,11 @@
   "IgnoreFoW": false,
   "LayoutGroupSortIndex": 0,
   "Locked": true,
-  "LuaScript": "",
   "LuaScriptState": "",
-  "MaterialIndex": -1,
+  "LuaScript_path": "EncounterSets.304ffc.ttslua",
   "MeasureMovement": false,
-  "MeshIndex": -1,
-  "Name": "Custom_Model_Bag",
+  "Name": "Custom_Model",
   "Nickname": "Encounter Sets",
-  "Number": 0,
   "Snap": true,
   "Sticky": false,
   "Tooltip": true,

--- a/objects/EncounterSets.304ffc.ttslua
+++ b/objects/EncounterSets.304ffc.ttslua
@@ -1,0 +1,7 @@
+function onLoad()
+  self.addContextMenuItem("Download", download)
+end
+
+function download()
+  Global.call('placeholder_download', { url = self.getGMNotes(), replace = self.guid })
+end

--- a/objects/PlayerCards.2d30ee.json
+++ b/objects/PlayerCards.2d30ee.json
@@ -44,7 +44,7 @@
   "Transform": {
     "posX": 60,
     "posY": 1.481,
-    "posZ": 70,
+    "posZ": 71,
     "rotX": 0,
     "rotY": 270,
     "rotZ": 0,

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -22,35 +22,28 @@
     font="font_teutonic-arkham"/>
 </Defaults>
 
-<!-- Buttons in the bottom right of the screen -->
+<!-- Buttons at the bottom right (height: n * 35 + (n-1) * 2) -->
 <VerticalLayout visibility="Admin"
   color="#000000"
   outlineSize="1 1"
   outline="#303030"
   rectAlignment="LowerRight"
   width="35"
-  height="215"
+  height="146"
   offsetXY="-1 60"
-  spacing="1">
+  spacing="2">
   <Button icon="cthulhu"
     tooltip="Campaigns"
     onClick="onClick_toggleUi(Campaigns)"/>
   <Button icon="dark-cult"
     tooltip="Standalone Scenarios"
     onClick="onClick_toggleUi(Standalone Scenarios)"/>
-  <Button icon="yog-sothoth"
-    tooltip="Extras"
-    onClick="onClick_toggleUi(Extras)"/>
-  <Button icon="elder-sign"
-    tooltip="Investigators"
-    onClick="onClick_toggleUi(Investigators)"/>
   <Button icon="devourer"
     tooltip="Community Content"
     onClick="onClick_toggleUi(Community Content)"/>
   <Button icon="option-gear"
     tooltip="Options"
     onClick="onClick_toggleUi(Options)"/>
-  <!--<Button icon="download" tooltip="ArkhamDB Deck Importer" onClick="onClick_toggleUi(Deck Importer)"/> -->
 </VerticalLayout>
 
 <!-- Basic UI that will be replaced based on title -->


### PR DESCRIPTION
- Removes the two sections "Extras" and "Investigators" from the menu at the bottom right
![image](https://user-images.githubusercontent.com/97286811/211213560-4426cbb2-7f77-4e91-b5b7-a168c325e305.png)
- downloading for encounter sets added directly to the gun
![image](https://user-images.githubusercontent.com/97286811/211213495-921019d4-669e-49c5-a6f8-28711e4b8d5d.png)
- re-added the ammo tokens near the gun as separate objects
- some small posZ fixes on the left side
