### PR TITLE
Added regular JSON parser as fallback

### DIFF
--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -116,7 +116,14 @@ end
 ---@param cardData table TTS object data for the card
 function addCardToIndex(cardData)
   -- using the more efficient 'json.parse()' to speed this process up
-  local cardMetadata = json.parse(cardData.GMNotes)
+  local status, cardMetadata = pcall(function() json.parse(cardData.GMNotes) end)
+
+  -- if an error happens, fallback to the regular parser
+  if status ~= true then
+    cardMetadata = JSON.decode(cardData.GMNotes)
+  end
+
+  -- if metadata was not valid JSON or empty, don't add the card
   if not cardMetadata then return end
 
   -- use the ZoopGuid as fallback if no id present


### PR DESCRIPTION
The faster `json.parse()` function has some limitations, for example negative integers (https://github.com/moonsharp-devs/moonsharp/issues/319). This adds the regular `JSON.decode()` as fallback (if the faster parser fails).