### PR TITLE
added discard top card of deck hotkey

### DIFF
--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -8,6 +8,7 @@ function onLoad()
   addHotkey("Add Doom to Agenda", addDoomToAgenda)
   addHotkey("Bless/Curse Status", showBlessCurseStatus)
   addHotkey("Discard Object", discardObject)
+  addHotkey("Discard top card", discardTopDeck)
   addHotkey("Move card to Victory Display", moveCardToVictoryDisplay)
   addHotkey("Remove a use", removeOneUse)
   addHotkey("Take clue from location", takeClueFromLocation)
@@ -78,6 +79,23 @@ function discardObject(playerColor, hoveredObject)
   local discardForMatColor = getColorToDiscardFor(hoveredObject, playerColor)
   playmatApi.discardListOfObjects(discardForMatColor, discardTheseObjects)
 end
+
+-- discard the top card of hovered deck, calling discardObject function
+function discardTopDeck(playerColor, hoveredObject)
+  -- only continue if an unlocked card or deck was hovered
+  if hoveredObject == nil
+      or (hoveredObject.type ~= "Card" and hoveredObject.type ~= "Deck")
+      or hoveredObject.locked then
+    broadcastToColor("Hover a deck/card and try again.", playerColor, "Yellow")
+    return
+  end
+  if hoveredObject.type == "Deck" then
+    takenCard = hoveredObject.takeObject({index = 0})
+  else
+    takenCard = hoveredObject
+  end
+  Wait.frames(function() discardObject(playerColor, takenCard) end, 1)
+end 
 
 -- helper function to get the player to trigger the discard function for
 function getColorToDiscardFor(hoveredObject, playerColor)


### PR DESCRIPTION
Added a hotkey to call the discardObject function on the top card of a deck.

Useful for
- Dunwich treacheries (for player deck)
- Circle Undone (for encounter deck)
- "Discard cards from the encounter deck until..." effects (every campaign)
- Various token effects in EOTE & other campaigns
- Finding an enemy for Zoey's weakness
- etc.