### PR TITLE
Updated Pete's Replacement Signature IDs

### DIFF
--- a/objects/AllPlayerCards.15bb07/HardTimes.876557.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HardTimes.876557.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "91048",
+  "id": "90048",
   "type": "Treachery",
   "class": "Neutral",
   "traits": "Hardship.",

--- a/objects/AllPlayerCards.15bb07/PetesGuitar.876557.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PetesGuitar.876557.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "91047",
+  "id": "90047",
   "type": "Asset",
   "class": "Neutral",
   "cost": 2,

--- a/src/playercards/PlayerCardPanelData.ttslua
+++ b/src/playercards/PlayerCardPanelData.ttslua
@@ -247,7 +247,7 @@ INVESTIGATORS["Jim Culver"] = {
 INVESTIGATORS["\"Ashcan\" Pete"] = {
 	cards = { "02005", "02005-p", "02005-pf", "02005-pb" },
 	minicards = { "02005-m" },
-	signatures = { "02014", "02015", "91047", "91048" },
+	signatures = { "02014", "02015", "90047", "90048" },
 	starterDeck = "2624969"
 }
 --Carcosa--


### PR DESCRIPTION
910xx - > 900xx.

Parallel Pete himself already has the right metadata