### PR TITLE
discard hotkey from hand

### DIFF
--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -120,6 +120,8 @@ function getColorToDiscardFor(hoveredObject, playerColor)
   local discardForMatColor
   if inArea(pos, areaNearPlaymat) then
     return closestMatColor
+  elseif pos.y > 3 then -- discard to closest mat if card is in a hand
+    return closestMatColor
   else
     return playmatApi.getMatColor(playerColor)
   end

--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -120,7 +120,7 @@ function getColorToDiscardFor(hoveredObject, playerColor)
   local discardForMatColor
   if inArea(pos, areaNearPlaymat) then
     return closestMatColor
-  elseif pos.y > 3 then -- discard to closest mat if card is in a hand
+  elseif pos.y > (Player[playerColor].getHandTransform().position.y - (Player[playerColor].getHandTransform().scale.y / 2)) then -- discard to closest mat if card is in a hand
     return closestMatColor
   else
     return playmatApi.getMatColor(playerColor)


### PR DESCRIPTION
uses discard button from closest playermat, not triggering player when card is in a player's hand