### PR TITLE
Custom Data Helper referring bugfix

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -160,7 +160,7 @@ end
 -- main function
 ---------------------------------------------------------
 
-function cleanUp()
+function cleanUp(_, color)
   printToAll("------------------------------", "White")
   printToAll("Clean up started!", "Orange")
   printToAll("Resetting counters...", "White")
@@ -172,7 +172,7 @@ function cleanUp()
   updateCounters(CLUE_CLICKER_GUIDS, 0, "Clue clickers")
   resetSkillTrackers()
   resetDoomCounter()
-  removeBlessCurse()
+  removeBlessCurse(color)
   removeLines()
   discardHands()
   tokenSpawnTrackerApi.resetAll()
@@ -232,8 +232,8 @@ end
 -- gets the GUID of a custom data helper (if present) and adds it to the ignore list
 function ignoreCustomDataHelper()
   local playArea = getObjectFromGUID("721ba2")
-  local guid = playArea.getVar("customDataHelper")
-  if guid then table.insert(IGNORE_GUIDS, guid) end
+  local customDataHelper = playArea.getVar("customDataHelper")
+  if customDataHelper then table.insert(IGNORE_GUIDS, customDataHelper.getGUID()) end
 end
 
 -- read values for trauma from campaign log if enabled
@@ -272,11 +272,11 @@ function getTrauma()
 end
 
 -- get rid of bless/curse tokens via bless/curse manager
-function removeBlessCurse()
+function removeBlessCurse(color)
   local BlessCurseManager = getObjectFromGUID("5933fb")
 
   if BlessCurseManager ~= nil then
-    BlessCurseManager.call("doRemove", "White")
+    BlessCurseManager.call("doRemove", color)
   else
     printToAll("Bless / Curse manager could not be found and thus bless/curse tokens were skipped.", "Yellow")
   end

--- a/src/core/PlayAreaSelector.ttslua
+++ b/src/core/PlayAreaSelector.ttslua
@@ -84,7 +84,10 @@ function updateSurface(newURL)
     playArea.setCustomObject(customInfo)
 
     -- get custom data helper and call the playarea with it after reloading
-    local guid = playArea.getVar("customDataHelper")
+    local customDataHelper = playArea.getVar("customDataHelper")
+    local guid
+
+    if customDataHelper then guid = customDataHelper.getGUID() end
     playArea = playArea.reload()
 
     if guid ~= nil then


### PR DESCRIPTION
- Fixes the reference to the custom data helper for the clean up helper and play area image swapper
- also sneakily includes a small bugfix for the clean up helper when using it while the "White" player is not ingame