### PR TITLE
Token Manager: out-commented log statements

### DIFF
--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -348,7 +348,8 @@ do
       for i, useInfo in ipairs(uses) do
         type = useInfo.type
         token = useInfo.token
-        tokenCount = (useInfo.count or 0) + (useInfo.countPerInvestigator or 0) * playArea.getInvestigatorCount()
+        tokenCount = (useInfo.count or 0)
+            + (useInfo.countPerInvestigator or 0) * playArea.getInvestigatorCount()
         if extraUses ~= nil and extraUses[type] ~= nil then
           tokenCount = tokenCount + extraUses[type]
         end

--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -342,18 +342,17 @@ do
       if extraUses ~= nil and extraUses[type] ~= nil then
         tokenCount = tokenCount + extraUses[type]
       end
-      log("Spawning single use tokens for "..card.getName()..'['..card.getDescription()..']: '..tokenCount.."x "..token)
+      --log("Spawning single use tokens for "..card.getName()..'['..card.getDescription()..']: '..tokenCount.."x "..token)
       TokenManager.spawnTokenGroup(card, token, tokenCount)
     else
       for i, useInfo in ipairs(uses) do
         type = useInfo.type
         token = useInfo.token
-        tokenCount = (useInfo.count or 0)
-            + (useInfo.countPerInvestigator or 0) * playArea.getInvestigatorCount()
+        tokenCount = (useInfo.count or 0) + (useInfo.countPerInvestigator or 0) * playArea.getInvestigatorCount()
         if extraUses ~= nil and extraUses[type] ~= nil then
           tokenCount = tokenCount + extraUses[type]
         end
-        log("Spawning use array tokens for "..card.getName()..'['..card.getDescription()..']: '..tokenCount.."x "..token)
+        --log("Spawning use array tokens for "..card.getName()..'['..card.getDescription()..']: '..tokenCount.."x "..token)
         -- Shift each spawned group after the first down so they don't pile on each other
         TokenManager.spawnTokenGroup(card, token, tokenCount, (i - 1) * 0.8)
       end
@@ -383,7 +382,7 @@ do
   internal.spawnPlayerCardTokensFromDataHelper = function(card, playerData)
     token = playerData.tokenType
     tokenCount = playerData.tokenCount
-    log("Spawning data helper tokens for "..card.getName()..'['..card.getDescription()..']: '..tokenCount.."x "..token)
+    --log("Spawning data helper tokens for "..card.getName()..'['..card.getDescription()..']: '..tokenCount.."x "..token)
     TokenManager.spawnTokenGroup(card, token, tokenCount)
     tokenSpawnTracker.markTokensSpawned(card.getGUID())
   end
@@ -416,7 +415,7 @@ do
       return 0
     end
 
-    log(card.getName() .. ' : ' .. locationData.type .. ' : ' .. locationData.value .. ' : ' .. locationData.clueSide)
+    --log(card.getName() .. ' : ' .. locationData.type .. ' : ' .. locationData.value .. ' : ' .. locationData.clueSide)
     if ((card.is_face_down and locationData.clueSide == 'back')
         or (not card.is_face_down and locationData.clueSide == 'front')) then
       if locationData.type == 'fixed' then


### PR DESCRIPTION
Right now playing an asset with uses pulls up the chat (if auto-hide is enabled) because there are log statements to the system console. This was not the case pre 3.1.0 and thus this PR disables the logs from the Token Manager.