### PR TITLE
Split the custom content from the "download all" button into separate bags

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -751,9 +751,9 @@ function coroutineDownloadAll()
     {
       "Name": "Bag",
       "Transform": {
-        "posX": -39.5,
+        "posX": {{POSX}},
         "posY": 2,
-        "posZ": -87,
+        "posZ": -95,
         "rotX": 0,
         "rotY": 270,
         "rotZ": 0,
@@ -761,20 +761,21 @@ function coroutineDownloadAll()
         "scaleY": 1.0,
         "scaleZ": 1.0
       },
-      "Nickname": "All Downloadable Content",
+      "Nickname": "{{NICKNAME}}",
       "Bag": {
         "Order": 0
       },
       "ContainedObjects": [
   ]]
-         
-  local contained = ""
+
+  local posx = -45.0
   local downloadedItems = 0
   local skippedItems = 0
 
   -- loop through the library to add content
   for contentType, objectList in pairs(library) do
     broadcastToAll("Downloading " .. contentType .. "...")
+    local contained = ""
     for _, params in ipairs(objectList) do
       local request = WebRequest.get(SOURCE_REPO .. '/' .. params.url)
       local start = os.time()
@@ -791,10 +792,13 @@ function coroutineDownloadAll()
         coroutine.yield(0)
       end
     end
+    local JSONCopy = JSON
+    JSONCopy = JSONCopy .. contained .. "]}"
+    JSONCopy = JSONCopy:gsub("{{POSX}}", posx)
+    JSONCopy = JSONCopy:gsub("{{NICKNAME}}", contentType)
+    spawnObjectJSON({json = JSONCopy})
+    posx = posx + 3
   end
-
-  JSON = JSON .. contained .. "]}"
-  spawnObjectJSON({json = JSON})
 
   broadcastToAll(downloadedItems .. " objects downloaded.", "Green")
   broadcastToAll(skippedItems .. " objects had a time-out / error.", "Orange")


### PR DESCRIPTION
One bag is created for each contentType, in a column on the right side of the table