### PR TITLE
Updated GM Notes of FOHV Story Assets

### DIFF
--- a/objects/AllPlayerCards.15bb07/Ajax.f8a7c6.gmnotes
+++ b/objects/AllPlayerCards.15bb07/Ajax.f8a7c6.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10642",
   "type": "Asset",
+  "slot": "Ally",
   "class": "Neutral",
   "cost": 2,
   "traits": "Ally. Creature.",

--- a/objects/AllPlayerCards.15bb07/CornHuskDoll.3602f5.gmnotes
+++ b/objects/AllPlayerCards.15bb07/CornHuskDoll.3602f5.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10714",
   "type": "Asset",
+  "slot": "Accessory",
   "class": "Neutral",
   "cost": 1,
   "willpowerIcons": 1,

--- a/objects/AllPlayerCards.15bb07/DrRosaMarquez.62d5a6.gmnotes
+++ b/objects/AllPlayerCards.15bb07/DrRosaMarquez.62d5a6.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10702",
   "type": "Asset",
+  "slot": "Ally",
   "class": "Neutral",
   "cost": 4,
   "traits": "Ally. Miskatonic. Wayfarer.",

--- a/objects/AllPlayerCards.15bb07/HelenPeters.33bfa1.gmnotes
+++ b/objects/AllPlayerCards.15bb07/HelenPeters.33bfa1.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10703",
   "type": "Asset",
+  "slot": "Ally",
   "class": "Neutral",
   "cost": 3,
   "traits": "Ally. Hunter.",

--- a/objects/AllPlayerCards.15bb07/LittleSylvie.153a42.gmnotes
+++ b/objects/AllPlayerCards.15bb07/LittleSylvie.153a42.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10548",
   "type": "Asset",
+  "slot": "Accessory",
   "class": "Neutral",
   "cost": 1,
   "traits": "Item. Charm. Cursed.",

--- a/objects/AllPlayerCards.15bb07/PrismaticShard.27fe24.gmnotes
+++ b/objects/AllPlayerCards.15bb07/PrismaticShard.27fe24.gmnotes
@@ -4,5 +4,12 @@
   "class": "Neutral",
   "cost": 2,
   "traits": "Item. Relic. Colour.",
+  "uses": [
+    {
+      "count": 4,
+      "type": "Brilliance",
+      "token": "resource"
+    }
+  ],
   "cycle": "The Feast of Hemlock Vale"
 }

--- a/objects/AllPlayerCards.15bb07/ThePearlDiary.34a7b5.gmnotes
+++ b/objects/AllPlayerCards.15bb07/ThePearlDiary.34a7b5.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10715",
   "type": "Asset",
+  "slot": "Hand",
   "class": "Neutral",
   "cost": 1,
   "traits": "Item. Tome.",

--- a/objects/AllPlayerCards.15bb07/WorryRock.5e5dc6.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WorryRock.5e5dc6.gmnotes
@@ -1,6 +1,7 @@
 {
   "id": "10713",
   "type": "Asset",
+  "slot": "Accessory",
   "class": "Neutral",
   "cost": 1,
   "traits": "Item. Charm. Blessed.",


### PR DESCRIPTION
Missing slot metadata on all cards; missing "uses" for Prismatic Shard.

Corn Husk Doll additionally has an error in the loadable-objects repository on spawning tokens.