### PR TITLE
Bugfix: Discard tokens that are on cards that enter discard pile deck

### DIFF
--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -12,7 +12,7 @@ local ENCOUNTER_DECK_AREA = {
 }
 local ENCOUNTER_DISCARD_AREA = {
   upperLeft = { x = 1.62, z = 0.42 },
-  lowerRight = { x = 1.58, z = 0.38 }, 
+  lowerRight = { x = 1.58, z = 0.38 },
 }
 local DRAWN_ENCOUNTER_CARD_OFFSET = {1.365, 0.5, -0.625}
 

--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -12,7 +12,7 @@ local ENCOUNTER_DECK_AREA = {
 }
 local ENCOUNTER_DISCARD_AREA = {
   upperLeft = { x = 1.62, z = 0.42 },
-  lowerRight = { x = 1.58, z = 0.38 },
+  lowerRight = { x = 1.58, z = 0.38 }, 
 }
 local DRAWN_ENCOUNTER_CARD_OFFSET = {1.365, 0.5, -0.625}
 
@@ -99,12 +99,13 @@ function onCollisionExit(collisionInfo)
   end
 end
 
--- Listens for cards entering the encounter deck or encounter discard, and resets the spawn state
--- for the cards when they do.
+-- Listens for cards entering the encounter deck or encounter discard, discards tokens on them,
+-- and resets the spawn state for the cards when they do.
 function onObjectEnterContainer(container, object)
   local localPos = self.positionToLocal(container.getPosition())
   if inArea(localPos, ENCOUNTER_DECK_AREA) or inArea(localPos, ENCOUNTER_DISCARD_AREA) then
     tokenSpawnTrackerApi.resetTokensSpawned(object.getGUID())
+    removeTokensFromObject(object)
   end
 end
 


### PR DESCRIPTION
Previously tokens (clue, doom, etc.) stuck around if you manually dropped a card into the discard pile.