### PR TITLE
Upkeep: rotate cards to the next multiple of 90° towards 0°

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -280,9 +280,23 @@ function doUpkeep(_, clickedByColor, isRightClick)
     elseif obj.tag == "Card" and not inArea(self.positionToLocal(obj.getPosition()), INVESTIGATOR_AREA) then
       local cardMetadata = JSON.decode(obj.getGMNotes()) or {}
       if not doNotReady(obj) then
+        local cardRotation = round(obj.getRotation().y, 0) - rot.y
+        local yRotDiff = 0
+
+        if cardRotation < 0 then
+          cardRotation = cardRotation + 360
+        end
+
+        -- rotate cards to the next multiple of 90° towards 0°
+        if cardRotation > 90 and cardRotation <= 180 then
+          yRotDiff = 90
+        elseif cardRotation < 270 and cardRotation > 180 then
+          yRotDiff = 270
+        end
+
         -- set correct rotation for face-down cards
         rot.z = obj.is_face_down and 180 or 0
-        obj.setRotation(rot)
+        obj.setRotation({rot.x, rot.y + yRotDiff, rot.z})
       end
       if cardMetadata.id == "08031" then
         forcedLearning = true
@@ -961,4 +975,12 @@ function updatePlayerCards(args)
   local customDataHelper = getObjectFromGUID(args[1])
   local playerCardData = customDataHelper.getTable("PLAYER_CARD_DATA")
   tokenManager.addPlayerCardData(playerCardData)
+end
+
+-- utility function for rounding
+---@param num Number Initial value
+---@param numDecimalPlaces Number Amount of decimal places
+function round(num, numDecimalPlaces)
+  local mult = 10^(numDecimalPlaces or 0)
+  return math.floor(num * mult + 0.5) / mult
 end


### PR DESCRIPTION
The "Upkeep" function will now rotate cards to the next closest multiple of 90° towards 0° (local rotation to the playmat).
This can be used to mark cards as "do not ready during the next upkeep phase" by simply rotating them to something between 90° and 270°.

Example of Rotation Change in Upkeep
before -> after
45 -> 0
90 -> 0
135 -> 90
180 -> 90 (had to apply some precedence here and chose 90 over 270)
225 -> 270
270 -> 0