### PR TITLE
Bugfix for Clean Up Helper

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -121,7 +121,6 @@ function cleanUp(_, color)
   blessCurseManagerApi.removeAll(color)
   removeLines()
   discardHands()
-  tokenSpawnTrackerApi.resetAll()
   chaosBagApi.returnChaosTokens()
   chaosBagApi.releaseAllSealedTokens(color)
 
@@ -317,6 +316,8 @@ function tidyPlayerMatCoroutine()
     end
   end
 
+  -- reset spawned data
+  tokenSpawnTrackerApi.resetAll()
   local datahelper = guidReferenceApi.getObjectByOwnerAndType("Mythos", "DataHelper")
   if datahelper then
     datahelper.setTable("SPAWNED_PLAYER_CARD_GUIDS", {})


### PR DESCRIPTION
Moved spawn data resetting to the end, so that locations are removed first and then the data is reset (otherwise some clues will respawn).