### PR TITLE
Bless/Curse Manager: fixed function name

### DIFF
--- a/src/chaosbag/BlessCurseManager.ttslua
+++ b/src/chaosbag/BlessCurseManager.ttslua
@@ -106,7 +106,7 @@ function broadcastCount(token)
     broadcastToAll(token .. " Tokens " .. count, "White")
 end
 
-function printStatus(color)
+function broadcastStatus(color)
     broadcastToColor("Curse Tokens " .. formatTokenCount("Curse"), color, "White")
     broadcastToColor("Bless Tokens " .. formatTokenCount("Bless"), color, "White")
 end


### PR DESCRIPTION
The changed function is referenced via Bless/Curse Manager API and has the wrong name.