### PR TITLE
Option Panel: moved descriptions to tooltips

### DIFF
--- a/xml/Global/OptionPanel.xml
+++ b/xml/Global/OptionPanel.xml
@@ -115,8 +115,8 @@
           </Row>
 
           <!-- Option: card language -->
-          <Row class="option-text"
-            tooltip="Downloading a campaign or importing a deck will use&#xA;this language for cards (NOT FUNCTIONAL YET!).">
+          <!-- disabled until we have the backend in place
+          <Row class="option-text" tooltip="Downloading a campaign or importing a deck will use&#xA;this language for cards (NOT FUNCTIONAL YET!).">
             <Cell class="option-dropdowntext">
               <Panel class="option-wrapper">
                 <Text class="option-header">Card language</Text>
@@ -124,8 +124,7 @@
             </Cell>
             <Cell class="option-dropdown">
               <Panel class="dropdown-wrapper">
-                <Dropdown id="cardLanguage"
-                  onValueChanged="languageSelected(selectedIndex)">
+                <Dropdown id="cardLanguage" onValueChanged="languageSelected(selectedIndex)">
                   <Option>简体中文</Option>
                   <Option>繁體中文</Option>
                   <Option>Deutsch</Option>
@@ -136,7 +135,7 @@
                 </Dropdown>
               </Panel>
             </Cell>
-          </Row>
+          </Row> -->
 
           <!-- Option: play area snap tags -->
           <Row class="option-text"

--- a/xml/Global/OptionPanel.xml
+++ b/xml/Global/OptionPanel.xml
@@ -38,7 +38,9 @@
 
   <!-- options -->
   <Row class="option-text"
-    preferredHeight="70"/>
+    preferredHeight="50"
+    tooltipPosition="Left"
+    tooltipBackgroundColor="rgba(0,0,0,1)"/>
   <Cell class="option-text"
     color="#333333"
     columnSpan="2"/>
@@ -50,14 +52,13 @@
   <Cell class="option-dropdown"
     color="#333333"
     columnSpan="2"/>
-  <VerticalLayout class="text-column"
-    padding="10 0 0 0"
-    spacing="5"/>
+  <Panel class="option-wrapper"
+    padding="10 0 0 0"/>
   <Text class="option-header"
-    fontSize="20"
+    fontSize="22"
     font="font_teutonic-arkham"/>
-  <Text class="description"
-    fontSize="12"/>
+  <Panel class="dropdown-wrapper"
+    padding="0 17 3 3"/>
 
   <!-- buttons at the bottom -->
   <Button class="bottomButtons"
@@ -101,7 +102,7 @@
         raycastTarget="true">
         <TableLayout columnWidths="0 100 75"
           autoCalculateHeight="1"
-          cellPadding="10 5 5 5">
+          cellPadding="10 10 5 5">
 
           <!-- Group: general settings -->
           <Row class="group-header">
@@ -114,15 +115,15 @@
           </Row>
 
           <!-- Option: card language -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Downloading a campaign or importing a deck will use&#xA;this language for cards (NOT FUNCTIONAL YET!).">
             <Cell class="option-dropdowntext">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Card language</Text>
-                <Text class="description">Downloading a campaign or importing a deck will use this language for cards (NOT FUNCTIONAL YET!).</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-dropdown">
-              <Panel padding="0 17 13 13">
+              <Panel class="dropdown-wrapper">
                 <Dropdown id="cardLanguage"
                   onValueChanged="languageSelected(selectedIndex)">
                   <Option>简体中文</Option>
@@ -138,12 +139,12 @@
           </Row>
 
           <!-- Option: play area snap tags -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Only cards with the tag 'Location' will snap (official cards are supported by default).&#xA;Disable this if you are having issues with custom content.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Enable snap tags for play area</Text>
-                <Text class="description">Only cards with the tag "Location" will snap (official cards are supported by default). Disable this if you are having issues with custom content.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="playAreaSnapTags"
@@ -152,12 +153,12 @@
           </Row>
 
           <!-- Option: splash scenario name on setup -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Fade in the name of the scenario for 2 seconds&#xA;when placing down a scenario.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Show scenario title on setup</Text>
-                <Text class="description">Fade in the name of the scenario for 2 seconds when placing down a scenario.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showTitleSplash"
@@ -176,12 +177,12 @@
           </Row>
 
           <!-- Option: enable snap tags -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Only cards with the tag 'Asset' will snap (official cards are supported by default).&#xA;Disable this if you are having issues with custom content.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Enable snap tags</Text>
