### PR TITLE
searchable area for doom counters matches playmat size

### DIFF
--- a/src/core/DoomInPlayCounter.ttslua
+++ b/src/core/DoomInPlayCounter.ttslua
@@ -6,7 +6,7 @@ local doomURL    = "https://i.imgur.com/EoL7yaZ.png"
 local IGNORE_TAG = "DoomCounter_ignore"
 local TOTAL_PLAY_AREA = {
   upperLeft = {
-    x = -10,
+    x = -9,
     z = -35
   },
   lowerRight = {


### PR DESCRIPTION
top sliver of playmat originally did not count doom tokens