### PR TITLE
Playermat: moving threat area down

### DIFF
--- a/objects/Playermat1White.8b081b.json
+++ b/objects/Playermat1White.8b081b.json
@@ -231,9 +231,9 @@
     },
     {
       "Position": {
-        "x": 1.38,
+        "x": 1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -243,9 +243,9 @@
     },
     {
       "Position": {
-        "x": 0.92,
+        "x": 0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -255,9 +255,9 @@
     },
     {
       "Position": {
-        "x": 0.46,
+        "x": 0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -269,7 +269,7 @@
       "Position": {
         "x": 0,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -279,9 +279,9 @@
     },
     {
       "Position": {
-        "x": -0.46,
+        "x": -0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -291,9 +291,9 @@
     },
     {
       "Position": {
-        "x": -0.92,
+        "x": -0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -303,9 +303,9 @@
     },
     {
       "Position": {
-        "x": -1.38,
+        "x": -1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -329,7 +329,7 @@
     },
     "ImageScalar": 1,
     "ImageSecondaryURL": "",
-    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/1859438430150777205/4ED2E0BC2A2C4728DA5E155C06AF1BA1FCB00D3B/",
+    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2037357630681963618/E7271737B19CE0BFAAA382BEEEF497FE3E06ECC1/",
     "WidthScale": 0
   },
   "Description": "",

--- a/objects/Playermat2Orange.bd0ff4.json
+++ b/objects/Playermat2Orange.bd0ff4.json
@@ -231,9 +231,9 @@
     },
     {
       "Position": {
-        "x": 1.38,
+        "x": 1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -243,9 +243,9 @@
     },
     {
       "Position": {
-        "x": 0.92,
+        "x": 0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -255,9 +255,9 @@
     },
     {
       "Position": {
-        "x": 0.46,
+        "x": 0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -269,7 +269,7 @@
       "Position": {
         "x": 0,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -279,9 +279,9 @@
     },
     {
       "Position": {
-        "x": -0.46,
+        "x": -0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -291,9 +291,9 @@
     },
     {
       "Position": {
-        "x": -0.92,
+        "x": -0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -303,9 +303,9 @@
     },
     {
       "Position": {
-        "x": -1.38,
+        "x": -1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -329,7 +329,7 @@
     },
     "ImageScalar": 1,
     "ImageSecondaryURL": "",
-    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/1859438430150777205/4ED2E0BC2A2C4728DA5E155C06AF1BA1FCB00D3B/",
+    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2037357630681963618/E7271737B19CE0BFAAA382BEEEF497FE3E06ECC1/",
     "WidthScale": 0
   },
   "Description": "",

--- a/objects/Playermat3Green.383d8b.json
+++ b/objects/Playermat3Green.383d8b.json
@@ -231,9 +231,9 @@
     },
     {
       "Position": {
-        "x": 1.38,
+        "x": 1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -243,9 +243,9 @@
     },
     {
       "Position": {
-        "x": 0.92,
+        "x": 0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -255,9 +255,9 @@
     },
     {
       "Position": {
-        "x": 0.46,
+        "x": 0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -269,7 +269,7 @@
       "Position": {
         "x": 0,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -279,9 +279,9 @@
     },
     {
       "Position": {
-        "x": -0.46,
+        "x": -0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -291,9 +291,9 @@
     },
     {
       "Position": {
-        "x": -0.92,
+        "x": -0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -303,9 +303,9 @@
     },
     {
       "Position": {
-        "x": -1.38,
+        "x": -1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -329,7 +329,7 @@
     },
     "ImageScalar": 1,
     "ImageSecondaryURL": "",
-    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/1859438430150777205/4ED2E0BC2A2C4728DA5E155C06AF1BA1FCB00D3B/",
+    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2037357630681963618/E7271737B19CE0BFAAA382BEEEF497FE3E06ECC1/",
     "WidthScale": 0
   },
   "Description": "",

--- a/objects/Playermat4Red.0840d5.json
+++ b/objects/Playermat4Red.0840d5.json
@@ -231,9 +231,9 @@
     },
     {
       "Position": {
-        "x": 1.38,
+        "x": 1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -243,9 +243,9 @@
     },
     {
       "Position": {
-        "x": 0.92,
+        "x": 0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -255,9 +255,9 @@
     },
     {
       "Position": {
-        "x": 0.46,
+        "x": 0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -269,7 +269,7 @@
       "Position": {
         "x": 0,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -279,9 +279,9 @@
     },
     {
       "Position": {
-        "x": -0.46,
+        "x": -0.455,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -291,9 +291,9 @@
     },
     {
       "Position": {
-        "x": -0.92,
+        "x": -0.91,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -303,9 +303,9 @@
     },
     {
       "Position": {
-        "x": -1.38,
+        "x": -1.365,
         "y": 0.1,
-        "z": -0.645
+        "z": -0.625
       },
       "Rotation": {
         "x": 0,
@@ -329,7 +329,7 @@
     },
     "ImageScalar": 1,
     "ImageSecondaryURL": "",
-    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/1859438430150777205/4ED2E0BC2A2C4728DA5E155C06AF1BA1FCB00D3B/",
+    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2037357630681963618/E7271737B19CE0BFAAA382BEEEF497FE3E06ECC1/",
     "WidthScale": 0
   },
   "Description": "",

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -8,17 +8,13 @@ local DEBUG = false
 local collisionEnabled = false
 
 -- position offsets relative to mat [x, y, z]
-local DRAWN_ENCOUNTER_CARD_OFFSET = {1.365, 0.5, -0.635}
-local DRAWN_CHAOS_TOKEN_OFFSET = {-1.55, 0.5, -0.58}
-local DISCARD_BUTTON_OFFSETS = {
-  {-1.38, 0.1, -0.94},
-  {-0.92, 0.1, -0.94},
-  {-0.46, 0.1, -0.94},
-  {0.00, 0.1, -0.94},
-  {0.46, 0.1, -0.94},
-  {0.92, 0.1, -0.94}
-}
+local DRAWN_ENCOUNTER_CARD_OFFSET = {1.365, 0.5, -0.625}
+local DRAWN_CHAOS_TOKEN_OFFSET = {-1.55, 0.25, -0.58}
 
+-- x-Values for discard buttons
+local DISCARD_BUTTON_OFFSETS = {-1.365, -0.91, -0.455, 0, 0.455, 0.91}
+
+-- defined areas for the function "inArea()""
 local MAIN_PLAY_AREA = {
   upperLeft = {
     x = 1.98,
@@ -193,7 +189,8 @@ function makeDiscardHandlerFor(searchPosition, discardPosition)
 end
 
 -- build a discard button to discard from searchPosition to discardPosition (number must be unique)
-function makeDiscardButton(position, discardPosition, number)
+function makeDiscardButton(xValue, discardPosition, number)
+  local position = { xValue, 0.1, -0.94}
   local searchPosition = {-position[1], position[2], position[3] + 0.32}
   local handler = makeDiscardHandlerFor(searchPosition, discardPosition)
   local handlerName = 'handler' .. number


### PR DESCRIPTION
This moves the threat area slightly down to make the discard buttons clickable when zoomed out. The horizontal offset of the snap points is also slightly adjusted to center the outer cards better.

Old:
![image](https://user-images.githubusercontent.com/97286811/231398895-401dd865-43d9-4720-9295-08805cde5b61.png)

New:
![image](https://user-images.githubusercontent.com/97286811/231398594-34a5f9c5-63a4-4ca1-9bc0-46c67366dea2.png)