### PR TITLE
Living Ink bugfix

### DIFF
--- a/objects/AllPlayerCards.15bb07/LivingInk.42b36d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/LivingInk.42b36d.gmnotes
@@ -14,6 +14,8 @@
   ],
   "customizations": [
     {
+    },
+    {
       "name": "Shifting Ink",
       "xp": 1,
       "text": "You may play Living Ink under the control of another investigator at your location."


### PR DESCRIPTION
This adds an empty entry to the customizations table for Living Ink to account for the empty row with the skill selection (without this the additional charges effect is falsely applied to the 2nd row instead of the 3rd)