### PR TITLE
Handle duplicate connections

### DIFF
--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -286,7 +286,8 @@ function buildConnection(cardId, iconCardList)
         for _, connectedGuid in ipairs(iconCardList[icon]) do
           -- If the reciprocal exists, convert it to BiDi, otherwise add as a one-way
           if locationConnections[connectedGuid] ~= nil
-              and locationConnections[connectedGuid][card.getGUID()] == ONE_WAY then
+          and (locationConnections[connectedGuid][card.getGUID()] == ONE_WAY
+              or locationConnections[connectedGuid][card.getGUID()] == BIDIRECTIONAL) then
             locationConnections[connectedGuid][card.getGUID()] = BIDIRECTIONAL
             locationConnections[card.getGUID()][connectedGuid] = nil
           else


### PR DESCRIPTION
Some icon/ability combinations on locations results in duplicate connections.  The connection logic was parsing this as both a bidirectional and one-way connection, resulting in a one-way being drawn when it shouldn't be.

This adds a simple check to recommit an existing bidirectional connection, rather than drawing a new one-way for it.