### PR TITLE
Clean Up Helper: return sealed tokens to chaos bag

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -173,7 +173,7 @@ function cleanUp(_, color)
   removeLines()
   discardHands()
   tokenSpawnTrackerApi.resetAll()
-  Global.call("findAllChaosTokens")
+  Global.call("releaseAllSealedTokens", color)
 
   printToAll("Tidying main play area...", "White")
   startLuaCoroutine(self, "tidyPlayareaCoroutine")

--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -172,7 +172,7 @@ function cleanUp(_, color)
   removeLines()
   discardHands()
   tokenSpawnTrackerApi.resetAll()
-  Global.call("returnChaosTokens")
+  Global.call("findAllChaosTokens")
 
   printToAll("Tidying main play area...", "White")
   startLuaCoroutine(self, "tidyPlayareaCoroutine")

--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -172,6 +172,7 @@ function cleanUp(_, color)
   removeLines()
   discardHands()
   tokenSpawnTrackerApi.resetAll()
+  Global.call("returnChaosTokens")
 
   printToAll("Tidying main play area...", "White")
   startLuaCoroutine(self, "tidyPlayareaCoroutine")

--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -6,6 +6,7 @@ Cleans up the table for the next scenario in a campaign:
 local tokenSpawnTrackerApi      = require("core/token/TokenSpawnTrackerApi")
 local soundCubeApi              = require("core/SoundCubeApi")
 local playmatApi                = require("playermat/PlaymatApi")
