### PR TITLE
Add camera_ignore tags and reduce X_BUFFER

### DIFF
--- a/objects/TableDivider.612072.json
+++ b/objects/TableDivider.612072.json
@@ -29,6 +29,11 @@
   "Nickname": "Table Divider",
   "Snap": true,
   "Sticky": true,
+  "Tags": [
+    "CameraZoom_ignore",
+    "CleanUpHelper_ignore",
+    "displacement_excluded"
+  ],
   "Tooltip": false,
   "Transform": {
     "posX": 0,

--- a/objects/TableDivider.75937e.json
+++ b/objects/TableDivider.75937e.json
@@ -29,6 +29,11 @@
   "Nickname": "Table Divider",
   "Snap": true,
   "Sticky": true,
+  "Tags": [
+    "CameraZoom_ignore",
+    "CleanUpHelper_ignore",
+    "displacement_excluded"
+  ],
   "Tooltip": false,
   "Transform": {
     "posX": -16.807,

--- a/objects/TableDivider.8646eb.json
+++ b/objects/TableDivider.8646eb.json
@@ -29,6 +29,11 @@
   "Nickname": "Table Divider",
   "Snap": true,
   "Sticky": true,
+  "Tags": [
+    "CameraZoom_ignore",
+    "CleanUpHelper_ignore",
+    "displacement_excluded"
+  ],
   "Tooltip": false,
   "Transform": {
     "posX": -29.99,

--- a/objects/TableDivider.975c39.json
+++ b/objects/TableDivider.975c39.json
@@ -29,6 +29,11 @@
   "Nickname": "Table Divider",
   "Snap": true,
   "Sticky": true,
+  "Tags": [
+    "CameraZoom_ignore",
+    "CleanUpHelper_ignore",
+    "displacement_excluded"
+  ],
   "Tooltip": false,
   "Transform": {
     "posX": 0,

--- a/objects/VictoryDisplay.6ccd6d.json
+++ b/objects/VictoryDisplay.6ccd6d.json
@@ -163,7 +163,9 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "CleanUpHelper_ignore"
+    "CameraZoom_ignore",
+    "CleanUpHelper_ignore",
+    "displacement_excluded"
   ],
   "Tooltip": true,
   "Transform": {

--- a/src/core/NavigationOverlayHandler.ttslua
+++ b/src/core/NavigationOverlayHandler.ttslua
@@ -260,7 +260,7 @@ function getDynamicViewBounds(objList)
     -- handling for Physics.cast() results
     if not obj.type then obj = obj.hit_object end
 
-    if not obj.hasTag("CameraZoom_ignore") then
+    if not obj.hasTag("CameraZoom_ignore") and not obj.hasTag("CampaignLog") then
       count = count + 1
       local bounds = obj.getBounds()
       local x1 = bounds['center'][1] - bounds['size'][1] / 2

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -153,7 +153,7 @@ function searchArea(origin, size)
     type         = 3,
     size         = size,
     max_distance = 1,
-    debug        = true
+    debug        = DEBUG
   })
 end
 

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -15,7 +15,7 @@ local DRAWN_CHAOS_TOKEN_OFFSET = {-1.55, 0.25, -0.58}
 -- x-Values for discard buttons
 local DISCARD_BUTTON_OFFSETS = {-1.365, -0.91, -0.455, 0, 0.455, 0.91}
 
-local SEARCH_AROUND_SELF_X_BUFFER = 18
+local SEARCH_AROUND_SELF_X_BUFFER = 8
 
 -- defined areas for the function "inArea()""
 local MAIN_PLAY_AREA = {
@@ -153,7 +153,7 @@ function searchArea(origin, size)
     type         = 3,
     size         = size,
     max_distance = 1,
-    debug        = DEBUG
+    debug        = true
   })
 end
 


### PR DESCRIPTION
Purpose of this PR is to fix the Navigation Overlay zooming on the victory display / campaign log / table dividers since they are now getting hit by the playmat's `searchAroundSelf`.

This is a draft since I am not yet sure what the best solution to this issue is.