### PR TITLE
Added "continue" for empty hotfix bags

### DIFF
--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -77,7 +77,11 @@ function buildIndex()
   -- process hotfix bags (and the additional playercards bag)
   for _, hotfixBag in ipairs(getObjectsWithTag("AllCardsHotfix")) do
     local hotfixData = hotfixBag.getData()
-    if not hotfixData.ContainedObjects then break end
+
+    -- if the bag is empty, continue with the next bag
+    if not hotfixData.ContainedObjects then
+      goto nextBag
+    end
 
     for _, cardData in ipairs(hotfixData.ContainedObjects) do
       -- process containers
@@ -100,6 +104,7 @@ function buildIndex()
         end
       end
     end
+    ::nextBag::
   end
 
   buildSupplementalIndexes()


### PR DESCRIPTION
Before this change, the loop would interrupt on the first empty bag.