### PR TITLE
Friends in Low Places: fixed inputfield row

### DIFF
--- a/src/playercards/customizable/FriendsinLowPlacesUpgradeSheet.ttslua
+++ b/src/playercards/customizable/FriendsinLowPlacesUpgradeSheet.ttslua
@@ -25,16 +25,16 @@ customizations = {
     checkboxes = {
       posZ = -0.44,
       count = 2,
+    },
+    textField = {
+      position = { 0.6295, 0.25, -0.44 },
+      width = 290
     }
   },
   [4] = {
     checkboxes = {
       posZ = -0.05,
       count = 2,
-    },
-    textField = {
-      position = { 0.6295, 0.25, -0.44 },
-      width = 290
     }
   },
   [5] = {


### PR DESCRIPTION
Inputfield was falsely added as "4th row" and was thus not getting the data from ArkhamDB