### PR TITLE
updated zones file to match snap points

### DIFF
--- a/src/playermat/Zones.ttslua
+++ b/src/playermat/Zones.ttslua
@@ -24,23 +24,23 @@ do
   local Zones = { }
 
   local commonZones           = {}
-  commonZones["Investigator"] = { -1.17702, 0, 0.00209 }
-  commonZones["Deck"]         = { -1.822724, 0, -0.02940192 }
-  commonZones["Discard"]      = { -1.822451, 0, 0.6092291 }
-  commonZones["Ally"]         = { -0.6157398, 0, 0.02435675 }
-  commonZones["Body"]         = { -0.6306521, 0, 0.553170 }
-  commonZones["Hand1"]        = { 0.2155387, 0, 0.04257287 }
-  commonZones["Hand2"]        = { -0.1803701, 0, 0.03745948 }
-  commonZones["Arcane1"]      = { 0.2124223, 0, 0.5596902 }
-  commonZones["Arcane2"]      = { -0.1711275, 0, 0.5567944 }
-  commonZones["Tarot"]        = { 0.6016169, 0, 0.03273106 }
-  commonZones["Accessory"]    = { 0.6049907, 0, 0.5546234 }
-  commonZones["BlankTop"]     = { 1.758446, 0, 0.03965336 }
-  commonZones["BlankBottom"]  = { 1.754469, 0, 0.5634764 }
-  commonZones["Threat1"]      = { -0.9116555, 0, -0.6446251 }
-  commonZones["Threat2"]      = { -0.4544126, 0, -0.6428719 }
-  commonZones["Threat3"]      = { 0.002246313, 0, -0.6430681 }
-  commonZones["Threat4"]      = { 0.4590618, 0, -0.6432732 }
+  commonZones["Investigator"] = { -1.177, 0, 0.002 }
+  commonZones["Deck"]         = { -1.82, 0, 0 }
+  commonZones["Discard"]      = { -1.82, 0, 0.61 }
+  commonZones["Ally"]         = { -0.615, 0, 0.024 }
+  commonZones["Body"]         = { -0.630, 0, 0.553 }
+  commonZones["Hand1"]        = { 0.215, 0, 0.042 }
+  commonZones["Hand2"]        = { -0.180, 0, 0.037 }
+  commonZones["Arcane1"]      = { 0.212, 0, 0.559 }
+  commonZones["Arcane2"]      = { -0.171, 0, 0.557 }
+  commonZones["Tarot"]        = { 0.602, 0, 0.033 }
+  commonZones["Accessory"]    = { 0.602, 0, 0.555 }
+  commonZones["BlankTop"]     = { 1.758, 0, 0.040 }
+  commonZones["BlankBottom"]  = { 1.754, 0, 0.563 }
+  commonZones["Threat1"]      = { -0.911, 0, -0.625 }
+  commonZones["Threat2"]      = { -0.454, 0, -0.625 }
+  commonZones["Threat3"]      = { 0.002, 0, -0.625 }
+  commonZones["Threat4"]      = { 0.459, 0, -0.625 }
 
   local zoneData                      = {}
   zoneData["White"]                   = {}
@@ -62,14 +62,14 @@ do
   zoneData["White"]["Threat3"]        = commonZones["Threat3"]
   zoneData["White"]["Threat4"]        = commonZones["Threat4"]
   zoneData["White"]["Minicard"]       = { -1, 0, -1.45 }
-  zoneData["White"]["SetAside1"]      = { 2.345893, 0, -0.520315 }
-  zoneData["White"]["SetAside2"]      = { 2.345893, 0, 0.042552 }
-  zoneData["White"]["SetAside3"]      = { 2.345893, 0, 0.605419 }
-  zoneData["White"]["UnderSetAside3"] = { 2.495893, 0, 0.805419 }
-  zoneData["White"]["SetAside4"]      = { 2.775893, 0, -0.520315 }
-  zoneData["White"]["SetAside5"]      = { 2.775893, 0, 0.042552 }
-  zoneData["White"]["SetAside6"]      = { 2.775893, 0, 0.605419 }
-  zoneData["White"]["UnderSetAside6"] = { 2.925893, 0, 0.805419 }
+  zoneData["White"]["SetAside1"]      = { 2.35, 0, -0.520 }
+  zoneData["White"]["SetAside2"]      = { 2.35, 0, 0.042 }
+  zoneData["White"]["SetAside3"]      = { 2.35, 0, 0.605 }
+  zoneData["White"]["UnderSetAside3"] = { 2.50, 0, 0.805 }
+  zoneData["White"]["SetAside4"]      = { 2.78, 0, -0.520 }
+  zoneData["White"]["SetAside5"]      = { 2.78, 0, 0.042 }
+  zoneData["White"]["SetAside6"]      = { 2.78, 0, 0.605 }
+  zoneData["White"]["UnderSetAside6"] = { 2.93, 0, 0.805 }
 
   zoneData["Orange"]                   = {}
   zoneData["Orange"]["Investigator"]   = commonZones["Investigator"]
@@ -90,14 +90,14 @@ do
   zoneData["Orange"]["Threat3"]        = commonZones["Threat3"]
   zoneData["Orange"]["Threat4"]        = commonZones["Threat4"]
   zoneData["Orange"]["Minicard"]       = { 1, 0, -1.45 }
-  zoneData["Orange"]["SetAside1"]      = { -2.350362, 0, -0.520315 }
-  zoneData["Orange"]["SetAside2"]      = { -2.350362, 0, 0.042552 }
-  zoneData["Orange"]["SetAside3"]      = { -2.350362, 0, 0.605419 }
-  zoneData["Orange"]["UnderSetAside3"] = { -2.500362, 0, 0.80419 }
-  zoneData["Orange"]["SetAside4"]      = { -2.7803627, 0, -0.520315 }
-  zoneData["Orange"]["SetAside5"]      = { -2.7803627, 0, 0.042552 }
-  zoneData["Orange"]["SetAside6"]      = { -2.7803627, 0, 0.605419 }
-  zoneData["Orange"]["UnderSetAside6"] = { -2.9303627, 0, 0.80419 }
+  zoneData["Orange"]["SetAside1"]      = { -2.35, 0, -0.520 }
+  zoneData["Orange"]["SetAside2"]      = { -2.35, 0, 0.042}
+  zoneData["Orange"]["SetAside3"]      = { -2.35, 0, 0.605 }
+  zoneData["Orange"]["UnderSetAside3"] = { -2.50, 0, 0.805 }
+  zoneData["Orange"]["SetAside4"]      = { -2.78, 0, -0.520 }
+  zoneData["Orange"]["SetAside5"]      = { -2.78, 0, 0.042 }
+  zoneData["Orange"]["SetAside6"]      = { -2.78, 0, 0.605 }
+  zoneData["Orange"]["UnderSetAside6"] = { -2.93, 0, 0.805 }
 
   -- Green positions are the same as White and Red the same as Orange
   zoneData["Red"] = zoneData["Orange"]


### PR DESCRIPTION
Main reason for this is that the zone data for the deck didn't match the snap point and thus the deck importer would place decks with an offset