### PR TITLE
Bugfixes for Clean Up Helper

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -288,7 +288,9 @@ function tidyPlayerMatCoroutine()
     -- only continue for playermat (1-4) if option enabled
     if options["tidyPlayermats"] or i == 5 then
       -- delay for animation purpose
-      for k = 1, 30 do coroutine.yield(0) end
+      for k = 1, 30 do
+        coroutine.yield(0)
+      end
 
       -- get respective trash
       local trash = guidReferenceApi.getObjectByOwnerAndType(COLORS[i], "Trash")
@@ -315,7 +317,7 @@ function tidyPlayerMatCoroutine()
         if obj.hasTag(IGNORE_TAG) == false
             and obj.getDescription() ~= "Action Token"
             and obj.hasTag("chaosBag") == false
-            and obj.locked == false
+            and (obj.locked == false or obj.hasTag("Investigator"))
             and obj.interactable == true then
           coroutine.yield(0)
           trash.putObject(obj)
@@ -326,11 +328,13 @@ function tidyPlayerMatCoroutine()
           if obj.getScale().x < 0.4 then
             local pos = playmatApi.transformLocalPosition(Vector(-0.865, 0.1, -0.28), COLORS[i])
             obj.setPosition(pos)
+            coroutine.yield(0)
           end
 
           -- flip action tokens back to ready
           if obj.is_face_down then
             obj.flip()
+            coroutine.yield(0)
           end
 
           -- reset action token state


### PR DESCRIPTION
- added some more delays to gives action tokens enough time to reposition / flip / change state
- added check to remove investigator cards even if locked (I like to lock them)