### PR TITLE
Bless/Curse Manager: image change (added transparent border)

### DIFF
--- a/objects/BlessCurseManager.5933fb.json
+++ b/objects/BlessCurseManager.5933fb.json
@@ -19,7 +19,7 @@
     },
     "ImageScalar": 1,
     "ImageSecondaryURL": "",
-    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/1910115722577754046/64AF9853E51B79561BEAA3BEF13BBC694BBF9A34/",
+    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2018214163835858903/EECF1C00C9A0C837DD40D7B5A3456B88DF0CEC08/",
     "WidthScale": 0
   },
   "Description": "Left-Click: Add token\nRight-Click: Remove token\n\nContextmenu allows resetting the current state or removing all bless/curse tokens from play.\n\nSee Notebook for detailed instructions.",


### PR DESCRIPTION
Since custom tokens without transparent borders can under rare circumstances fail to generate a mesh, this adds a border to the bless/curse manager.