### PR TITLE
Resource tokens - correcting rotation

### DIFF
--- a/objects/Resourcetokens.0168ae/Resource.4cd3f6.json
+++ b/objects/Resourcetokens.0168ae/Resource.4cd3f6.json
@@ -281,7 +281,7 @@
     "posY": 1.5,
     "posZ": 8,
     "rotX": 0,
-    "rotY": 270,
+    "rotY": 0,
     "rotZ": 0,
     "scaleX": 0.17,
     "scaleY": 0.17,

--- a/objects/Resourcetokens.9fadf9/Resource.4cd3f6.json
+++ b/objects/Resourcetokens.9fadf9/Resource.4cd3f6.json
@@ -281,7 +281,7 @@
     "posY": 1.5,
     "posZ": 8,
     "rotX": 0,
-    "rotY": 270,
+    "rotY": 0,
     "rotZ": 0,
     "scaleX": 0.17,
     "scaleY": 0.17,

--- a/objects/Resourcetokens.fd617a/Resource.4cd3f6.json
+++ b/objects/Resourcetokens.fd617a/Resource.4cd3f6.json
@@ -264,7 +264,7 @@
         "posY": 1.5,
         "posZ": 8,
         "rotX": 0,
-        "rotY": 270,
+        "rotY": 0,
         "rotZ": 0,
         "scaleX": 0.17,
         "scaleY": 0.17,


### PR DESCRIPTION
Since the objects in an infinite bag use local rotations (that are added on top of the bags rotation), the rotation needs to be set to 0 for these tokens to have the same rotation as the bag. This corrects the rotation (that was messed up when I added the states...).