### PR TITLE
Excludes "The Heart of Madness" from line drawing

### DIFF
--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -41,6 +41,7 @@ local SHIFT_EXCLUSION = {
 }
 local LOC_LINK_EXCLUDE_SCENARIOS = {
   ["The Witching Hour"] = true,
+  ["The Heart of Madness"] = true
 }
 
 local tokenManager = require("core/token/TokenManager")


### PR DESCRIPTION
This stops the lines drawn by the setup helper to be deleted