### PR TITLE
Clean Up Helper: fixed typo for TokenSpawnTrackerApi

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -5,7 +5,7 @@ Cleans up the table for the next scenario in a campaign:
 - use the IGNORE_TAG to exclude objects from tidying (default: "CleanUpHelper_Ignore")
 --]]
 
-local tokenSpawnTracker = require("core/token/TokenSpawnTracker")
+local tokenSpawnTrackerApi = require("core/token/TokenSpawnTrackerApi")
 
 -- enable this for debugging
 local SHOW_RAYS = false
@@ -175,7 +175,7 @@ function cleanUp()
   removeBlessCurse()
   removeLines()
   discardHands()
-  TokenSpawnTracker.resetAll()
+  tokenSpawnTrackerApi.resetAll()
 
   printToAll("Tidying main play area...", "White")
   startLuaCoroutine(self, "tidyPlayareaCoroutine")


### PR DESCRIPTION
Now correctly references the Api instead of the actual object script