### PR TITLE
Bless/Curse: fixed multiseal and save/load

### DIFF
--- a/src/chaosbag/BlessCurseManager.ttslua
+++ b/src/chaosbag/BlessCurseManager.ttslua
@@ -85,7 +85,7 @@ function initializeState()
     -- find tokens in the play area
     for _, obj in ipairs(getObjects()) do
         local pos = obj.getPosition()
-        if pos.x > -50 and pos.x < 50 and pos.z > 8 and pos.z < 50 then
+        if pos.x > -65 and pos.x < 10 and pos.z > -35 and pos.z < 35 then
             if obj.getName() == "Bless" then
                 table.insert(tokensTaken.Bless, obj.getGUID())
                 numInPlay.Bless = numInPlay.Bless + 1

--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -62,7 +62,6 @@ Thus it should be implemented like this:
   > SHOW_MULTI_SEAL = 2
   > require...
 ----------------------------------------------------------]]
-----------------------------------------------------------]]
 
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
 local tokenArrangerApi = require("accessories/TokenArrangerApi")

--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -48,7 +48,7 @@ Thus it should be implemented like this:
   >   ["+1"] = true,
   >   ["Elder Sign"] = true
   > }
-  > require ("playercards/CardsThatSealTokens") -- includes a space after "require" to not executing bundling
+  > require...
 ----------------------------------------------------------
 Example 2: Holy Spear
 This card features the following abilities (just listing the relevant parts):
@@ -60,7 +60,8 @@ Thus it should be implemented like this:
   > }
   > SHOW_SINGLE_RELEASE = true
   > SHOW_MULTI_SEAL = 2
-  > require ("playercards/CardsThatSealTokens") -- includes a space after "require" to not executing bundling
+  > require...
+----------------------------------------------------------]]
 ----------------------------------------------------------]]
 
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
@@ -167,16 +168,12 @@ function sealToken(name, playerColor)
 end
 
 -- release the last sealed token
-function releaseOneToken(playerColor, doPrint)
+function releaseOneToken(playerColor)
   if not Global.call("canTouchChaosTokens") then return end
   if #sealedTokens == 0 then
-    if doPrint or doPrint == nil then
-      printToColor("No sealed token(s) found", playerColor)
-    end
+    printToColor("No sealed token(s) found", playerColor)
   else
-    if doPrint or doPrint == nil then
-      printToColor("Releasing token", playerColor)
-    end
+    printToColor("Releasing token", playerColor)
     putTokenAway(table.remove(sealedTokens))
   end
 end
@@ -185,9 +182,9 @@ end
 function releaseMultipleTokens(playerColor)
   if SHOW_MULTI_RELEASE <= #sealedTokens then
     for i = 1, SHOW_MULTI_RELEASE do
-      releaseOneToken(playerColor, false)
+      putTokenAway(table.remove(sealedTokens))
     end
-    printToColor("Releasing tokens", playerColor)
+    printToColor("Releasing " .. SHOW_MULTI_RELEASE .. " tokens", playerColor)
   else
     printToColor("Not enough tokens sealed.", playerColor)
   end

--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -14,7 +14,7 @@ SHOW_SINGLE_RELEASE --@type: boolean
 
 SHOW_MULTI_RELEASE  --@type: number (amount of tokens to release at once)
   - enables an entry in the context menu
-  - this enty allows releasing of multiple tokens at once
+  - this entry allows releasing of multiple tokens at once
   - example usage: "Nephthys" (to release 3 bless tokens at once)
 
 SHOW_MULTI_SEAL     --@type: number (amount of tokens to seal at once)
@@ -44,25 +44,23 @@ Example 1: Crystalline Elder Sign
 This card can only seal the "+1" or "Elder Sign" token,
 it does not need specific options for multi-sealing or releasing.
 Thus it should be implemented like this:
-
-> VALID_TOKENS = {
->   ["+1"] = true,
->   ["Elder Sign"] = true
-> }
-> require ("playercards/CardsThatSealTokens") -- includes a space after "require" to not executing bundling
+  > VALID_TOKENS = {
+  >   ["+1"] = true,
+  >   ["Elder Sign"] = true
+  > }
+  > require ("playercards/CardsThatSealTokens") -- includes a space after "require" to not executing bundling
 ----------------------------------------------------------
 Example 2: Holy Spear
 This card features the following abilities (just listing the relevant parts):
 - releasing a single bless token
 - sealing two bless tokens
 Thus it should be implemented like this:
-
-> VALID_TOKENS = {
->   ["Bless"] = true
-> }
-> SHOW_SINGLE_RELEASE = true
-> SHOW_MULTI_SEAL = 2
-> require ("playercards/CardsThatSealTokens") -- includes a space after "require" to not executing bundling
+  > VALID_TOKENS = {
+  >   ["Bless"] = true
+  > }
+  > SHOW_SINGLE_RELEASE = true
+  > SHOW_MULTI_SEAL = 2
+  > require ("playercards/CardsThatSealTokens") -- includes a space after "require" to not executing bundling
 ----------------------------------------------------------]]
 
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
@@ -169,24 +167,29 @@ function sealToken(name, playerColor)
 end
 
 -- release the last sealed token
-function releaseOneToken(playerColor)
+function releaseOneToken(playerColor, doPrint)
   if not Global.call("canTouchChaosTokens") then return end
   if #sealedTokens == 0 then
-    printToColor("No sealed token(s) found", playerColor)
+    if doPrint or doPrint == nil then
+      printToColor("No sealed token(s) found", playerColor)
+    end
   else
-    printToColor("Releasing token", playerColor)
+    if doPrint or doPrint == nil then
+      printToColor("Releasing token", playerColor)
+    end
     putTokenAway(table.remove(sealedTokens))
   end
 end
 
 -- release multiple tokens at once
 function releaseMultipleTokens(playerColor)
-  if SHOW_MULTI_RELEASE >= #sealedTokens then
+  if SHOW_MULTI_RELEASE <= #sealedTokens then
     for i = 1, SHOW_MULTI_RELEASE do
-      releaseOneToken(playerColor)
+      releaseOneToken(playerColor, false)
     end
+    printToColor("Releasing tokens", playerColor)
   else
-    printToColor("Not enough " .. name .. " tokens sealed.", playerColor)
+    printToColor("Not enough tokens sealed.", playerColor)
   end
 end
 


### PR DESCRIPTION
- fixed a bug with multisealing (undefined `name` variable)
- fixed logic to only allow multirelease if enough tokens are sealed
- reduced messages for multisealing to one instead of one per seal (e.g. from 3x the same print only 1 for Nephthys)
- fixed the bless/curse manager token detection area (didn't catch bottom playmats, now covers all mats)
- fixed formatting on code examples in documentation