### PR TITLE
Doom token on mythos area: rotation fix

### DIFF
--- a/objects/Doomtokens.b015d8/Custom_Tile.a3fb6c.json
+++ b/objects/Doomtokens.b015d8/Custom_Tile.a3fb6c.json
@@ -47,7 +47,7 @@
     "posY": 1.884,
     "posZ": 8.88,
     "rotX": 0,
-    "rotY": 0,
+    "rotY": 180,
     "rotZ": 180,
     "scaleX": 0.25,
     "scaleY": 1,


### PR DESCRIPTION
fixes the wrong rotation on these
![image](https://user-images.githubusercontent.com/97286811/215182884-16f809cc-e4e1-4e5a-9d21-9ad58ac2d129.png)