### PR TITLE
Playarea Image Swapper: Bugfix for custom data helpers

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -775,7 +775,8 @@ end
 -- called by custom data helpers to add player card data
 ---@param args table Contains only one entry, the GUID of the custom data helper
 function updatePlayerCards(args)
-  local customDataHelper = getObjectFromGUID(args[1])
+  -- keep this variable global so that the image swapper can access it
+  customDataHelper = getObjectFromGUID(args[1])
   local playerCardData = customDataHelper.getTable("PLAYER_CARD_DATA")
   tokenManager.addPlayerCardData(playerCardData)
 end


### PR DESCRIPTION
changes the scope of the variable so that it can be accessed from outside