### PR TITLE
Bless Curse Manager: skip tokens from the Token Arranger

### DIFF
--- a/src/chaosbag/BlessCurseManager.ttslua
+++ b/src/chaosbag/BlessCurseManager.ttslua
@@ -74,7 +74,9 @@ function initializeState()
   -- find tokens in the play area
   for _, obj in ipairs(getObjects()) do
     local pos = obj.getPosition()
-    if pos.x > -65 and pos.x < 10 and pos.z > -35 and pos.z < 35 and obj.type == "Tile" then
+    if obj.hasTag("tempToken") then
+      -- skip the tokens from the Token Arranger
+    elseif pos.x > -65 and pos.x < 10 and pos.z > -35 and pos.z < 35 and obj.type == "Tile" then
       if obj.getName() == "Bless" then
         table.insert(tokensTaken.Bless, obj.getGUID())
         numInPlay.Bless = numInPlay.Bless + 1


### PR DESCRIPTION
Since we now have an easy way to remove playermats, people might move the Token Arranger closer. This properly excludes the temporary tokens from the Bless / Curse Manager.