### PR TITLE
Bugfix for Family Inheritance: stopped overriding resources

### DIFF
--- a/src/playercards/cards/FamilyInheritance.ttslua
+++ b/src/playercards/cards/FamilyInheritance.ttslua
@@ -1,5 +1,5 @@
-local tokenManager = require("core/token/TokenManager")
 local playmatApi = require("playermat/PlaymatApi")
+local tokenManager = require("core/token/TokenManager")
 
 local clickableResourceCounter = nil
 local foundTokens = 0
@@ -47,7 +47,7 @@ end
 function takeAll(playerColor)
   searchSelf()
   local matColor = playmatApi.getMatColorByPosition(self.getPosition())
-  playmatApi.updateCounter(matColor, "ResourceCounter", foundTokens)
+  playmatApi.updateCounter(matColor, "ResourceCounter", _, foundTokens)
 
   if clickableResourceCounter then
     clickableResourceCounter.call("updateVal", 0)


### PR DESCRIPTION
Previously, the call to the playmatApi had the modifier at the wrong position and thus that would be used as new value instead of modifier.