### PR TITLE
improved readability of master clue counter (again!)

### DIFF
--- a/objects/MasterClueCounter.4a3aa4.json
+++ b/objects/MasterClueCounter.4a3aa4.json
@@ -19,7 +19,7 @@
     },
     "ImageScalar": 1,
     "ImageSecondaryURL": "",
-    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/1758068501357164917/1D06F1DC4D6888B6F57124BD2AFE20D0B0DA15A8/",
+    "ImageURL": "http://cloud-3.steamusercontent.com/ugc/784129913444610342/7903BA89870C1656A003FD69C79BFA99BD1AAC24/",
     "WidthScale": 0
   },
   "Description": "Click to remove all clues from all investigators",

--- a/src/core/MasterClueCounter.ttslua
+++ b/src/core/MasterClueCounter.ttslua
@@ -20,7 +20,7 @@ function onLoad(savedData)
     width = 900,
     scale = { 1.5, 1.5, 1.5 },
     font_size = 650,
-    font_color = { 0, 0, 0, 100 },
+    font_color = { 1, 1, 1, 100 },
     color = { 0, 0, 0, 0 }
   })
 


### PR DESCRIPTION
Now it's back to white, but with a green background:

![image](https://github.com/argonui/SCED/assets/97286811/91c400a7-c451-47ef-b181-5cf335534329)