### PR TITLE
Token Group Spawning: fixed shiftdown vector

### DIFF
--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -225,9 +225,11 @@ do
       -- Copy the offsets to make sure we don't change the static values
       local baseOffsets = offsets
       offsets = { }
+
+      -- get a vector for the shifting (downwards local to the card)
+      local shiftDownVector = Vector(0, 0, shiftDown):rotateOver("y", card.getRotation().y)
       for i, baseOffset in ipairs(baseOffsets) do
-        offsets[i] = baseOffset
-        offsets[i][3] = offsets[i][3] + shiftDown
+        offsets[i] = baseOffset + shiftDownVector
       end
     end
 


### PR DESCRIPTION
This fixes the spawning of multiple token groups. The shiftdown needs to be in the same rotation as the card.

Example:
![image](https://github.com/argonui/SCED/assets/97286811/cbe691a5-3ac5-4ac7-b311-c392ecde3ef6)