### PR TITLE
Token Arranger: create percetange labels onLoad if temp tokens present

### DIFF
--- a/src/accessories/TokenArranger.ttslua
+++ b/src/accessories/TokenArranger.ttslua
@@ -69,7 +69,13 @@ function onLoad(saveState)
   end
 
   createButtonsAndInputs()
-
+  
+  -- maybe trigger layout() to draw percentage buttons
+  local objList = getObjectsWithTag("tempToken")
+  if #objList > 0 then
+    Wait.time(layout, 0.5)
+  end
+  
   -- context menu items
   self.addContextMenuItem("Load default values", function()
     loadDefaultValues()


### PR DESCRIPTION
Previously, these labels would not be present after saving & loading until the first update is triggered.