### PR TITLE
"Take Clue" Game Key: support taking clues from the token pool

### DIFF
--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -287,6 +287,9 @@ function takeClueFromLocation(playerColor, hoveredObject)
     if #searchResult ~= 0 then
       cardName = searchResult[1].getName()
     end
+  elseif hoveredObject.type == "Infinite" and hoveredObject.getName() == "Clue tokens" then
+    clue = hoveredObject.takeObject()
+    cardName = "token pool"
   else
     broadcastToColor("Hover a clue or card with clues and try again.", playerColor, "Yellow")
     return


### PR DESCRIPTION
Hovering a token bag with clue and using the hotkey will now take one clue and place it on your playermat.