-                <Text class="description">Only cards with the tag "Asset" will snap (official cards are supported by default). Disable this if you are having issues with custom content.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="useSnapTags"
@@ -190,12 +191,12 @@
           </Row>
 
           <!-- Option: show draw 1 button -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Displays a button below the 'Upkeep' button that draws a card from your deck.&#xA;Useful for multi-handed solo play.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Show "Draw 1" button</Text>
-                <Text class="description">Displays a button below the "Upkeep" button that draws a card from your deck. Useful for multi-handed solo play.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showDrawButton"
@@ -204,12 +205,12 @@
           </Row>
 
           <!-- Option: use clickable clue-counters -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Instead of automatically counting clues in the respective area on your playermat,&#xA;this displays a clickable counter for clues.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Use clickable clue counters</Text>
-                <Text class="description">Instead of automatically counting clues in the respective area on your playermat, this displays a clickable counter for clues.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="useClueClickers"
@@ -218,15 +219,15 @@
           </Row>
 
           <!-- Option: use clickable resource counters -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="This enables spawning of clickable resource tokens for player cards.&#xA;(Chef's Selection = assets with 0 uses)">
             <Cell class="option-dropdowntext">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Use clickable resource tokens</Text>
-                <Text class="description">This enables spawning of clickable resource tokens for player cards. (Chef's Selection = assets with 0 uses)</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-dropdown">
-              <Panel padding="0 17 13 13">
+              <Panel class="dropdown-wrapper">
                 <Dropdown id="useResourceCounters"
                   onValueChanged="resourceCounterSelected(selectedIndex)">
                   <Option>Enabled</Option>
@@ -248,12 +249,12 @@
           </Row>
 
           <!-- Option: show attachment helper -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Provides a card-sized bag for cards that are attached to other cards&#xA;(e.g. Backpack).">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Attachment Helper</Text>
-                <Text class="description">Provides a card-sized bag for cards that are attached to other cards (e.g. Backpack).</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showAttachmentHelper"
@@ -262,12 +263,12 @@
           </Row>
 
           <!-- Option: show clean up helper -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Useful for campaign-play:&#xA;It resets play areas to allow continuous gameplay in the same savegame.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Clean Up Helper</Text>
-                <Text class="description">Useful for campaign-play: It resets play areas to allow continuous gameplay in the same savegame.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showCleanUpHelper"
@@ -276,12 +277,12 @@
           </Row>
 
           <!-- Option: show custom playmat images -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Places a tool that displays custom playmat images&#xA;for all cycles in a gallery-like fashion.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Custom Playmat Images</Text>
-                <Text class="description">Places a tool that displays custom playmat images for all cycles in a gallery-like fashion.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showCustomPlaymatImages"
@@ -290,12 +291,12 @@
           </Row>
 
           <!-- Option: show CYOA campaign guides -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Displays in a 'Choose Your Own Adventure'&#xA;style redesigned campaign guides.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">CYOA Campaign Guides</Text>
-                <Text class="description">Displays in a "Choose Your Own Adventure" style redesigned campaign guides.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showCYOA"
@@ -304,12 +305,12 @@
           </Row>
 
           <!-- Option: show displacement tool -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="This allows moving all objects on the main playmat&#xA;in a chosen direction.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Displacement Tool</Text>
-                <Text class="description">This allows moving all objects on the main playmat in a chosen direction.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showDisplacementTool"
@@ -318,12 +319,12 @@
           </Row>
 
           <!-- Option: show hand helper -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Never count your hand cards again! This tool does that for you&#xA;and additionally enables easy discarding of random cards.">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Hand Helper</Text>
-                <Text class="description">Never count your hand cards again! This tool does that for you and additionally enables easy discarding of random cards.</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showHandHelper"
@@ -332,12 +333,12 @@
           </Row>
 
           <!-- Option: show search assistant -->
-          <Row class="option-text">
+          <Row class="option-text"
+            tooltip="Quickly search 3, 6, 9 or the top X&#xA;cards of your deck!">
             <Cell class="option-text">
-              <VerticalLayout class="text-column">
+              <Panel class="option-wrapper">
                 <Text class="option-header">Search Assistant</Text>
-                <Text class="description">Quickly search 3, 6, 9 or the top X cards of your deck!</Text>
-              </VerticalLayout>
+              </Panel>
             </Cell>
             <Cell class="option-button">
               <Toggle id="showSearchAssistant"


### PR DESCRIPTION
This is easier on the eyes since it doesn't put so much text on the user at once:

![image](https://github.com/argonui/SCED/assets/97286811/74e10704-b9ea-47a7-b42f-e129c9ccc1d0)