### PR TITLE
Expanded custom chaos token support

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -296,10 +296,10 @@ function drawChaosToken(params)
 
     -- add the token to the list, compute new position based on list length
     tokenOffset[1] = tokenOffset[1] + (0.17 * #chaosTokens)
-    
-    local token
 
-    if params.guidToBeResolved then -- resolve a sealed token from a card
+    local token
+    -- resolve a sealed token from a card
+    if params.guidToBeResolved then
       token = getObjectFromGUID(params.guidToBeResolved)
       token.setPositionSmooth(params.mat.positionToWorld(tokenOffset))
       local guid = token.getGUID()
@@ -308,24 +308,28 @@ function drawChaosToken(params)
         blessCurseManagerApi.releasedToken(tokenType, guid)
       end
       tokenArrangerApi.layout()
-    else -- take a token from the bag, either specified or random
+    -- take a token from the bag, either specified or random
+    else
       local takeParameters = {
         position = params.mat.positionToWorld(tokenOffset),
         rotation = params.mat.getRotation()
       }
 
       if params.tokenType then
-          for i, lookedForToken in ipairs(chaosBag.getObjects()) do
-              if lookedForToken.name == params.tokenType then
-                  takeParameters.index = i - 1
-              end
+        for i, lookedForToken in ipairs(chaosBag.getObjects()) do
+          if lookedForToken.nickname == params.tokenType then
+            takeParameters.index = i - 1
           end
+        end
       end
 
       token = chaosBag.takeObject(takeParameters)
-    end 
+    end
+
     -- get data for token description
     local name = token.getName()
+    if name == "" then name = "Custom" end
+
     local tokenData = mythosAreaApi.returnTokenData().tokenData or {}
     local specificData = tokenData[name] or {}
     token.setDescription(specificData.description or "")


### PR DESCRIPTION
- now displays "Custom" instead of nothing for the name of tracked custom tokens
- added ability for scripts to request a custom token (previously used `.name` field did not support empty strings)