### PR TITLE
Bottom menu: Increase offset from 60 to 80

### DIFF
--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -30,7 +30,7 @@
   rectAlignment="LowerRight"
   width="35"
   height="146"
-  offsetXY="-1 60"
+  offsetXY="-1 80"
   spacing="2">
   <Button icon="cthulhu"
     tooltip="Campaigns"

--- a/xml/OptionPanel.xml
+++ b/xml/OptionPanel.xml
@@ -72,7 +72,7 @@
   class="window"
   active="false"
   rectAlignment="LowerRight"
-  offsetXY="-50 60">
+  offsetXY="-50 80">
   <!-- Header: Options -->
   <Row preferredHeight="60">
     <Cell>


### PR DESCRIPTION
To stop overlapping with the note button on lower resolutions