### PR TITLE
Added deck-checking for "Forced Learning"

### DIFF
--- a/objects/AllPlayerCards.15bb07/ForcedLearning.fa06f9.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ForcedLearning.fa06f9.gmnotes
@@ -2,6 +2,7 @@
   "id": "08031",
   "type": "Asset",
   "class": "Seeker",
+  "startsInPlay": true,
   "level": 0,
   "traits": "Talent. Ritual.",
   "permanent": true,

--- a/objects/AllPlayerCards.15bb07/ForcedLearning.fa06f9.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ForcedLearning.fa06f9.gmnotes
@@ -2,7 +2,6 @@
   "id": "08031",
   "type": "Asset",
   "class": "Seeker",
-  "startsInPlay": true,
   "level": 0,
   "traits": "Talent. Ritual.",
   "permanent": true,

--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -295,6 +295,14 @@ function doUpkeep(_, clickedByColor, isRightClick)
       if cardMetadata.uses ~= nil then
         tokenManager.maybeReplenishCard(obj, cardMetadata.uses, self)
       end
+    -- check decks for forced learning
+    elseif obj.type == "Deck" and forcedLearning == false then
+      for _, deepObj in ipairs(obj.getObjects()) do
+        local cardMetadata = JSON.decode(deepObj.gm_notes) or {}
+        if cardMetadata.id == "08031" then
+          forcedLearning = true
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Playmat will now check decks for forced learning (e.g. the set-aside pile of permanents)