### PR TITLE
Check for card types when updating customizable data

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -458,16 +458,18 @@ end
 function syncCustomizableMetadata(card)
   local cardMetadata = JSON.decode(card.getGMNotes()) or { }
   if cardMetadata ~= nil and cardMetadata.customizations ~= nil then
-    for _, obj in ipairs(searchArea(PLAY_ZONE_POSITION, PLAY_ZONE_SCALE)) do
-      local obj = obj.hit_object
-      local notes = JSON.decode(obj.getGMNotes()) or { }
-      if notes.id == (cardMetadata.id .. "-c") then
-        for i, customization in ipairs(cardMetadata.customizations) do
-          if obj.getVar("markedBoxes")[i] == customization.xp
-              and customization.replaces ~= nil
-              and customization.replaces.uses ~= nil then
-            cardMetadata.uses = customization.replaces.uses
-            card.setGMNotes(JSON.encode(cardMetadata))
+    for _, collision in ipairs(searchArea(PLAY_ZONE_POSITION, PLAY_ZONE_SCALE)) do
+      local obj = collision.hit_object
+      if obj.name == "Card" or obj.name == "CardCustom" then
+        local notes = JSON.decode(obj.getGMNotes()) or { }
+        if notes.id == (cardMetadata.id .. "-c") then
+          for i, customization in ipairs(cardMetadata.customizations) do
+            if obj.getVar("markedBoxes")[i] == customization.xp
+                and customization.replaces ~= nil
+                and customization.replaces.uses ~= nil then
+              cardMetadata.uses = customization.replaces.uses
+              card.setGMNotes(JSON.encode(cardMetadata))
+            end
           end
         end
       end


### PR DESCRIPTION
Avoids errors from GMNotes on tokens which aren't JSON