### PR TITLE
Playermat: additional condition for discarding tokens

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -696,6 +696,7 @@ function removeTokensFromObject(object)
         obj ~= self and
         obj.type ~= "Deck" and
         obj.type ~= "Card" and
+        obj.memo ~= nil and
         obj.getLock() == false and
         obj.getDescription() ~= "Action Token" and
         not tokenChecker.isChaosToken(obj) then


### PR DESCRIPTION
This stops the auto-discard from removing tokens like the keys in TIC and all other custom tokens.