### PR TITLE
Chaos Token Stat Tracker: sorted printing

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -370,7 +370,7 @@ function handleStatTrackerClick(_, _, isRightClick)
         playerColor = playmatApi.getPlayerColor(MAT_GUID_TO_COLOR[key])
         playerName = Player[playerColor].steam_name or playerColor
 
-        local playerSquidCount = personalStats["Auto-fail"] or 0
+        local playerSquidCount = personalStats["Auto-fail"]
         if playerSquidCount > maxSquid then
           squidKing = playerName
           maxSquid = playerSquidCount
@@ -403,39 +403,17 @@ function handleStatTrackerClick(_, _, isRightClick)
       printToAll("------------------------------")
       printToAll(squidKing .. " is an auto-fail magnet.", {255, 0, 0})
     else
-      printToAll("Couldn't find any stats for chaos token draws.")
+      printToAll("No tokens have been drawn yet.", "Yellow")
     end
   end
 end
 
 -- resets the count for each token to 0
 function resetChaosTokenStatTracker()
-  local tokenNameList = {
-    "+1",
-    "0",
-    "-1",
-    "-2",
-    "-3",
-    "-4",
-    "-5",
-    "-6",
-    "-7",
-    "-8",
-    "Skull",
-    "Cultist",
-    "Tablet",
-    "Elder Thing",
-    "Curse",
-    "Bless",
-    "Frost",
-    "Elder Sign",
-    "Auto-fail"
-  }
-
   for key, _ in pairs(tokenDrawingStats) do
     tokenDrawingStats[key] = {}
-    for _, tokenName in ipairs(tokenNameList) do
-      tokenDrawingStats[key][tokenName] = 0
+    for _, token in pairs(ID_URL_MAP) do
+      tokenDrawingStats[key][token.name] = 0
     end
   end
 end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -122,6 +122,7 @@ function onLoad(savedData)
     if obj ~= nil then obj.interactable = false end
   end
 
+  resetChaosTokenStatTracker()
   getModVersion()
   math.randomseed(os.time())
 end
@@ -353,42 +354,89 @@ end
 -- Left-click: print stats, Right-click: reset stats
 function handleStatTrackerClick(_, _, isRightClick)
   if isRightClick then
-    for key, _ in pairs(tokenDrawingStats) do
-      tokenDrawingStats[key] = {}
-    end
+    resetChaosTokenStatTracker()
   else
     local squidKing = "Nobody"
     local maxSquid  = 0
-    local playerColor, playerName
- 
-    for key, personalStats in pairs(tokenDrawingStats) do
-      if personalStats ~= {} then
-        if key == "Overall" then
-          playerColor = "White"
-          playerName = "Overall"
-        else
-          playerColor = playmatApi.getPlayerColor(MAT_GUID_TO_COLOR[key])
-          playerName = Player[playerColor].steam_name or playerColor
+    local foundAnyStats = false
 
-          local playerSquidCount = personalStats["Auto-fail"] or 0
-          if playerSquidCount > maxSquid then
-            squidKing = playerName
-            maxSquid = playerSquidCount
-          end
+    for key, personalStats in pairs(tokenDrawingStats) do
+      local playerColor, playerName
+
+      if key == "Overall" then
+        playerColor = "White"
+        playerName = "Overall"
+      else
+        playerColor = playmatApi.getPlayerColor(MAT_GUID_TO_COLOR[key])
+        playerName = Player[playerColor].steam_name or playerColor
+
+        local playerSquidCount = personalStats["Auto-fail"] or 0
+        if playerSquidCount > maxSquid then
+          squidKing = playerName
+          maxSquid = playerSquidCount
         end
-      
+      end
+
+      -- get the total count of drawn tokens for the player
+      local totalCount = 0
+      for tokenName, value in pairs(personalStats) do
+        totalCount = totalCount + value
+      end
+
+      -- only print the personal stats if any tokens were drawn
+      if totalCount > 0 then
+        foundAnyStats = true
         printToAll("------------------------------")
         printToAll(playerName ..  " Stats", playerColor)
-      
+        
         for tokenName, value in pairs(personalStats) do
-          if value then
+          if value ~= 0 then
             printToAll(tokenName .. ': ' .. tostring(value))
           end
         end
+        printToAll('Total: ' .. tostring(totalCount))
       end
     end
-    printToAll("------------------------------")
-    printToAll(squidKing .. " is an auto-fail magnet.", {255, 0, 0})
+
+    -- detect if any player drew tokens
+    if foundAnyStats then
+      printToAll("------------------------------")
+      printToAll(squidKing .. " is an auto-fail magnet.", {255, 0, 0})
+    else
+      printToAll("Couldn't find any stats for chaos token draws.")
+    end
+  end
+end
+
+-- resets the count for each token to 0
+function resetChaosTokenStatTracker()
+  local tokenNameList = {
+    "+1",
+    "0",
+    "-1",
+    "-2",
+    "-3",
+    "-4",
+    "-5",
+    "-6",
+    "-7",
+    "-8",
+    "Skull",
+    "Cultist",
+    "Tablet",
+    "Elder Thing",
+    "Curse",
+    "Bless",
+    "Frost",
+    "Elder Sign",
+    "Auto-fail"
+  }
+
+  for key, _ in pairs(tokenDrawingStats) do
+    tokenDrawingStats[key] = {}
+    for _, tokenName in ipairs(tokenNameList) do
+      tokenDrawingStats[key][tokenName] = 0
+    end
   end
 end
 


### PR DESCRIPTION
This sorts the print from the chaos token start tracker by prepopulating the table. Additionally, it will now omit the stat printing for players that haven't drawn any tokens (e.g. playmats that are not used).

![image](https://github.com/argonui/SCED/assets/97286811/742b683d-dd7c-465a-8325-d5cf54122008)