### PR TITLE
Add "Asset" tag to Enchant Weapon for snapping

### DIFF
--- a/objects/AllPlayerCards.15bb07/EnchantWeapon3.33455f.json
+++ b/objects/AllPlayerCards.15bb07/EnchantWeapon3.33455f.json
@@ -42,6 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
+    "Asset",
     "PlayerCard"
   ],
   "Tooltip": true,


### PR DESCRIPTION
While "Enchant Weapon" is not an asset per-se, it very much behaves like one since it basically takes up an arcane slot. This adds the tag to support snapping.