### PR TITLE
Victory Display: trigger update from clue hotkey

### DIFF
--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -1,5 +1,6 @@
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
 local playmatApi = require("playermat/PlaymatApi")
+local victoryDisplayApi = require("core/VictoryDisplayApi")
 
 function onLoad()
   addHotkey("Add Doom to Agenda", addDoomToAgenda)
@@ -121,6 +122,8 @@ function takeClueFromLocation(playerColor, hoveredObject)
   else
     broadcastToAll(playerName .. " took one clue.", "Green")
   end
+
+  victoryDisplayApi.update()
 end
 
 -- broadcasts the bless/curse status to the calling player

--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -44,10 +44,8 @@ function addDoomToAgenda()
 end
 
 -- moves the hovered card to the victory display
-function moveCardToVictoryDisplay(playerColor, hoveredObject)
-  -- check if the provided object is a card
-  if hoveredObject == nil or hoveredObject.tag ~= "Card" then return end
-  getObjectFromGUID("6ccd6d").call("placeCard", hoveredObject)
+function moveCardToVictoryDisplay(_, hoveredObject)
+  victoryDisplayApi.placeCard(hoveredObject)
 end
 
 -- takes a clue from a location, player needs to hover the clue directly or the location

--- a/src/core/VictoryDisplay.ttslua
+++ b/src/core/VictoryDisplay.ttslua
@@ -74,18 +74,12 @@ end
 
 -- dropping an object on the victory display
 function onCollisionEnter()
-  -- stop if there is already an update call running
-  if pendingCall then return end
-  pendingCall = true
-  Wait.time(updateCount, 0.2)
+  startUpdate()
 end
 
 -- removing an object from the victory display
 function onCollisionExit()
-  -- stop if there is already an update call running
-  if pendingCall then return end
-  pendingCall = true
-  Wait.time(updateCount, 0.2)
+  startUpdate()
 end
 
 -- picking a clue or location up
@@ -132,11 +126,14 @@ function maybeUpdate(obj, delay, flipped)
   -- only continue if the obj in in the play area
   if not playAreaApi.isInPlayArea(obj) then return end
 
-  -- set this flag to limit function calls (will be reset by "updateCount")
-  pendingCall = true
+  startUpdate(delay)
+end
 
-  -- update the count with delay (or 0 if no delay is provided)
-  -- this is needed to let tokens drop on the card
+-- starts an update
+function startUpdate(delay)
+  -- stop if there is already an update call running
+  if pendingCall then return end
+  pendingCall = true
   delay = tonumber(delay) or 0
   Wait.time(updateCount, delay + 0.2)
 end

--- a/src/core/VictoryDisplayApi.ttslua
+++ b/src/core/VictoryDisplayApi.ttslua
@@ -1,0 +1,12 @@
+do
+  local VictoryDisplayApi = {}
+  local VD_GUID = "6ccd6d"
+
+  -- triggers an update of the Victory count
+  ---@param delay Number Delay in seconds after which the update call is executed
+  VictoryDisplayApi.update = function(delay)
+    getObjectFromGUID(VD_GUID).call("startUpdate", delay)
+  end
+
+  return VictoryDisplayApi
+end

--- a/src/core/VictoryDisplayApi.ttslua
+++ b/src/core/VictoryDisplayApi.ttslua
@@ -8,5 +8,13 @@ do
     getObjectFromGUID(VD_GUID).call("startUpdate", delay)
   end
 
+  -- moves a card to the victory display (in the first empty spot)
+  ---@param object Object Object that should be checked and potentially moved
+  VictoryDisplayApi.placeCard = function(object)
+    if object ~= nil and object.tag == "Card" then
+      getObjectFromGUID(VD_GUID).call("placeCard", object)
+    end
+  end
+
   return VictoryDisplayApi
 end


### PR DESCRIPTION
Adds the VictoryDisplayApi, which contains just one function for now. This function triggers an update and is used to keep the VD updated if clues are taken via hotkey (since they don't trigger an update through the existing events).