### PR TITLE
Deckimporter: spawn reality acid reference dynamically

### DIFF
--- a/objects/AllPlayerCards.15bb07/RealityAcidReference.858b0a.gmnotes
+++ b/objects/AllPlayerCards.15bb07/RealityAcidReference.858b0a.gmnotes
@@ -1,0 +1,7 @@
+{
+  "id": "89005",
+  "type": "Story",
+  "class": "Neutral",
+  "permanent": true,
+  "cycle": "Standalone"
+}

--- a/objects/AllPlayerCards.15bb07/RealityAcidReference.858b0a.json
+++ b/objects/AllPlayerCards.15bb07/RealityAcidReference.858b0a.json
@@ -24,7 +24,7 @@
   },
   "Description": "",
   "DragSelectable": true,
-  "GMNotes": "{\r\n  \"id\": \"89005\",\r\n  \"type\": \"Story\",\r\n  \"cycle\": \"Standalone\"\r\n}\r",
+  "GMNotes_path": "AllPlayerCards.15bb07/RealityAcidReference.858b0a.gmnotes",
   "GUID": "858b0a",
   "Grid": true,
   "GridProjection": false,

--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -146,6 +146,7 @@ do
     internal.maybeAddCustomizeUpgradeSheets(slots)
     internal.maybeAddSummonedServitor(slots)
     internal.maybeAddOnTheMend(slots, playerColor)
+    internal.maybeAddRealityAcidReference(slots)
     local bondList = internal.extractBondedCards(slots)
     internal.checkTaboos(deck.taboo_id, slots, playerColor)
 
@@ -277,6 +278,15 @@ do
         internal.maybePrint("Something went wrong with the load, adding 4 copies of On the Mend", playerColor)
         slots["09006"] = 4
       end
+    end
+  end
+
+  -- Process the card list looking for Reality Acid and adds the reference sheet when needed
+  ---@param slots Table The slot list for cards in this deck. Table key is the cardId, value is the number
+  --     of those cards which will be spawned
+  internal.maybeAddRealityAcidReference = function(slots)
+    if slots["89004"] ~= nil then
+      slots["89005"] = 1
     end
   end
 


### PR DESCRIPTION
This spawns the reality acid reference sheet dynamically, if reality acid is in the deck