### PR TITLE
Fix two timing-related bugs in MythosArea

### DIFF
--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -44,10 +44,6 @@ end
 -- Listens for cards entering the encounter deck or encounter discard, and resets the spawn state
 -- for the cards when they do.
 function onObjectEnterContainer(container, object)
-  Wait.frames(function() resetTokensIfInDeckZone(container, object) end, 1)
-end
-
-function resetTokensIfInDeckZone(container, object)
   local localPos = self.positionToLocal(container.getPosition())
   if inArea(localPos, ENCOUNTER_DECK_AREA) or inArea(localPos, ENCOUNTER_DISCARD_AREA) then
     tokenSpawnTracker.resetTokensSpawned(object.getGUID())
@@ -55,7 +51,7 @@ function resetTokensIfInDeckZone(container, object)
 end
 
 function fireScenarioChangedEvent()
-  Global.call('titleSplash', currentScenario)
+  Wait.frames(function() Global.call('titleSplash', currentScenario) end, 20)
   playArea.onScenarioChanged(currentScenario)
 end
 


### PR DESCRIPTION
- Using a frame delay in onObjectEnterContainer was causing errors.  Unclear why, but removing the delay fixes it
- Add a delay to the scenario splash screen, as load lag when placing large scenarios was causing the show to be janky