### PR TITLE
Underworld Market: stop including permanent cards

### DIFF
--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -269,7 +269,8 @@ function handleUnderworldMarket(cardList, playerColor)
       card.zone = "SetAside3"
     elseif (card.metadata.traits ~= nil and string.find(card.metadata.traits, "Illicit", 1, true)
         and card.metadata.bonded_to == nil
-        and not card.metadata.weakness) then
+        and not card.metadata.weakness
+        and not card.metadata.permanent) then
       table.insert(illicitList, i)
     end
   end

--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -267,10 +267,7 @@ function handleUnderworldMarket(cardList, playerColor)
       -- Underworld Market found
       hasMarket = true
       card.zone = "SetAside3"
-    elseif (card.metadata.traits ~= nil and string.find(card.metadata.traits, "Illicit", 1, true)
-        and card.metadata.bonded_to == nil
-        and not card.metadata.weakness
-        and not card.metadata.permanent) then
+    elseif card.metadata.traits ~= nil and string.find(card.metadata.traits, "Illicit", 1, true) and card.zone == "Deck" then
       table.insert(illicitList, i)
     end
   end


### PR DESCRIPTION
Bugfix to stop permanent cards from being included in the market deck (e.g. Underworld Support)