### PR TITLE
Re-added collision disabling until onLoad is finished

### DIFF
--- a/config.json
+++ b/config.json
@@ -20,6 +20,7 @@
   "Note": "",
   "ObjectStates_order": [
     "GUIDReferenceHandler.123456",
+    "TokenSpawnTracker.e3ffc9",
     "HandTrigger.5fe087",
     "HandTrigger.be2f17",
     "HandTrigger.0285cc",
@@ -167,7 +168,7 @@
     "PhaseTrackerCache.49922d",
     "PhaseTrackerCache.16832f",
     "PhaseTrackerCache.645841",
-    "TokenSpawnTracker.e3ffc9",
+    
     "TokenSource.124381",
     "GameData.3dbe47",
     "SCEDTour.0e5aa8",

--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -19,6 +19,7 @@ local ENCOUNTER_DISCARD_AREA = {
 local ENCOUNTER_DECK_POS = { x = -3.93, y = 1, z = 5.76 }
 local ENCOUNTER_DISCARD_POSITION = { x = -3.85, y = 1, z = 10.38 }
 local isReshuffling = false
+local collisionEnabled = false
 local currentScenario, useFrontData, tokenData
 local TRASH, DATA_HELPER
 
@@ -31,6 +32,8 @@ function onLoad(saveState)
   end
   TRASH = guidReferenceApi.getObjectByOwnerAndType("Mythos", "Trash")
   DATA_HELPER = guidReferenceApi.getObjectByOwnerAndType("Mythos", "DataHelper")
+
+  Wait.time(function() collisionEnabled = true end, 0.1)
 end
 
 function onSave()
@@ -47,8 +50,14 @@ end
 
 -- TTS event handler.  Handles scenario name event triggering and encounter card token resets.
 function onCollisionEnter(collisionInfo)
+  if not collisionEnabled then return end
+
   local object = collisionInfo.collision_object
 
+  -- early exit for better performance
+  if object.type ~= "Card" then return end
+
+  -- get scenario name and maybe fire followup event
   if object.getName() == "Scenario" then
     local description = object.getDescription()
 
@@ -72,7 +81,7 @@ function onCollisionEnter(collisionInfo)
 
   local localPos = self.positionToLocal(object.getPosition())
   if inArea(localPos, ENCOUNTER_DECK_AREA) or inArea(localPos, ENCOUNTER_DISCARD_AREA) then
-    tokenSpawnTrackerApi.resetTokensSpawned(object.getGUID())
+    Wait.frames(function() tokenSpawnTrackerApi.resetTokensSpawned(object.getGUID()) end, 1)
     removeTokensFromObject(object)
   end
 end

--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -39,13 +39,12 @@ local LOC_LINK_EXCLUDE_SCENARIOS    = {
   ["The Heart of Madness"] = true
 }
 
-local clueData                      = {}
-local spawnedLocationGUIDs          = {}
 local locations                     = {}
 local locationConnections           = {}
 local draggingGuids                 = {}
 local missingData                   = {}
-local locationData, currentScenario, connectionsEnabled
+local collisionEnabled              = false
+local currentScenario, connectionsEnabled
 
 ---------------------------------------------------------
 -- general code
@@ -67,6 +66,8 @@ function onLoad(savedData)
   currentScenario    = loadedData.currentScenario
   connectionColor    = loadedData.connectionColor or { 0.4, 0.4, 0.4, 1 }
   connectionsEnabled = loadedData.connectionsEnabled or true
+
+  Wait.time(function() collisionEnabled = true end, 0.1)
 end
 
 -- Called by Custom Data Helpers to push their location data into the Data Helper.  This adds the
@@ -105,31 +106,30 @@ end
 
 -- TTS event, called for each object that is placed on the playarea
 function onCollisionEnter(collisionInfo)
-  local obj = collisionInfo.collision_object
-  local objType = obj.name
+  if not collisionEnabled then return end
+
+  local object = collisionInfo.collision_object
+
+  if object.type == "Deck" then
+    table.insert(missingData, object)
+  end
 
   -- only continue for cards
-  if objType ~= "Card" and objType ~= "CardCustom" then
-    if objType == "Deck" then
-      table.insert(missingData, obj)
-    end
-    return
-  end
+  if object.type ~= "Card" then return end
 
   -- check if we should spawn clues here and do so according to playercount
-  local card = collisionInfo.collision_object
-  if shouldSpawnTokens(card) then
-    tokenManager.spawnForCard(card)
+  if shouldSpawnTokens(object) then
+    tokenManager.spawnForCard(object)
   end
-  
+
   -- If this card was being dragged, clear the dragging connections.  A multi-drag/drop may send
   -- the dropped card immediately into a deck, so this has to be done here
-  if draggingGuids[card.getGUID()] ~= nil then
-    card.setVectorLines(nil)
-    draggingGuids[card.getGUID()] = nil
+  if draggingGuids[object.getGUID()] ~= nil then
+    object.setVectorLines(nil)
+    draggingGuids[object.getGUID()] = nil
   end
-  
-  maybeTrackLocation(card)
+
+  maybeTrackLocation(object)
 end
 
 function shouldSpawnTokens(card)
@@ -538,11 +538,6 @@ function isInPlayArea(object)
   local c2 = { x = bounds.center.x + bounds.size.x / 2, z = bounds.center.z + bounds.size.z / 2 }
 
   return position.x > c1.x and position.x < c2.x and position.z > c1.z and position.z < c2.z
-end
-
--- Reset the play area's tracking of which cards have had tokens spawned.
-function resetSpawnedCards()
-  spawnedLocationGUIDs = {}
 end
 
 function onScenarioChanged(scenarioName)

--- a/src/core/PlayAreaApi.ttslua
+++ b/src/core/PlayAreaApi.ttslua
@@ -41,11 +41,6 @@ do
     return getPlayArea().call("shiftContentsRight", playerColor)
   end
 
-  -- Reset the play area's tracking of which cards have had tokens spawned.
-  PlayAreaApi.resetSpawnedCards = function()
-    return getPlayArea().call("resetSpawnedCards")
-  end
-
   -- Sets whether location connections should be drawn
   PlayAreaApi.setConnectionDrawState = function(state)
     getPlayArea().call("setConnectionDrawState", state)

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -144,8 +144,8 @@ function onLoad(saveState)
   end
 
   showDrawButton(isDrawButtonVisible)
-  collisionEnabled = true
   math.randomseed(os.time())
+  Wait.time(function() collisionEnabled = true end, 0.1)
 end
 
 ---------------------------------------------------------


### PR DESCRIPTION
- disabled collision for mythos area and play area until onLoad is completed
- removed deprecated functions from play area
- ensured token spawn tracker is loaded early (for good measure)