### PR TITLE
updated ID range for parallel investigators

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -199,7 +199,7 @@ do
       local altArt     = { front = "normal", back = "normal" }
 
       -- translating front ID
-      if altFrontId > 90000 and altFrontId < 90006 then
+      if altFrontId > 90000 and altFrontId < 90038 then
         altArt.front = "parallel"
       elseif altFrontId > 01500 and altFrontId < 01506 then
         altArt.front = "revised"
@@ -208,7 +208,7 @@ do
       end
 
       -- translating back ID
-      if altBackId > 90000 and altBackId < 90006 then
+      if altBackId > 90000 and altBackId < 90038 then
         altArt.back = "parallel"
       elseif altBackId > 01500 and altBackId < 01506 then
         altArt.back = "revised"


### PR DESCRIPTION
This accounts for ArkhamDBs ID change for parallel investigators, from 90001-90005 to:
```
Daisy 90001
Skids 90008
Agnes 90017
Roland 90024
Wendy 90037
```