### PR TITLE
Updated clue offset calculation

### DIFF
--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -466,20 +466,12 @@ do
   ---@param count number How many clues?
   ---@return table: Array of global positions to spawn the clues at
   internal.buildClueOffsets = function(card, count)
-    local pos = card.getPosition()
-    local rot = card.getRotation()
     local cluePositions = {}
     for i = 1, count do
       local row = math.floor(1 + (i - 1) / 4)
       local column = (i - 1) % 4
-      local cluePos = Vector(pos.x + 1.5 - 0.55 * row, pos.y + 0.15, pos.z - 0.825 + 0.55 * column)
-
-      -- rotate clue offsets to card rotation
-      local lCluePos = card.positionToLocal(cluePos)
-      lCluePos:rotateOver("y", 270 - rot.y)
-      cluePos = card.positionToWorld(lCluePos)
-
-      -- add clue position to table
+      local cluePos = card.positionToWorld(Vector(-0.825 + 0.55 * column, 0, -1.5 + 0.55 * row))
+      cluePos.y = cluePos.y + 0.05
       table.insert(cluePositions, cluePos)
     end
     return cluePositions
@@ -517,7 +509,7 @@ do
     -- if there are already more uses than the replenish amount, keep them
     if foundTokens > uses[1].count then
       newCount = foundTokens
-    -- only replenish up until the replenish amount
+      -- only replenish up until the replenish amount
     elseif newCount > uses[1].count then
       newCount = uses[1].count
     end

--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -129,8 +129,8 @@ do
   local playerCardData
   local locationData
 
-  local TokenManager = { }
-  local internal = { }
+  local TokenManager = {}
+  local internal = {}
 
   -- Spawns tokens for the card.  This function is built to just throw a card at it and let it do
   -- the work once a card has hit an area where it might spawn tokens.  It will check to see if
@@ -221,7 +221,7 @@ do
     if shiftDown ~= nil then
       -- Copy the offsets to make sure we don't change the static values
       local baseOffsets = offsets
-      offsets = { }
+      offsets = {}
 
       -- get a vector for the shifting (downwards local to the card)
       local shiftDownVector = Vector(0, 0, shiftDown):rotateOver("y", card.getRotation().y)
@@ -239,7 +239,7 @@ do
     if subType == nil then
       subType = ""
     end
-    
+
     -- this is used to load the correct state for additional resource tokens (e.g. "Ammo")
     local callback = nil
     local stateID = stateTable[string.lower(subType)]
@@ -272,9 +272,7 @@ do
     local tokenTemplate = tokenTemplates[loadTokenType]
 
     -- Take ONLY the Y-value for rotation, so we don't flip the token coming out of the bag
-    local rot = Vector(tokenTemplate.Transform.rotX,
-        270,
-        tokenTemplate.Transform.rotZ)
+    local rot = Vector(tokenTemplate.Transform.rotX, 270, tokenTemplate.Transform.rotZ)
     if rotation ~= nil then
       rot.y = rotation.y
     end
@@ -376,7 +374,7 @@ do
       -- Shift each spawned group after the first down so they don't pile on each other
       TokenManager.spawnTokenGroup(card, useInfo.token, tokenCount, (i - 1) * 0.8, useInfo.type)
     end
-    
+
     tokenSpawnTrackerApi.markTokensSpawned(card.getGUID())
   end
 
@@ -435,7 +433,7 @@ do
     end
 
     if ((card.is_face_down and locationData.clueSide == 'back')
-        or (not card.is_face_down and locationData.clueSide == 'front')) then
+          or (not card.is_face_down and locationData.clueSide == 'front')) then
       if locationData.type == 'fixed' then
         return locationData.value
       elseif locationData.type == 'perPlayer' then
@@ -449,7 +447,7 @@ do
   -- Gets the right uses structure for this card, based on metadata and face up/down state
   ---@param card tts__Object Card to pull the uses from
   internal.getUses = function(card)
-    local metadata = JSON.decode(card.getGMNotes()) or { }
+    local metadata = JSON.decode(card.getGMNotes()) or {}
     if metadata.type == "Location" then
       if card.is_face_down and metadata.locationBack ~= nil then
         return metadata.locationBack.uses
@@ -469,11 +467,20 @@ do
   ---@return table: Array of global positions to spawn the clues at
   internal.buildClueOffsets = function(card, count)
     local pos = card.getPosition()
-    local cluePositions = { }
+    local rot = card.getRotation()
+    local cluePositions = {}
     for i = 1, count do
       local row = math.floor(1 + (i - 1) / 4)
       local column = (i - 1) % 4
-      table.insert(cluePositions, Vector(pos.x + 1.5 - 0.55 * row, pos.y + 0.15, pos.z - 0.825 + 0.55 * column))
+      local cluePos = Vector(pos.x + 1.5 - 0.55 * row, pos.y + 0.15, pos.z - 0.825 + 0.55 * column)
+
+      -- rotate clue offsets to card rotation
+      local lCluePos = card.positionToLocal(cluePos)
+      lCluePos:rotateOver("y", 270 - rot.y)
+      cluePos = card.positionToWorld(lCluePos)
+
+      -- add clue position to table
+      table.insert(cluePositions, cluePos)
     end
     return cluePositions
   end

--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -509,7 +509,7 @@ do
     -- if there are already more uses than the replenish amount, keep them
     if foundTokens > uses[1].count then
       newCount = foundTokens
-      -- only replenish up until the replenish amount
+    -- only replenish up until the replenish amount
     elseif newCount > uses[1].count then
       newCount = uses[1].count
     end


### PR DESCRIPTION
This is needed to spawn clues correctly on rotated cards (e.g. "Cover Up" on the red/green playermat.