### PR TITLE
keep context menu open for specific cards with "sealing"

### DIFF
--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -7,6 +7,11 @@ UPDATE_ON_HOVER     --@type: boolean
   - the "Read Bag" function reads the content of the chaos bag to update the context menu
   - example usage: "Unrelenting" (to only display valid tokens)
 
+KEEP_OPEN           --@type: boolean
+- meant for cards that seal single tokens multiple times (one by one)
+- makes the context menu stay open after selecting an option
+- example usage: "Unrelenting"
+
 SHOW_SINGLE_RELEASE --@type: boolean
   - enables an entry in the context menu
   - this entry allows releasing a single token
@@ -94,7 +99,7 @@ function generateContextMenu()
       if not SHOW_MULTI_SEAL then
         self.addContextMenuItem("Seal " .. map.name, function(playerColor)
           sealToken(map.name, playerColor)
-        end, true)
+        end, KEEP_OPEN)
       else
         self.addContextMenuItem("Seal " .. SHOW_MULTI_SEAL .. " " .. map.name, function(playerColor)
           readBag()

--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -94,7 +94,7 @@ function generateContextMenu()
       if not SHOW_MULTI_SEAL then
         self.addContextMenuItem("Seal " .. map.name, function(playerColor)
           sealToken(map.name, playerColor)
-        end)
+        end, true)
       else
         self.addContextMenuItem("Seal " .. SHOW_MULTI_SEAL .. " " .. map.name, function(playerColor)
           readBag()

--- a/src/playercards/cards/DarkRitual.ttslua
+++ b/src/playercards/cards/DarkRitual.ttslua
@@ -2,4 +2,6 @@ VALID_TOKENS = {
   ["Curse"] = true
 }
 
+KEEP_OPEN = true
+
 require("playercards/CardsThatSealTokens")

--- a/src/playercards/cards/FavoroftheMoon1.ttslua
+++ b/src/playercards/cards/FavoroftheMoon1.ttslua
@@ -3,5 +3,6 @@ VALID_TOKENS = {
 }
 
 SHOW_SINGLE_RELEASE = true
+KEEP_OPEN = true
 
 require("playercards/CardsThatSealTokens")

--- a/src/playercards/cards/FavoroftheSun1.ttslua
+++ b/src/playercards/cards/FavoroftheSun1.ttslua
@@ -3,5 +3,6 @@ VALID_TOKENS = {
 }
 
 SHOW_SINGLE_RELEASE = true
+KEEP_OPEN = true
 
 require("playercards/CardsThatSealTokens")

--- a/src/playercards/cards/FluteoftheOuterGods4.ttslua
+++ b/src/playercards/cards/FluteoftheOuterGods4.ttslua
@@ -3,5 +3,6 @@ VALID_TOKENS = {
 }
 
 SHOW_SINGLE_RELEASE = true
+KEEP_OPEN = true
 
 require("playercards/CardsThatSealTokens")

--- a/src/playercards/cards/RadiantSmite1.ttslua
+++ b/src/playercards/cards/RadiantSmite1.ttslua
@@ -2,4 +2,6 @@ VALID_TOKENS = {
   ["Bless"] = true
 }
 
+KEEP_OPEN = true
+
 require("playercards/CardsThatSealTokens")

--- a/src/playercards/cards/ShieldofFaith2.ttslua
+++ b/src/playercards/cards/ShieldofFaith2.ttslua
@@ -3,5 +3,6 @@ VALID_TOKENS = {
 }
 
 SHOW_SINGLE_RELEASE = true
+KEEP_OPEN = true
 
 require("playercards/CardsThatSealTokens")

--- a/src/playercards/cards/Unrelenting1.ttslua
+++ b/src/playercards/cards/Unrelenting1.ttslua
@@ -4,5 +4,6 @@ INVALID_TOKENS = {
 }
 
 UPDATE_ON_HOVER = true
+KEEP_OPEN = true
 
 require("playercards/CardsThatSealTokens")


### PR DESCRIPTION
This keeps the context menu open for cards that seal tokens one by one, e.g. Unrelenting.