### PR TITLE
Replenishing cards: Bugfix to allow overcharging

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -500,9 +500,18 @@ function replenishTokens(card, count, replenish)
     end
   end
 
+  -- this is the theoretical new amount of uses (to be checked below)
   local newCount = foundTokens + replenish
-  if newCount > count then newCount = count end
+  
+  -- if there are already more uses than the replenish amount, keep them
+  if foundTokens > count then
+    newCount = foundTokens
+  -- only replenish up until the replenish amount
+  elseif newCount > count then
+    newCount = count
+  end
 
+  -- update the clickable counter or spawn a group of tokens
   if clickableResourceCounter then
     clickableResourceCounter.call("updateVal", newCount)
   else


### PR DESCRIPTION
Previously, the script would remove any additional uses from cards with "Replenish". This si not correct, since you can have more if you add them with other effects. This PR fixes this removing to allow "overcharging".