### PR TITLE
Add alt view angle for sideways decks

### DIFF
--- a/src/playercards/PlayerCardSpawner.ttslua
+++ b/src/playercards/PlayerCardSpawner.ttslua
@@ -37,7 +37,7 @@ Spawner.spawnCards = function(cardList, pos, rot, sort, callback)
   -- Spawn each of the three types individually.  Each Y position shift accounts for the thickness
   -- of the spawned deck
   local position = { x = pos.x, y = pos.y, z = pos.z }
-  Spawner.spawn(investigatorCards, position, { rot.x, rot.y - 90, rot.z}, callback)
+  Spawner.spawn(investigatorCards, position, { rot.x, rot.y - 90, rot.z }, callback, true)
 
   position.y = position.y + (#investigatorCards + #standardCards) * 0.07
   Spawner.spawn(standardCards, position, rot, callback)
@@ -82,7 +82,7 @@ end
 -- @param pos Position table where the cards should be spawned (global)
 -- @param rot Rotation table for the orientation of the spawned cards (global)
 -- @param callback Function, callback to be called after the card/deck spawns.
-Spawner.spawn = function(cardList, pos, rot, callback)
+Spawner.spawn = function(cardList, pos, rot, callback, sidewaysDeck)
   if (#cardList == 0) then
     return
   end
@@ -105,6 +105,10 @@ Spawner.spawn = function(cardList, pos, rot, callback)
     scaleY = 1,
     scaleZ = cardList[1].data.Transform.scaleZ,
   }
+  -- set the alt view angle for sideway decks
+  if sidewaysDeck then
+    deck.AltLookAngle = { x = 0, y = 180, z = 90 }
+  end
   for _, spawnCard in ipairs(cardList) do
     Spawner.addCardToDeck(deck, spawnCard.data)
   end

--- a/src/playercards/PlayerCardSpawner.ttslua
+++ b/src/playercards/PlayerCardSpawner.ttslua
@@ -108,9 +108,8 @@ Spawner.spawn = function(cardList, pos, rot, callback)
   local sidewaysDeck = true
   for _, spawnCard in ipairs(cardList) do
     Spawner.addCardToDeck(deck, spawnCard.data)
-    if not spawnCard.data.SidewaysCard then
-      sidewaysDeck = false
-    end
+    -- set sidewaysDeck to false if any card is not a sideways card
+    sidewaysDeck = (sidewaysDeck and spawnCard.data.SidewaysCard)
   end
   -- set the alt view angle for sideway decks
   if sidewaysDeck then

--- a/src/playercards/PlayerCardSpawner.ttslua
+++ b/src/playercards/PlayerCardSpawner.ttslua
@@ -37,7 +37,7 @@ Spawner.spawnCards = function(cardList, pos, rot, sort, callback)
   -- Spawn each of the three types individually.  Each Y position shift accounts for the thickness
   -- of the spawned deck
   local position = { x = pos.x, y = pos.y, z = pos.z }
-  Spawner.spawn(investigatorCards, position, { rot.x, rot.y - 90, rot.z }, callback, true)
+  Spawner.spawn(investigatorCards, position, { rot.x, rot.y - 90, rot.z }, callback)
 
   position.y = position.y + (#investigatorCards + #standardCards) * 0.07
   Spawner.spawn(standardCards, position, rot, callback)
@@ -78,11 +78,11 @@ end
 
 -- Spawn a specific list of cards.  This method is for internal use and should not be called
 -- directly, use spawnCards instead.
--- @param cardList: A list of Player Card data structures (data/metadata)
--- @param pos Position table where the cards should be spawned (global)
--- @param rot Rotation table for the orientation of the spawned cards (global)
--- @param callback Function, callback to be called after the card/deck spawns.
-Spawner.spawn = function(cardList, pos, rot, callback, sidewaysDeck)
+---@param cardList: A list of Player Card data structures (data/metadata)
+---@param pos table Position where the cards should be spawned (global)
+---@param rot table Rotation for the orientation of the spawned cards (global)
+---@param callback function callback to be called after the card/deck spawns.
+Spawner.spawn = function(cardList, pos, rot, callback)
   if (#cardList == 0) then
     return
   end
@@ -105,12 +105,16 @@ Spawner.spawn = function(cardList, pos, rot, callback, sidewaysDeck)
     scaleY = 1,
     scaleZ = cardList[1].data.Transform.scaleZ,
   }
+  local sidewaysDeck = true
+  for _, spawnCard in ipairs(cardList) do
+    Spawner.addCardToDeck(deck, spawnCard.data)
+    if not spawnCard.data.SidewaysCard then
+      sidewaysDeck = false
+    end
+  end
   -- set the alt view angle for sideway decks
   if sidewaysDeck then
     deck.AltLookAngle = { x = 0, y = 180, z = 90 }
-  end
-  for _, spawnCard in ipairs(cardList) do
-    Spawner.addCardToDeck(deck, spawnCard.data)
   end
   spawnObjectData({
     data = deck,


### PR DESCRIPTION
This sets the alt view angle for sideways decks (namely the stacks of investigators spawned by the playercard panel) so that the preview is correctly rotated.

Preview of difference:
https://user-images.githubusercontent.com/97286811/227521058-95ca67a8-78c0-4732-af62-0f801cd668c9.mp4