### PR TITLE
Added missing tag to imported decks

### DIFF
--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -154,12 +154,18 @@ function deckSpawned(deck, playerColor)
   local player = Player[playmatApi.getPlayerColor(playerColor)]
   local handPos = player.getHandTransform(1).position -- Only one hand zone per player
   local deckCards = deck.getData().ContainedObjects
+
   -- Process in reverse order so taking cards out doesn't upset the indexing
   for i = #deckCards, 1, -1 do
     local cardMetadata = JSON.decode(deckCards[i].GMNotes) or { }
     if cardMetadata.startsInHand then
       deck.takeObject({ index = i - 1, position = handPos, flip = true, smooth = true})
     end
+  end
+
+  -- add the "PlayerCard" tag to the deck
+  if deck and deck.type == "Deck" and deck.getQuantity() > 1 then
+    deck.addTag("PlayerCard")
   end
 end
 


### PR DESCRIPTION
Manually created decks will inherit the tag of the contained cards if they all share a tag. Thus, freshly imported decks should always have the "PlayerCard" tag. This fixes that. (For example relevant for discard hotkey / buttons)