### PR TITLE
Springfield 1903: metadata correction

### DIFF
--- a/objects/AllPlayerCards.15bb07/SpringfieldM19034.a7944d.gmnotes
+++ b/objects/AllPlayerCards.15bb07/SpringfieldM19034.a7944d.gmnotes
@@ -1,5 +1,5 @@
 {
-  "id": "02226-t",
+  "id": "02226",
   "type": "Asset",
   "class": "Guardian",
   "cost": 4,


### PR DESCRIPTION
Falsely applied taboo ID was removed from the original card