### PR TITLE
Token-Arranger: removes faulty onExit handling from MythosArea

### DIFF
--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -12,9 +12,7 @@ local ENCOUNTER_DISCARD_AREA = {
   lowerRight = { x = 1.58, z = 0.38 },
 }
 
-local currentScenario
-local useFrontData
-local tokenData
+local currentScenario, useFrontData, tokenData
 
 local TRASHCAN
 local TRASHCAN_GUID = "70b9f6"
@@ -80,19 +78,6 @@ function onCollisionEnter(collisionInfo)
   if inArea(localPos, ENCOUNTER_DECK_AREA) or inArea(localPos, ENCOUNTER_DISCARD_AREA) then
     tokenSpawnTrackerApi.resetTokensSpawned(object.getGUID())
     removeTokensFromObject(object)
-  end
-end
-
--- TTS event handler. Handles scenario name event triggering
-function onCollisionExit(collisionInfo)
-  if not collisionEnabled then return end
-  local object = collisionInfo.collision_object
-
-  -- reset token metadata if scenario reference card is removed
-  if object.getName() == "Scenario" then
-    tokenData = {}
-    useFrontData = nil
-    fireTokenDataChangedEvent()
   end
 end
 


### PR DESCRIPTION
Removed code was added to "reset" the internal token data variable. As it turns out, this is also triggered when flipping the scenario card and thus stops the updating onFlip.