### PR TITLE
Token Arranger: more bugfixing

### DIFF
--- a/src/accessories/TokenArranger.ttslua
+++ b/src/accessories/TokenArranger.ttslua
@@ -312,6 +312,10 @@ function layout(_, _, isRightClick)
     local value = tonumber(objData.Nickname)
     local precedence = tokenPrecedence[objData.Nickname]
 
+    -- remove GUID to avoid issues for high latency clients
+    objData["GUID"] = nil
+
+    -- store data with value / precendence
     data[i] = {
       token = objData,
       value = value or precedence[1]


### PR DESCRIPTION
This removes the `GUID` field from the tokendata before spawning, so that TTS is forced to assign a new one and treat it as a new object instead of falsely displaying it in the wrong position for low latency clients (at least this is what I hope finally fixes this issue).