### PR TITLE
Deckimporter: Updated handling for parallel, revised and promo investigators

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -77,7 +77,7 @@ do
         return false, "Deck not found!"
       end
 
-      return true, JSON.decode(status.text)
+      return true, json
     end)
 
     deck:with(internal.onDeckResult, playerColor, loadNewest, loadInvestigators, callback)
@@ -139,8 +139,9 @@ do
     -- investigator may have bonded cards or taboo entries, and should be present
     local slots = deck.slots
     internal.maybeDrawRandomWeakness(slots, playerColor)
+    local loadAltInvestigator = "normal"
     if loadInvestigators then
-      internal.addInvestigatorCards(deck, slots, playerColor)
+      loadAltInvestigator = internal.addInvestigatorCards(deck, slots)
     end
     internal.maybeAddCustomizeUpgradeSheets(slots)
     internal.maybeAddSummonedServitor(slots)
@@ -149,13 +150,12 @@ do
     internal.checkTaboos(deck.taboo_id, slots, playerColor)
 
     -- get upgrades for customizable cards
-    local meta = deck.meta
     local customizations = {}
-    if meta then
-      customizations = JSON.decode(meta)
+    if deck.meta then
+      customizations = JSON.decode(deck.meta)
     end
 
-    callback(slots, deck.investigator_code, bondList, customizations, playerColor)
+    callback(slots, deck.investigator_code, bondList, customizations, playerColor, loadAltInvestigator)
   end
 
   -- Checks to see if the slot list includes the random weakness ID. If it does,
@@ -186,25 +186,54 @@ do
   ---@param deck Table The processed ArkhamDB deck response
   ---@param slots Table The slot list for cards in this deck.  Table key is the cardId, value is the
   ---    number of those cards which will be spawned
-  internal.addInvestigatorCards = function(deck, slots, playerColor)
+  ---@return string: Contains the name of the art that should be loaded ("normal", "promo" or "revised")
+  internal.addInvestigatorCards = function(deck, slots)
     local investigatorId = deck.investigator_code
     slots[investigatorId .. "-m"] = 1
     local deckMeta = JSON.decode(deck.meta)
-    local parallelFront = deckMeta ~= nil and deckMeta.alternate_front ~= nil and deckMeta.alternate_front ~= ""
-    local parallelBack = deckMeta ~= nil and deckMeta.alternate_back ~= nil and deckMeta.alternate_back ~= ""
-    if parallelFront and parallelBack then
-      investigatorId = investigatorId .. "-p"
-    elseif parallelFront then
-      local alternateNum = tonumber(deckMeta.alternate_front)
-      if alternateNum >= 01501 and alternateNum <= 01506 then
-        internal.maybePrint("Original investigator art loaded. Revised art added as states to the card.", playerColor)
-      else
-        investigatorId = investigatorId .. "-pf"
+    -- handling alternative investigator art and parallel investigators
+    local loadAltInvestigator = "normal"
+    if deckMeta ~= nil then
+      local altFrontId = tonumber(deckMeta.alternate_front) or 0
+      local altBackId  = tonumber(deckMeta.alternate_back) or 0
+      local altArt     = { front = "normal", back = "normal" }
+
+      -- translating front ID
+      if altFrontId > 90000 and altFrontId < 90006 then
+        altArt.front = "parallel"
+      elseif altFrontId > 01500 and altFrontId < 01506 then
+        altArt.front = "revised"
+      elseif altFrontId > 98000 then
+        altArt.front = "promo"
       end
-    elseif parallelBack then
-      investigatorId = investigatorId .. "-pb"
+
+      -- translating back ID
+      if altBackId > 90000 and altBackId < 90006 then
+        altArt.back = "parallel"
+      elseif altBackId > 01500 and altBackId < 01506 then
+        altArt.back = "revised"
+      elseif altBackId > 98000 then
+        altArt.back = "promo"
+      end
+
+      -- updating investigatorID based on alt investigator selection
+      -- precedence: parallel > promo > revised
+      if altArt.front == "parallel" then
+        if altArt.back == "parallel" then
+          investigatorId = investigatorId .. "-p"
+        else
+          investigatorId = investigatorId .. "-pf"
+        end
+      elseif altArt.back == "parallel" then
+        investigatorId = investigatorId .. "-pb"
+      elseif altArt.front == "promo" or altArt.back == "promo" then
+        loadAltInvestigator = "promo"
+      elseif altArt.front == "revised" or altArt.back == "revised" then
+        loadAltInvestigator = "revised"
+      end
     end
     slots[investigatorId] = 1
+    return loadAltInvestigator
   end
 
   -- Process the card list looking for the customizable cards, and add their upgrade sheets if needed

