### PR TITLE
Enhancements and tweaks for the scenario title splash

### DIFF
--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -198,5 +198,10 @@
     "Name": "Inv-Jacqueline",
     "Type": 0,
     "URL": "https://i.imgur.com/AFuB9II.png"
+  },
+  {
+    "Name": "TitleGradient",
+    "Type": 0,
+    "URL": "https://i.imgur.com/bY6nZbu.png"
   }
 ]

--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -202,6 +202,6 @@
   {
     "Name": "TitleGradient",
     "Type": 0,
-    "URL": "https://i.imgur.com/R1XY30L.png"
+    "URL": "https://i.imgur.com/Mdjm349.png"
   }
 ]

--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -202,6 +202,6 @@
   {
     "Name": "TitleGradient",
     "Type": 0,
-    "URL": "https://i.imgur.com/bY6nZbu.png"
+    "URL": "https://i.imgur.com/R1XY30L.png"
   }
 ]

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -875,7 +875,7 @@ function applyOptionPanelChange(id, state)
   -- option: Show CYOA campaign guides
   elseif id == "showCYOA" then
     optionPanel[id] = spawnOrRemoveHelper(state, "CYOA Campaign Guides", {65, 1.6, -11})
-    
+
   -- option: Show custom playmat images
   elseif id == "showCustomPlaymatImages" then
     optionPanel[id] = spawnOrRemoveHelper(state, "Custom Playmat Images", {67.5, 1.6, 37})
@@ -1014,14 +1014,17 @@ function titleSplash(scenarioName)
       Wait.stop(hideTitleSplashWaitFunctionId)
       hideTitleSplashWaitFunctionId = nil
       UI.setAttribute('title_splash', 'active', false)
+      -- UI.setAttribute('title_gradient', 'active', false)
     end
 
     -- display scenario name and set a 4 seconds (2 seconds animation and 2 seconds on screen)
     -- wait timer to hide the scenario name
-    UI.setValue('title_splash', scenarioName)
+    UI.setValue('title_splash_text', scenarioName)
     UI.show('title_splash')
+    -- UI.show('title_gradient')
     hideTitleSplashWaitFunctionId = Wait.time(function()
       UI.hide('title_splash')
+      -- UI.hide('title_gradient')
       hideTitleSplashWaitFunctionId = nil
     end, 4)
   end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1014,17 +1014,14 @@ function titleSplash(scenarioName)
       Wait.stop(hideTitleSplashWaitFunctionId)
       hideTitleSplashWaitFunctionId = nil
       UI.setAttribute('title_splash', 'active', false)
-      -- UI.setAttribute('title_gradient', 'active', false)
     end
 
     -- display scenario name and set a 4 seconds (2 seconds animation and 2 seconds on screen)
     -- wait timer to hide the scenario name
     UI.setValue('title_splash_text', scenarioName)
     UI.show('title_splash')
-    -- UI.show('title_gradient')
     hideTitleSplashWaitFunctionId = Wait.time(function()
       UI.hide('title_splash')
-      -- UI.hide('title_gradient')
       hideTitleSplashWaitFunctionId = nil
     end, 4)
   end

--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -11,12 +11,15 @@ local ENCOUNTER_DISCARD_AREA = {
 }
 
 local currentScenario
+-- we use this to turn off collision handling until onLoad() is complete
+local COLLISION_ENABLED = false
 
 function onLoad(saveState)
   if saveState ~= nil then
     local loadedState = JSON.decode(saveState) or { }
     currentScenario = loadedState.currentScenario
   end
+  COLLISION_ENABLED = true
 end
 
 function onSave()
@@ -27,6 +30,9 @@ end
 
 -- TTS event handler.  Handles scenario name event triggering and encounter card token resets.
 function onCollisionEnter(collisionInfo)
+  if not COLLISION_ENABLED then
+    return
+  end
   local object = collisionInfo.collision_object
   if object.getName() == "Scenario" then
     if currentScenario ~= object.getDescription() then

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -118,7 +118,7 @@
     font="font_teutonic-arkham"
     outline="black"
     outlineSize="3 -3"
-    horizontalOverflow="Wrap">
+    horizontalOverflow="Overflow">
   </Text>
 </Panel>
 <Include src="OptionPanel.xml"/>

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -98,16 +98,27 @@
 </VerticalLayout>
 
 <!-- Title Splash when starting a scenario -->
-<Text id="title_splash"
-  fontSize="150"
-  font="font_teutonic-arkham"
-  outline="black"
-  outlineSize="3 -3"
+<Panel
+  id="title_splash"
+  height="220"
   showAnimation="FadeIn"
   hideAnimation="FadeOut"
   active="false"
-  animationDuration="2"
-  horizontalOverflow="Wrap">
-</Text>
-
+  animationDuration="2">
+  <Image
+    id="title_gradient"
+    height="220"
+    image="TitleGradient" />
+  <Text id="title_splash_text"
+    width="95%"
+    height="180"
+    resizeTextForBestFit="true"
+    resizeTextMinSize="100"
+    resizeTextMaxSize="150"
+    font="font_teutonic-arkham"
+    outline="black"
+    outlineSize="3 -3"
+    horizontalOverflow="Wrap">
+  </Text>
+</Panel>
 <Include src="OptionPanel.xml"/>

--- a/xml/Global.xml
+++ b/xml/Global.xml
@@ -101,6 +101,7 @@
 <Panel
   id="title_splash"
   height="220"
+  position="0 250 0"
   showAnimation="FadeIn"
   hideAnimation="FadeOut"
   active="false"


### PR DESCRIPTION
- Add a background gradient
- Add a wrapping panel to hold both text and gradient
- Add font resizing in case of very long scenario names.  None currently overflow, but this should ensure they stay on one line if we get a longer one