### PR TITLE
Bugfix: spawn correct amount of bonded cards

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -295,7 +295,12 @@ do
       local card = allCardsBagApi.getCardById(cardId)
       if (card ~= nil and card.metadata.bonded ~= nil) then
         for _, bond in ipairs(card.metadata.bonded) do
-          bondedCards[bond.id] = bond.count
+          -- add a bonded card for each copy of the parent card (except for Pendant of the Queen)
+          if bond.id == "06022" then
+            bondedCards[bond.id] = bond.count
+          else
+            bondedCards[bond.id] = bond.count * cardCount
+          end
           -- We need to know which cards are bonded to determine their position, remember them
           bondedList[bond.id] = true
           -- Also adding taboo versions of bonded cards to the list


### PR DESCRIPTION
This corrects the amount of bonded cards to be dependable on the card count of the "parent" card (except for Pendant of the Queen).