### PR TITLE
"Auto-fail" exclusion for "Unrelenting (1)"

### DIFF
--- a/src/playercards/cards/Unrelenting1.ttslua
+++ b/src/playercards/cards/Unrelenting1.ttslua
@@ -1,5 +1,7 @@
 VALID_TOKENS = {}
-INVALID_TOKENS = {}
+INVALID_TOKENS = {
+  ["Auto-fail"] = true
+}
 
 UPDATE_ON_HOVER = true
 


### PR DESCRIPTION
This adds the missing exclusion for the "Auto-fail" to "Unrelenting", so that it doesn't show up as option in the context menu for sealing.