### PR TITLE
fixed taboo card width

### DIFF
--- a/objects/AllPlayerCards.15bb07/35WinchesterTaboo.22d821.json
+++ b/objects/AllPlayerCards.15bb07/35WinchesterTaboo.22d821.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/AWatchfulPeace3Taboo.25b73a.json
+++ b/objects/AllPlayerCards.15bb07/AWatchfulPeace3Taboo.25b73a.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/AceintheHole3Taboo.e92f21.json
+++ b/objects/AllPlayerCards.15bb07/AceintheHole3Taboo.e92f21.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/AllIn5Taboo.5db655.json
+++ b/objects/AllPlayerCards.15bb07/AllIn5Taboo.5db655.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/AncientCovenant2Taboo.e01cc7.json
+++ b/objects/AllPlayerCards.15bb07/AncientCovenant2Taboo.e01cc7.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Banish1Taboo.1a3b10.json
+++ b/objects/AllPlayerCards.15bb07/Banish1Taboo.1a3b10.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/BlackMarket2Taboo.4d085b.json
+++ b/objects/AllPlayerCards.15bb07/BlackMarket2Taboo.4d085b.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/BurnAfterReading1Taboo.2ced40.json
+++ b/objects/AllPlayerCards.15bb07/BurnAfterReading1Taboo.2ced40.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Counterspell2Taboo.9c9177.json
+++ b/objects/AllPlayerCards.15bb07/Counterspell2Taboo.9c9177.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/CrisisofIdentityTaboo.17cab7.json
+++ b/objects/AllPlayerCards.15bb07/CrisisofIdentityTaboo.17cab7.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/CyclopeanHammer5Taboo.42336b.json
+++ b/objects/AllPlayerCards.15bb07/CyclopeanHammer5Taboo.42336b.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DaredevilTaboo.cd1e54.json
+++ b/objects/AllPlayerCards.15bb07/DaredevilTaboo.cd1e54.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DarkProphecyTaboo.448db7.json
+++ b/objects/AllPlayerCards.15bb07/DarkProphecyTaboo.448db7.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DavidRenfieldTaboo.4c7c54.json
+++ b/objects/AllPlayerCards.15bb07/DavidRenfieldTaboo.4c7c54.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DelveTooDeepTaboo.ca5603.json
+++ b/objects/AllPlayerCards.15bb07/DelveTooDeepTaboo.ca5603.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DoubleorNothingTaboo.9aa0de.json
+++ b/objects/AllPlayerCards.15bb07/DoubleorNothingTaboo.9aa0de.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DrMilanChristopherTaboo.2a6fd1.json
+++ b/objects/AllPlayerCards.15bb07/DrMilanChristopherTaboo.2a6fd1.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/DrawingThinTaboo.49361a.json
+++ b/objects/AllPlayerCards.15bb07/DrawingThinTaboo.49361a.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ElusiveTaboo.3c046a.json
+++ b/objects/AllPlayerCards.15bb07/ElusiveTaboo.3c046a.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/EonChart1Taboo.389610.json
+++ b/objects/AllPlayerCards.15bb07/EonChart1Taboo.389610.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/EonChart4Taboo.41c449.json
+++ b/objects/AllPlayerCards.15bb07/EonChart4Taboo.41c449.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Eucatastrophe3Taboo.8be540.json
+++ b/objects/AllPlayerCards.15bb07/Eucatastrophe3Taboo.8be540.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Flamethrower5Taboo.62ceb5.json
+++ b/objects/AllPlayerCards.15bb07/Flamethrower5Taboo.62ceb5.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/FluteoftheOuterGods4Taboo.453fd1.json
+++ b/objects/AllPlayerCards.15bb07/FluteoftheOuterGods4Taboo.453fd1.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/GearedUpTaboo.83af5e.json
+++ b/objects/AllPlayerCards.15bb07/GearedUpTaboo.83af5e.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/GenBeauregard3Taboo.d300bf.json
+++ b/objects/AllPlayerCards.15bb07/GenBeauregard3Taboo.d300bf.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Hallow3Taboo.175810.json
+++ b/objects/AllPlayerCards.15bb07/Hallow3Taboo.175810.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/HypnoticGazeTaboo.47d782.json
+++ b/objects/AllPlayerCards.15bb07/HypnoticGazeTaboo.47d782.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/InterrogateTaboo.a6726e.json
+++ b/objects/AllPlayerCards.15bb07/InterrogateTaboo.a6726e.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/JeremiahKirbyTaboo.a03cd7.json
+++ b/objects/AllPlayerCards.15bb07/JeremiahKirbyTaboo.a03cd7.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/JewelofAureolus3Taboo.5f4d1c.json
+++ b/objects/AllPlayerCards.15bb07/JewelofAureolus3Taboo.5f4d1c.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/KeyofYs5Taboo.9451ee.json
+++ b/objects/AllPlayerCards.15bb07/KeyofYs5Taboo.9451ee.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/KnowledgeisPowerTaboo.0dd658.json
+++ b/objects/AllPlayerCards.15bb07/KnowledgeisPowerTaboo.0dd658.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/MrRookTaboo.522279.json
+++ b/objects/AllPlayerCards.15bb07/MrRookTaboo.522279.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Pathfinder1Taboo.305e37.json
+++ b/objects/AllPlayerCards.15bb07/Pathfinder1Taboo.305e37.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/PendantoftheQueenTaboo.02b9b9.json
+++ b/objects/AllPlayerCards.15bb07/PendantoftheQueenTaboo.02b9b9.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/PersuasionTaboo.821d99.json
+++ b/objects/AllPlayerCards.15bb07/PersuasionTaboo.821d99.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/PowerWordTaboo.dc1962.json
+++ b/objects/AllPlayerCards.15bb07/PowerWordTaboo.dc1962.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ProphesiaeProfana5Taboo.957c32.json
+++ b/objects/AllPlayerCards.15bb07/ProphesiaeProfana5Taboo.957c32.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/QuickThinkingTaboo.4a49ea.json
+++ b/objects/AllPlayerCards.15bb07/QuickThinkingTaboo.4a49ea.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ResearchNotesTaboo.085c08.json
+++ b/objects/AllPlayerCards.15bb07/ResearchNotesTaboo.085c08.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/RiteofEquilibrium5Taboo.2286b4.json
+++ b/objects/AllPlayerCards.15bb07/RiteofEquilibrium5Taboo.2286b4.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/RitualCandlesTaboo.7dc746.json
+++ b/objects/AllPlayerCards.15bb07/RitualCandlesTaboo.7dc746.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/RunicAxeTaboo.3e3b99.json
+++ b/objects/AllPlayerCards.15bb07/RunicAxeTaboo.3e3b99.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ScrollofSecrets3Taboo.84a7df.json
+++ b/objects/AllPlayerCards.15bb07/ScrollofSecrets3Taboo.84a7df.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ScrollofSecrets3Taboo.c127f1.json
+++ b/objects/AllPlayerCards.15bb07/ScrollofSecrets3Taboo.c127f1.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ScrollofSecretsTaboo.b383b8.json
+++ b/objects/AllPlayerCards.15bb07/ScrollofSecretsTaboo.b383b8.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/Sharpshooter3Taboo.77b1e7.json
+++ b/objects/AllPlayerCards.15bb07/Sharpshooter3Taboo.77b1e7.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ShedaLightTaboo.44292c.json
+++ b/objects/AllPlayerCards.15bb07/ShedaLightTaboo.44292c.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/SignumCrucis2Taboo.750b7a.json
+++ b/objects/AllPlayerCards.15bb07/SignumCrucis2Taboo.750b7a.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/SleightofHandTaboo.0d84b2.json
+++ b/objects/AllPlayerCards.15bb07/SleightofHandTaboo.0d84b2.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/SpringfieldM19034Taboo.23f8ec.json
+++ b/objects/AllPlayerCards.15bb07/SpringfieldM19034Taboo.23f8ec.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/StrangeSolution4Taboo.1be7f1.json
+++ b/objects/AllPlayerCards.15bb07/StrangeSolution4Taboo.1be7f1.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/TelescopicSight3Taboo.43cb9f.json
+++ b/objects/AllPlayerCards.15bb07/TelescopicSight3Taboo.43cb9f.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/TheNecronomicon5Taboo.4b7a8e.json
+++ b/objects/AllPlayerCards.15bb07/TheNecronomicon5Taboo.4b7a8e.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/ThreeAces1Taboo.baa553.json
+++ b/objects/AllPlayerCards.15bb07/ThreeAces1Taboo.baa553.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,

--- a/objects/AllPlayerCards.15bb07/VoiceofRaTaboo.b06042.json
+++ b/objects/AllPlayerCards.15bb07/VoiceofRaTaboo.b06042.json
@@ -15,7 +15,7 @@
     "3": {
       "BackIsHidden": true,
       "BackURL": "https://i.imgur.com/EcbhVuh.jpg/",
-      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2021607899142908284/92DF67E4310BCDFAD6C4BB12D31155DBF6B07A25/",
+      "FaceURL": "http://cloud-3.steamusercontent.com/ugc/2115061845812962486/A68B8BF7E4862F21369DAC4A37D813EC664EAC34/",
       "NumHeight": 6,
       "NumWidth": 10,
       "Type": 0,


### PR DESCRIPTION
The image for the latest taboo cards was sligthly distorted, resulting in cards with the wrong width:
![image](https://github.com/argonui/SCED/assets/97286811/f9b1293b-53b6-4ab1-b453-548c4ec9dcd3)

This corrects the aspect ratio of the decksheet.