### PR TITLE
Bugfix for unprovided subtype (token spawning)

### DIFF
--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -232,6 +232,11 @@ do
       return
     end
 
+    -- handling for not provided subtype (for example when spawning from custom data helpers)
+    if subType == nil then
+      subType = ""
+    end
+    
     -- this is used to load the correct state for additional resource tokens (e.g. "Ammo")
     local callback = nil
     local stateID = stateTable[string.lower(subType)]


### PR DESCRIPTION
This fixes an error when the subtype for a token is not provided.

VERY IMPORTANT since without this clue-spawning from custom data helper is broken!