### PR TITLE
Rehosted obj file of return to boxes from pastebin

### DIFF
--- a/objects/OfficialStandaloneChallengeScenarios.0ef5c8.json
+++ b/objects/OfficialStandaloneChallengeScenarios.0ef5c8.json
@@ -34,7 +34,7 @@
     },
     "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/1758068588410895356/0B5F0CCD29DEC12514840D7B9CD2329B635A79A6/",
     "MaterialIndex": 3,
-    "MeshURL": "http://pastebin.com/raw.php?i=uWAmuNZ2",
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/",
     "NormalURL": "",
     "TypeIndex": 6
   },

--- a/objects/ReturntoTheCircleUndone.757324.json
+++ b/objects/ReturntoTheCircleUndone.757324.json
@@ -27,7 +27,7 @@
     },
     "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/1697277388086852852/6FD56D74FDDDA5626A3B72E788993EC651AD25E1/",
     "MaterialIndex": 3,
-    "MeshURL": "http://pastebin.com/raw.php?i=uWAmuNZ2",
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/",
     "NormalURL": "",
     "TypeIndex": 0
   },

--- a/objects/ReturntoTheDunwichLegacy.ce9130.json
+++ b/objects/ReturntoTheDunwichLegacy.ce9130.json
@@ -27,7 +27,7 @@
     },
     "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/762723517667592476/36D86649503A49A36AA97B7B72C6150E4C2BE333/",
     "MaterialIndex": 3,
-    "MeshURL": "http://pastebin.com/raw.php?i=uWAmuNZ2",
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/",
     "NormalURL": "",
     "TypeIndex": 0
   },

--- a/objects/ReturntoTheForgottenAge.479ff3.json
+++ b/objects/ReturntoTheForgottenAge.479ff3.json
@@ -27,7 +27,7 @@
     },
     "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/1474319121423613924/490D56D20C6AE0547D67D942513396E8D0584A4A/",
     "MaterialIndex": 3,
-    "MeshURL": "http://pastebin.com/raw.php?i=uWAmuNZ2",
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/",
     "NormalURL": "",
     "TypeIndex": 0
   },

--- a/objects/ReturntoThePathtoCarcosa.e9889a.json
+++ b/objects/ReturntoThePathtoCarcosa.e9889a.json
@@ -27,7 +27,7 @@
     },
     "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/762723517667556656/9638E8CE7F209B50634B202C9EF4B0BDB4993BBB/",
     "MaterialIndex": 3,
-    "MeshURL": "http://pastebin.com/raw.php?i=uWAmuNZ2",
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/",
     "NormalURL": "",
     "TypeIndex": 0
   },

--- a/objects/ReturntotheNightoftheZealot.56270d.json
+++ b/objects/ReturntotheNightoftheZealot.56270d.json
@@ -27,7 +27,7 @@
     },
     "DiffuseURL": "http://cloud-3.steamusercontent.com/ugc/762723517667598054/18C06F0F20D9D4651E6736FB609E2D41F4D1964E/",
     "MaterialIndex": 3,
-    "MeshURL": "http://pastebin.com/raw.php?i=uWAmuNZ2",
+    "MeshURL": "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/",
     "NormalURL": "",
     "TypeIndex": 0
   },

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -834,7 +834,7 @@ function onClick_spawnPlaceholder()
   local meshTable = {
     big = "https://raw.githubusercontent.com/RobMayer/TTSLibrary/master/advboxes/core_h_MSH.obj",
     small = "https://raw.githubusercontent.com/RobMayer/TTSLibrary/master/advboxes/tuckbox_h_MSH.obj",
-    wide = "http://pastebin.com/raw.php?i=uWAmuNZ2"
+    wide = "http://cloud-3.steamusercontent.com/ugc/2278324073260846176/33EFCAF30567F8756F665BE5A2A6502E9C61C7F7/"
   }
 
   local scaleTable = {


### PR DESCRIPTION
Since pastebin is an awful file host (and blocked in some eastern countries), this moves the obj file to the steam cloud