### PR TITLE
Import Instructions: Bugfixes and QoL

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -302,9 +302,6 @@ do
     -- remove everything before instructions
     local tempStr = string.sub(description, pos)
 
-    -- remove instruction header (and potential copies)
-    tempStr = tempStr:gsub("++SCED import instructions++\n")
-    
     -- parse each line in instructions
     for line in tempStr:gmatch("([^\n]+)") do
       -- remove dashes at the start
@@ -324,7 +321,10 @@ do
         break
       end
 
-      if instructor == "" or (instructor ~= "add:" and instructor ~= "remove:") then break end
+      -- go to the next line if no valid instructor found
+      if instructor ~= "add:" and instructor ~= "remove:" then
+        goto nextLine
+      end
 
       -- remove instructor from line
       line = line:gsub(instructor, "")
@@ -335,7 +335,7 @@ do
           slots[str] = (slots[str] or 0) + 1
         elseif instructor == "remove:" then
           if slots[str] == nil then
-            internal.maybePrint("Tried to remove " .. str .. ", but didn't find card in deck.", playerColor)
+            internal.maybePrint("Tried to remove card ID " .. str .. ", but didn't find card in deck.", playerColor)
           else
             slots[str] = math.max(slots[str] - 1, 0)
 
@@ -349,6 +349,9 @@ do
           end
         end
       end
+
+      -- jump mark at the end of the loop
+      ::nextLine::
     end
   end
 

--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -299,8 +299,11 @@ do
     local pos = string.find(description, "++SCED import instructions++")
     if not pos then return end
 
-    -- remove everything before instructions (including newline)
-    local tempStr = string.sub(description, pos + 30)
+    -- remove everything before instructions
+    local tempStr = string.sub(description, pos)
+
+    -- remove instruction header (and potential copies)
+    tempStr = tempStr:gsub("++SCED import instructions++\n")
     
     -- parse each line in instructions
     for line in tempStr:gmatch("([^\n]+)") do
@@ -333,17 +336,17 @@ do
         elseif instructor == "remove:" then
           if slots[str] == nil then
             internal.maybePrint("Tried to remove " .. str .. ", but didn't find card in deck.", playerColor)
-            break
-          end
-          slots[str] = math.max(slots[str] - 1, 0)
+          else
+            slots[str] = math.max(slots[str] - 1, 0)
 
-          -- fully remove cards that have a quantity of 0
-          if slots[str] == 0 then
-            slots[str] = nil
-          end
+            -- fully remove cards that have a quantity of 0
+            if slots[str] == 0 then
+              slots[str] = nil
 
-          -- also remove related minicard
-          slots[str .. "-m"] = nil
+              -- also remove related minicard
+              slots[str .. "-m"] = nil
+            end
+          end
         end
       end
     end

--- a/src/arkhamdb/InstructionGenerator.ttslua
+++ b/src/arkhamdb/InstructionGenerator.ttslua
@@ -3,6 +3,7 @@ local searchLib = require("util/SearchLib")
 local idList = {}
 
 function onLoad()
+  -- "generate" button
   local buttonParameters          = {}
   buttonParameters.function_owner = self
   buttonParameters.height         = 200
@@ -13,6 +14,7 @@ function onLoad()
   buttonParameters.position       = { 0, 0.06, 1.55 }
   self.createButton(buttonParameters)
 
+  -- "output" text field
   local inputParameters          = {}
   inputParameters.label          = "Click button above"
   inputParameters.input_function = "none"
@@ -24,14 +26,15 @@ function onLoad()
   self.createInput(inputParameters)
 end
 
+-- generates a string for the ArkhamDB deck notes that will instruct the deck import to add the specified cards
 function generate(_, playerColor)
   idList = {}
   for _, obj in ipairs(searchLib.onObject(self, "isCardOrDeck")) do
     if obj.type == "Card" then
-      processCard(JSON.decode(obj.getGMNotes()), obj.getName())
+      processCard(JSON.decode(obj.getGMNotes()), obj.getName(), playerColor)
     elseif obj.type == "Deck" then
       for _, deepObj in ipairs(obj.getData().ContainedObjects) do
