### PR TITLE
Navigation Overlay: updated spawn position

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -888,7 +888,7 @@ function applyOptionPanelChange(id, state)
 
   -- option: Show navigation overlay
   elseif id == "showNavigationOverlay" then
-    optionPanel[id] = spawnOrRemoveHelper(state, "jaqenZann's Navigation Overlay", {-11.7, 1.6, -15})
+    optionPanel[id] = spawnOrRemoveHelper(state, "jaqenZann's Navigation Overlay", {-68, 1.4, -70})
 
   -- option: Show CYOA campaign guides
   elseif id == "showCYOA" then


### PR DESCRIPTION
Moved the Navigation Overlay into the bottom right corner to not overlay with the phasetracker or campaign specifics (e.g. flood tokens).

New position:
![image](https://user-images.githubusercontent.com/97286811/233487485-24444f7e-527a-427c-b30d-e1d04113a255.png)