+local blessCurseManagerApi      = require("chaosbag/BlessCurseManagerApi")
 
 -- these objects will be ignored
 local IGNORE_GUIDS              = {
@@ -168,7 +169,7 @@ function cleanUp(_, color)
   updateCounters(CLUE_CLICKER_GUIDS, 0, "Clue clickers")
   resetSkillTrackers()
   resetDoomCounter()
-  removeBlessCurse(color)
+  blessCurseManagerApi.removeAll(color)
   removeLines()
   discardHands()
   tokenSpawnTrackerApi.resetAll()
@@ -181,6 +182,7 @@ end
 ---------------------------------------------------------
 -- modular functions, called by other functions
 ---------------------------------------------------------
+
 function updateCounters(tableOfGUIDs, tableOfNewValues, info)
   if tonumber(tableOfNewValues) then
     local value = tableOfNewValues
@@ -264,17 +266,6 @@ function getTrauma()
   else
     printToAll("Trauma values could not be found in campaign log!", "Yellow")
     printToAll("Default values for health and sanity loaded.", "Yellow")
-  end
-end
-
--- get rid of bless/curse tokens via bless/curse manager
-function removeBlessCurse(color)
-  local BlessCurseManager = getObjectFromGUID("5933fb")
-
-  if BlessCurseManager ~= nil then
-    BlessCurseManager.call("doRemove", color)
-  else
-    printToAll("Bless / Curse manager could not be found and thus bless/curse tokens were skipped.", "Yellow")
   end
 end
 

--- a/src/chaosbag/BlessCurseManager.ttslua
+++ b/src/chaosbag/BlessCurseManager.ttslua
@@ -63,14 +63,21 @@ function onLoad(saved_state)
     self.addContextMenuItem("Remove all", doRemove)
     self.addContextMenuItem("Reset", doReset)
 
-    -- initializing tables
+    -- initializing tables 
+    initializeState()
+    broadcastCount("Curse")
+    broadcastCount("Bless")
+end
+
+function resetTables()
     numInPlay = { Bless = 0, Curse = 0 }
     tokensTaken = { Bless = {}, Curse = {} }
     sealedTokens = {}
-    Wait.time(initializeState, 1)
 end
 
 function initializeState()
+    resetTables()
+
     -- count tokens in the bag
     local chaosbag = Global.call("findChaosBag")
     local tokens = {}
@@ -95,9 +102,6 @@ function initializeState()
             end
         end
     end
-
-    broadcastCount("Curse")
-    broadcastCount("Bless")
 end
 
 function broadcastCount(token)
@@ -133,15 +137,15 @@ function doRemove(color)
     broadcastToColor("Removed " .. removeTakenTokens("Bless") .. " Bless and " ..
         removeTakenTokens("Curse") .. " Curse tokens from play.", color, "White")
 
-    doReset(color)
+    resetTables()
+    tokenArrangerApi.layout()
 end
 
 -- context menu function 2
 function doReset(color)
-    playerColor = color
-    numInPlay = { Bless = 0, Curse = 0 }
-    tokensTaken = { Bless = {}, Curse = {} }
     initializeState()
+    broadcastCount("Curse")
+    broadcastCount("Bless")
     tokenArrangerApi.layout()
 end
 

--- a/src/chaosbag/BlessCurseManagerApi.ttslua
+++ b/src/chaosbag/BlessCurseManagerApi.ttslua
@@ -26,6 +26,12 @@ do
     getObjectFromGUID(MANAGER_GUID).call("broadcastStatus", playerColor)
   end
 
+  -- removes all bless / curse tokens from the chaos bag and play
+  ---@param playerColor String Color of the player to show the broadcast to
+  BlessCurseManagerApi.removeAll = function(playerColor)
+    getObjectFromGUID(MANAGER_GUID).call("doRemove", playerColor)
+  end
+
   -- adds Wendy's menu to the hovered card (allows sealing of tokens)
   ---@param color String Color of the player to show the broadcast to
   BlessCurseManagerApi.addWendysMenu = function(playerColor, hoveredObject)

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -646,11 +646,15 @@ function emptyChaosBag()
   end
 end
 
--- find all chaos tokens that are on the table to the chaos bag (e.g. sealed on cards)
+-- move all regular chaos tokens that are on the table to the chaos bag (e.g. sealed on cards)
 function findAllChaosTokens()
   local chaosbag = findChaosBag()
   for _, obj in ipairs(getObjects()) do
-    if tokenChecker.isChaosToken(obj) and not obj.hasTag("tempToken") then
+    local name = obj.getName()
+    if tokenChecker.isChaosToken(obj) and
+        not obj.hasTag("tempToken") and
+        name ~= "Bless" and
+        name ~= "Curse" then
       chaosbag.putObject(obj)
     end
   end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -646,8 +646,8 @@ function emptyChaosBag()
   end
 end
 
--- return chaos tokens that are on the table to the chaos bag (e.g. sealed on cards)
-function returnChaosTokens()
+-- find all chaos tokens that are on the table to the chaos bag (e.g. sealed on cards)
+function findAllChaosTokens()
   local chaosbag = findChaosBag()
   for _, obj in ipairs(getObjects()) do
     if tokenChecker.isChaosToken(obj) and not obj.hasTag("tempToken") then

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -39,6 +39,7 @@ local mythosAreaApi = require("core/MythosAreaApi")
 local tokenArrangerApi = require("accessories/TokenArrangerApi")
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
 local navigationOverlayApi = require("core/NavigationOverlayApi")
+local tokenChecker = require("core/token/TokenChecker")
 
 -- online functionality related variables
 local MOD_VERSION = "3.1.0"
@@ -642,6 +643,16 @@ function emptyChaosBag()
   local chaosbag = findChaosBag()
   for _, object in ipairs(chaosbag.getObjects()) do
     chaosbag.takeObject({callback_function = function(item) item.destruct() end})
+  end
+end
+
+-- return chaos tokens that are on the table to the chaos bag (e.g. sealed on cards)
+function returnChaosTokens()
+  local chaosbag = findChaosBag()
+  for _, obj in ipairs(getObjects()) do
+    if tokenChecker.isChaosToken(obj) and not obj.hasTag("tempToken") then
+      chaosbag.putObject(obj)
+    end
   end
 end
 

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -646,16 +646,13 @@ function emptyChaosBag()
   end
 end
 
--- move all regular chaos tokens that are on the table to the chaos bag (e.g. sealed on cards)
-function findAllChaosTokens()
+-- returns all sealed tokens on cards to the chaos bag
+function releaseAllSealedTokens(playerColor)
   local chaosbag = findChaosBag()
   for _, obj in ipairs(getObjects()) do
-    local name = obj.getName()
-    if tokenChecker.isChaosToken(obj) and
-        not obj.hasTag("tempToken") and
-        name ~= "Bless" and
-        name ~= "Curse" then
-      chaosbag.putObject(obj)
+    local sealedTokens = obj.getTable("sealedTokens")
+    if sealedTokens ~= nil and #sealedTokens > 0 then
+      obj.call("releaseAllTokens", playerColor)
     end
   end
 end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -649,11 +649,8 @@ end
 -- returns all sealed tokens on cards to the chaos bag
 function releaseAllSealedTokens(playerColor)
   local chaosbag = findChaosBag()
-  for _, obj in ipairs(getObjects()) do
-    local sealedTokens = obj.getTable("sealedTokens")
-    if sealedTokens ~= nil and #sealedTokens > 0 then
-      obj.call("releaseAllTokens", playerColor)
-    end
+  for _, obj in ipairs(getObjectsWithTag("CardThatSeals")) do
+    obj.call("releaseAllTokens", playerColor)
   end
 end
 

--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -70,11 +70,9 @@ Thus it should be implemented like this:
 
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
 local tokenArrangerApi = require("accessories/TokenArrangerApi")
+local sealedTokens = {}
 local ID_URL_MAP = {}
 local tokensInBag = {}
-
--- this is intentionally global so that it can be accessed for clean up
-sealedTokens = {}
 
 function onSave() return JSON.encode(sealedTokens) end
 
@@ -82,6 +80,7 @@ function onLoad(savedData)
   sealedTokens = JSON.decode(savedData) or {}
   ID_URL_MAP = Global.getTable("ID_URL_MAP")
   generateContextMenu()
+  self.addTag("CardThatSeals")
 end
 
 -- builds the context menu

--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -70,9 +70,11 @@ Thus it should be implemented like this:
 
 local blessCurseManagerApi = require("chaosbag/BlessCurseManagerApi")
 local tokenArrangerApi = require("accessories/TokenArrangerApi")
-local sealedTokens = {}
 local ID_URL_MAP = {}
 local tokensInBag = {}
+
+-- this is intentionally global so that it can be accessed for clean up
+sealedTokens = {}
 
 function onSave() return JSON.encode(sealedTokens) end
 


### PR DESCRIPTION
- Adds a new function that returns chaos tokens that are on the table to the chaos bag. Intended usage if for the Clean Up Helper and Campaign Importer / Exporter. Closes https://github.com/argonui/SCED/issues/315
- uses the existing blesscursemanagerapi for the Clean Up Helper instead of a direct call
- minor update to bless / curse manager printing (yes, this is functionally unrelated... 🙈)