### PR TITLE
Fixing doom rotation for bottom token bag

### DIFF
--- a/objects/Doomtokens.47ffc3/Custom_Tile.a3fb6c.json
+++ b/objects/Doomtokens.47ffc3/Custom_Tile.a3fb6c.json
@@ -46,7 +46,7 @@
     "posY": 1.864,
     "posZ": 1.057,
     "rotX": 0,
-    "rotY": 0,
+    "rotY": 180,
     "rotZ": 180,
     "scaleX": 0.25,
     "scaleY": 1,


### PR DESCRIPTION
Top: before

Bot: after

![image](https://user-images.githubusercontent.com/97286811/213692967-bf9fa06a-f058-49ea-8821-5714e4f5b5b4.png)