-        processCard(JSON.decode(deepObj.GMNotes), deepObj.Nickname)
+        processCard(JSON.decode(deepObj.GMNotes), deepObj.Nickname, playerColor)
       end
     end
   end
@@ -66,11 +69,13 @@ function getIdFromData(metadata)
   end
 end
 
-function processCard(metadata, name)
+function processCard(metadata, name, playerColor)
   if metadata then
     local id = getIdFromData(metadata)
     if id then
       table.insert(idList, {id = id, name = name})
+    else
+      broadcastToColor("Couldn't get ID for " .. name .. ".", playerColor, "Red")
     end
   end
 end

--- a/src/arkhamdb/InstructionGenerator.ttslua
+++ b/src/arkhamdb/InstructionGenerator.ttslua
@@ -31,10 +31,10 @@ function generate(_, playerColor)
   idList = {}
   for _, obj in ipairs(searchLib.onObject(self, "isCardOrDeck")) do
     if obj.type == "Card" then
-      processCard(JSON.decode(obj.getGMNotes()), obj.getName(), playerColor)
+      processCard(obj.getGMNotes(), obj.getName(), playerColor)
     elseif obj.type == "Deck" then
       for _, deepObj in ipairs(obj.getData().ContainedObjects) do
-        processCard(JSON.decode(deepObj.GMNotes), deepObj.Nickname, playerColor)
+        processCard(deepObj.GMNotes, deepObj.Nickname, playerColor)
       end
     end
   end
@@ -69,14 +69,12 @@ function getIdFromData(metadata)
   end
 end
 
-function processCard(metadata, name, playerColor)
-  if metadata then
-    local id = getIdFromData(metadata)
-    if id then
-      table.insert(idList, {id = id, name = name})
-    else
-      broadcastToColor("Couldn't get ID for " .. name .. ".", playerColor, "Red")
-    end
+function processCard(notes, name, playerColor)
+  local id = getIdFromData(JSON.decode(notes) or {})
+  if id then
+    table.insert(idList, {id = id, name = name})
+  else
+    broadcastToColor("Couldn't get ID for " .. name .. ".", playerColor, "Red")
   end
 end
 

--- a/src/arkhamdb/InstructionGenerator.ttslua
+++ b/src/arkhamdb/InstructionGenerator.ttslua
@@ -52,11 +52,9 @@ function generate(_, playerColor)
   -- construct the string (new line for each instruction)
   local description = "++SCED import instructions++"
   for _, entry in ipairs(idList) do
-    description = description .. "\n- add: " .. entry.id .. " (**" .. entry.name .. "**)" .. ", "
+    description = description .. "\n- add: " .. entry.id .. " (**" .. entry.name .. "**)"
   end
-  
-  -- remove last delimiter (last two characters)
-  description = description:sub(1, -3)
+
   self.editInput({index = 0, value = description})
 end
 

--- a/src/arkhamdb/InstructionGenerator.ttslua
+++ b/src/arkhamdb/InstructionGenerator.ttslua
@@ -46,10 +46,10 @@ function generate(_, playerColor)
   -- sort the idList
   table.sort(idList, sortById)
 
-  -- construct the string
-  local description = "++SCED import instructions++\n- add: "
+  -- construct the string (new line for each instruction)
+  local description = "++SCED import instructions++"
   for _, entry in ipairs(idList) do
-    description = description .. entry.id .. " (**" .. entry.name .. "**)" .. ", "
+    description = description .. "\n- add: " .. entry.id .. " (**" .. entry.name .. "**)" .. ", "
   end
   
   -- remove last delimiter (last two characters)


### PR DESCRIPTION
- trying to remove a non-existent card does no longer stop the instructions after that
- removing a card will now only remove the related mini-card if the quantity got to 0
- additional copies of the instruction header will now ignored instead of ending the execution
- instruction generator will now put each instruction on a new line
- instruction generator will now broadcast an error if it couldn't get an ID for a card

TODO:
- increase inputfield size (gonna wait with this until we get a new image for it)