### PR TITLE
Clean Up Helper: updated trauma getting

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -254,15 +254,19 @@ function getTrauma()
     printToAll("Default values for health and sanity loaded.", "Yellow")
     return
   end
+  campaignLog = campaignLog.hit_object
+
+  -- set campaign log to first state
+  local stateId = campaignLog.getStateId()
+  if stateId ~= 1 then
+    campaignLog.setState(1)
+  end
 
   -- get data from campaign log if possible
-  local counterData = campaignLog.hit_object.getVar("ref_buttonData")
-  if counterData ~= nil then
+  local trauma = campaignLog.getVar("returnTrauma")
+  if trauma ~= nil then
     printToAll("Trauma values found in campaign log!", "Green")
-    for i = 1, 10, 3 do
-      RESET_VALUES[1 + (i - 1) / 3] = counterData.counter[i].value
-      RESET_VALUES[5 + (i - 1) / 3] = counterData.counter[i + 1].value
-    end
+    RESET_VALUES = campaignLog.call("returnTrauma")
   else
     printToAll("Trauma values could not be found in campaign log!", "Yellow")
     printToAll("Default values for health and sanity loaded.", "Yellow")


### PR DESCRIPTION
This change utilizes the "returnTrauma" function that is included in the campaign logs instead of directly accessing their data (results in the same behaviour, but allows support for unconventional campaign logs like Dark Matter with its Memory stat)