### PR TITLE
Fix some investigator card data

### DIFF
--- a/src/playercards/PlayerCardPanelData.ttslua
+++ b/src/playercards/PlayerCardPanelData.ttslua
@@ -283,7 +283,7 @@ INVESTIGATORS["William Yorick"] = {
 INVESTIGATORS["Lola Hayes"] = {
 	cards = { "03006", "03006-t" },
 	minicards = { "03006-m" },
-	signatures = { "03018", "03019", "03019-t" },
+	signatures = { "03018", "03018", "03019", "03019", "03019-t", "03019-t" },
 	starterDeck = "2624990"
 }
 --Forgotten--
@@ -469,7 +469,7 @@ INVESTIGATORS["Monterey Jack"] = {
 INVESTIGATORS["Lily Chen"] = {
 	cards = { "08010" },
 	minicards = { "08010-m" },
-	signatures = { "08011", "08012", "08013", "08014", "08015" },
+	signatures = { "08011a", "08012a", "08013a", "08014a", "08015" },
 	starterDeck = "2634658"
 }
 INVESTIGATORS["Bob Jenkins"] = {


### PR DESCRIPTION
Fixes the IDs for Lily's Disciplines and adds the extra copies of Lola's signatures