### PR TITLE
Changed default behaviour to 3 tokens

### DIFF
--- a/src/playermat/Playmat.ttslua
+++ b/src/playermat/Playmat.ttslua
@@ -903,10 +903,7 @@ function maybeUpdateActiveInvestigator(card)
   end
 
   -- spawn additional token (maybe specific for investigator)
-  if extraToken ~= "None" then
-    -- set to current class if nil
-    extraToken = extraToken or activeInvestigatorClass
-
+  if extraToken and extraToken ~= "None" then
     -- local positions
     local tokenSpawnPos = {
       action = {


### PR DESCRIPTION
Previously, the code would default to 4 tokens if the `extraToken` metadata field was empty. This changes the default to 3.

![image](https://github.com/argonui/SCED/assets/97286811/503f345d-12cc-47e8-8a42-884deae05709)