### PR TITLE
Allow changing card state with number typing

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -211,6 +211,16 @@ function onObjectNumberTyped(hoveredObject, playerColor, number)
       return true
     end
   end
+
+  -- check if this is a card with states (and then change state instead of drawing it)
+  local states = hoveredObject.getStates()
+  if states ~= nil and #states > 0 then
+    local stateId = hoveredObject.getStateId()
+    if stateId ~= number and (#states + 1) >= number then
+      hoveredObject.setState(number)
+      return true
+    end
+  end
 end
 
 ---------------------------------------------------------


### PR DESCRIPTION
Changing the state of a card via number typing is now possible (e.g. for revised / promo art for Core Investigators)