### PR TITLE
Added missing "uses" metadata

### DIFF
--- a/objects/AllPlayerCards.15bb07/AncientStone4.3289b0.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AncientStone4.3289b0.gmnotes
@@ -6,5 +6,12 @@
   "level": 4,
   "traits": "Item. Relic.",
   "agilityIcons": 2,
+  "uses": [
+    {
+      "count": 0,
+      "type": "Secret",
+      "token": "resource"
+    }
+  ],
   "cycle": "Return to the Forgotten Age"
 }

--- a/objects/AllPlayerCards.15bb07/AncientStone4.863f91.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AncientStone4.863f91.gmnotes
@@ -6,5 +6,12 @@
   "level": 4,
   "traits": "Item. Relic.",
   "intellectIcons": 2,
+  "uses": [
+    {
+      "count": 0,
+      "type": "Secret",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Forgotten Age"
 }

--- a/objects/AllPlayerCards.15bb07/AncientStone4.9c56d3.gmnotes
+++ b/objects/AllPlayerCards.15bb07/AncientStone4.9c56d3.gmnotes
@@ -6,5 +6,12 @@
   "level": 4,
   "traits": "Item. Relic.",
   "willpowerIcons": 2,
+  "uses": [
+    {
+      "count": 0,
+      "type": "Secret",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Forgotten Age"
 }

--- a/objects/AllPlayerCards.15bb07/CustomAmmunition3.f03baa.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CustomAmmunition3.f03baa.gmnotes
@@ -7,5 +7,12 @@
   "traits": "Upgrade. Supply. Blessed.",
   "combatIcons": 1,
   "agilityIcons": 1,
+  "uses": [
+    {
+      "count": 2,
+      "type": "Ammo",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Forgotten Age"
 }

--- a/objects/AllPlayerCards.15bb07/EmbezzledTreasure.8fd043.gmnotes
+++ b/objects/AllPlayerCards.15bb07/EmbezzledTreasure.8fd043.gmnotes
@@ -6,5 +6,12 @@
   "level": 0,
   "traits": "Item. Illicit.",
   "intellectIcons": 1,
+  "uses": [
+    {
+      "count": 0,
+      "type": "Resource",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/FamilyInheritance.394603.gmnotes
+++ b/objects/AllPlayerCards.15bb07/FamilyInheritance.394603.gmnotes
@@ -4,5 +4,12 @@
   "class": "Neutral",
   "traits": "Boon.",
   "permanent": true,
+  "uses": [
+    {
+      "count": 0,
+      "type": "Resource",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Circle Undone"
 }

--- a/objects/AllPlayerCards.15bb07/ResearchNotesTaboo.085c08.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ResearchNotesTaboo.085c08.gmnotes
@@ -6,5 +6,12 @@
   "level": 0,
   "traits": "Item. Tome. Science.",
   "intellectIcons": 1,
+  "uses": [
+    {
+      "count": 0,
+      "type": "Evidence",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Scarlet Keys"
 }

--- a/objects/AllPlayerCards.15bb07/SparrowMask.975d79.gmnotes
+++ b/objects/AllPlayerCards.15bb07/SparrowMask.975d79.gmnotes
@@ -7,5 +7,12 @@
   "traits": "Item. Charm. Mask.",
   "willpowerIcons": 1,
   "agilityIcons": 1,
+  "uses": [
+    {
+      "count": 2,
+      "type": "Offering",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Feast of Hemlock Vale"
 }

--- a/objects/AllPlayerCards.15bb07/WindsofPower1.bcdfde.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WindsofPower1.bcdfde.gmnotes
@@ -6,5 +6,12 @@
   "level": 1,
   "traits": "Spirit.",
   "willpowerIcons": 2,
+  "uses": [
+    {
+      "count": 2,
+      "type": "Charge",
+      "token": "resource"
+    }
+  ],
   "cycle": "Edge of the Earth"
 }


### PR DESCRIPTION
This adds missing "uses" metadata. Mostly cards with "uses (0 XYZ)", but that data is still getting used by for example the resource hotkey.