### PR TITLE
DeckImporter: change card zone priority for Hank

### DIFF
--- a/src/arkhamdb/DeckImporterMain.ttslua
+++ b/src/arkhamdb/DeckImporterMain.ttslua
@@ -25,6 +25,8 @@ function getDefaultCardZone(cardMetadata, bondedList)
     return "SetAside6"
   elseif (cardMetadata.id == "09006") then -- On The Mend is set aside
     return "SetAside2"
+  elseif bondedList[cardMetadata.id] then
+    return "SetAside2"
   elseif cardMetadata.type == "Investigator" then
     return "Investigator"
   elseif cardMetadata.type == "Minicard" then
@@ -35,8 +37,6 @@ function getDefaultCardZone(cardMetadata, bondedList)
     return startsInPlayTracker()
   elseif cardMetadata.permanent then
     return "SetAside1"
-  elseif bondedList[cardMetadata.id] then
-    return "SetAside2"
     -- SetAside3 is used for Ancestral Knowledge / Underworld Market
   else
     return "Deck"


### PR DESCRIPTION
This change is needed to properly set the bonded versions of Hank aside instead of spawning them in the investigator spot as deck.