### PR TITLE
Connection Token: Adding memo field and name

### DIFF
--- a/objects/Connectionmarkers.170f10.json
+++ b/objects/Connectionmarkers.170f10.json
@@ -11,7 +11,7 @@
     "r": 1
   },
   "ContainedObjects_order": [
-    "Custom_Tile.7234af"
+    "Path.7234af"
   ],
   "ContainedObjects_path": "Connectionmarkers.170f10",
   "CustomMesh": {

--- a/objects/Connectionmarkers.170f10/Path.7234af.json
+++ b/objects/Connectionmarkers.170f10/Path.7234af.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "path",
+  "GMNotes": "",
   "GUID": "7234af",
   "Grid": true,
   "GridProjection": false,
@@ -36,8 +36,9 @@
   "LuaScript": "",
   "LuaScriptState": "",
   "MeasureMovement": false,
+  "Memo": "path",
   "Name": "Custom_Tile",
-  "Nickname": "",
+  "Nickname": "Path",
   "Snap": true,
   "States": {
     "2": {


### PR DESCRIPTION
This adds the name and memo field to bring the token bag in line with the spawnable connection tokens