--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -140,7 +140,7 @@ do
     local slots = deck.slots
     internal.maybeDrawRandomWeakness(slots, playerColor)
     if loadInvestigators then
-      internal.addInvestigatorCards(deck, slots)
+      internal.addInvestigatorCards(deck, slots, playerColor)
     end
     internal.maybeAddCustomizeUpgradeSheets(slots)
     internal.maybeAddSummonedServitor(slots)
@@ -186,7 +186,7 @@ do
   ---@param deck Table The processed ArkhamDB deck response
   ---@param slots Table The slot list for cards in this deck.  Table key is the cardId, value is the
   ---    number of those cards which will be spawned
-  internal.addInvestigatorCards = function(deck, slots)
+  internal.addInvestigatorCards = function(deck, slots, playerColor)
     local investigatorId = deck.investigator_code
     slots[investigatorId .. "-m"] = 1
     local deckMeta = JSON.decode(deck.meta)
@@ -197,7 +197,7 @@ do
     elseif parallelFront then
       local alternateNum = tonumber(deckMeta.alternate_front)
       if alternateNum >= 01501 and alternateNum <= 01506 then
-        investigatorId = investigatorId .. "-r"
+        internal.maybePrint("Original investigator art loaded. Revised art added as states to the card.", playerColor)
       else
         investigatorId = investigatorId .. "-pf"
       end

--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -99,7 +99,8 @@ end
 --     from a parent bonded card.
 ---@param customizations String ArkhamDB data for customizations on customizable cards
 ---@param playerColor String Color name of the player mat to place this deck on (e.g. "Red")
-function loadCards(slots, investigatorId, bondedList, customizations, playerColor)
+---@param loadAltInvestigator String Contains the name of alternative art for the investigator ("normal", "revised" or "promo")
+function loadCards(slots, investigatorId, bondedList, customizations, playerColor, loadAltInvestigator)
   function coinside()
     local allCardsBag = getObjectFromGUID(ALL_CARDS_GUID)
     local yPos = {}
@@ -143,6 +144,8 @@ function loadCards(slots, investigatorId, bondedList, customizations, playerColo
         callback = function(deck) deck.spread(spreadDistance) end
       elseif zone == "Deck" then
         callback = function(deck) deckSpawned(deck, playerColor) end
+      elseif zone == "Investigator" or zone == "Minicard" then
+        callback = function(card) loadAltArt(card, loadAltInvestigator) end
       end
       Spawner.spawnCards(
           zoneCards,
@@ -405,6 +408,51 @@ function handleCustomizableUpgrades(cardList, customizations)
       end
     end
   end
+end
+
+-- Callback function for investigator cards and minicards to set the correct state for alt art
+---@param card Object Card which needs to be set the state for
+---@param loadAltInvestigator String Contains the name of alternative art for the investigator ("normal", "revised" or "promo")
+function loadAltArt(card, loadAltInvestigator)
+  if loadAltInvestigator == "normal" then return end
+
+  -- lookup correct stateId for investigator and alt art state
+  local baseId = string.gsub(JSON.decode(card.getGMNotes()).id, "-m", "")
+
+  local stateIdTable = {}
+  -- Roland Banks
+  stateIdTable["01001"] = {}
+  stateIdTable["01001"]["revised"] = 2
+  stateIdTable["01001"]["promo"] = 3
+  -- Daisy Walker
+  stateIdTable["01002"] = {}
+  stateIdTable["01002"]["revised"] = 2
+  -- "Skids" O'Toole
+  stateIdTable["01003"] = {}
+  stateIdTable["01003"]["revised"] = 2
+  -- Agnes Baker
+  stateIdTable["01004"] = {}
+  stateIdTable["01004"]["revised"] = 2
+  -- Wendy Adams
+  stateIdTable["01005"] = {}
+  stateIdTable["01005"]["revised"] = 2
+  -- Jenny Barnes
+  stateIdTable["02003"] = {}
+  stateIdTable["02003"]["promo"] = 2
+  -- Carolyn Fern
+  stateIdTable["05001"] = {}
+  stateIdTable["05001"]["promo"] = 2
+  -- Dexter Drake
+  stateIdTable["07004"] = {}
+  stateIdTable["07004"]["promo"] = 2
+  -- Silas Marsh
+  stateIdTable["07005"] = {}
+  stateIdTable["07005"]["promo"] = 2
+  -- Norman Withers
+  stateIdTable["08004"] = {}
+  stateIdTable["08004"]["promo"] = 2
+
+  card.setState(stateIdTable[baseId][loadAltInvestigator])
 end
 
 function log(message)


### PR DESCRIPTION
Since the revised and promo art for investigators are no longer added as separate cards (but states instead) this updates the deckimporter to automatically load the correct state for these cards.