### PR TITLE
Bugfix for clue counts > 12

### DIFF
--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -204,14 +204,15 @@ do
   ---@param shiftDown Number An offset for the z-value of this group of tokens
   ---@param subType Number Subtype of token to spawn.  This will only differ from the tokenName for resource tokens
   TokenManager.spawnMultipleTokens = function(card, tokenType, tokenCount, shiftDown, subType)
-    if tokenCount < 1 or tokenCount > 12 then
-      return
-    end
+    -- not checking the max at this point since clue offsets are calculated dynamically
+    if tokenCount < 1 then return end
 
     local offsets = {}
     if tokenType == "clue" then
       offsets = internal.buildClueOffsets(card, tokenCount)
     else
+      -- only up to 12 offset tables defined
+      if tokenCount > 12 then return end
       for i = 1, tokenCount do
         offsets[i] = card.positionToWorld(PLAYER_CARD_TOKEN_OFFSETS[tokenCount][i])
         -- Fix the y-position for the spawn, since positionToWorld considers rotation which can
@@ -479,7 +480,6 @@ do
       local column = (i - 1) % 4
       table.insert(cluePositions, Vector(pos.x + 1.5 - 0.55 * row, pos.y + 0.15, pos.z - 0.825 + 0.55 * column))
     end
-
     return cluePositions
   end
 


### PR DESCRIPTION
Since there are locations with more than 12 clues for 4 player playthroughs, this enables spawning clues for them.
Example location:
![image](https://github.com/argonui/SCED/assets/97286811/48b1f767-5d3b-48f5-8155-43ffdd1990d8)