### PR TITLE
Context Menus and Token Spawning

### DIFF
--- a/src/accessories/PhaseTracker.ttslua
+++ b/src/accessories/PhaseTracker.ttslua
@@ -42,10 +42,11 @@ function onLoad(savedData)
       color = { r = 0, g = 0, b = 0, a = 0 }
     })
 
-  self.addContextMenuItem("toggle broadcasting", updateBroadcast)
+  self.addContextMenuItem("Toggle Broadcasting", updateBroadcast)
 end
 
-function updateBroadcast()
+function updateBroadcast(playerColor)
+  Player[playerColor].clearSelectedObjects()
   for _, tracker in ipairs(getObjectsWithTag("LinkedPhaseTracker")) do
     tracker.setVar("broadcastChange", not broadcastChange)
   end

--- a/src/accessories/UnderworldMarketHelper.ttslua
+++ b/src/accessories/UnderworldMarketHelper.ttslua
@@ -32,7 +32,7 @@ function onload(savedData)
   isSetup = false
   movingCards = false
 
-  self.addContextMenuItem('Reset helper', resetHelper)
+  self.addContextMenuItem('Reset Helper', resetHelper)
 
   if savedData and savedData ~= '' then
     local loaded_data = JSON.decode(savedData)
@@ -242,7 +242,8 @@ function finish()
     0.75)
 end
 
-function resetHelper()
+function resetHelper(playerColor)
+  Player[playerColor].clearSelectedObjects()
   for i, card in ipairs(self.getObjects()) do
     self.takeObject({
       index = 0,
@@ -268,8 +269,6 @@ function resetHelper()
   hiddenCards = 10
   isSetup = false
   movingCards = false
-
-  self.reset()
 
   print('Underworld Market Helper: Helper has been reset.')
 end

--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -78,7 +78,7 @@ function onCollisionEnter(collisionInfo)
 
   local localPos = self.positionToLocal(object.getPosition())
   if inArea(localPos, ENCOUNTER_DECK_AREA) or inArea(localPos, ENCOUNTER_DISCARD_AREA) then
-    Wait.frames(function() tokenSpawnTrackerApi.resetTokensSpawned(object.getGUID()) end, 1)
+    Wait.frames(function() tokenSpawnTrackerApi.resetTokensSpawned(object) end, 1)
     removeTokensFromObject(object)
   end
 end
@@ -100,7 +100,7 @@ end
 function onObjectEnterContainer(container, object)
   local localPos = self.positionToLocal(container.getPosition())
   if inArea(localPos, ENCOUNTER_DECK_AREA) or inArea(localPos, ENCOUNTER_DISCARD_AREA) then
-    tokenSpawnTrackerApi.resetTokensSpawned(object.getGUID())
+    tokenSpawnTrackerApi.resetTokensSpawned(object)
     removeTokensFromObject(object)
   end
 end

--- a/src/core/UniversalActionAbilityToken.ttslua
+++ b/src/core/UniversalActionAbilityToken.ttslua
@@ -202,6 +202,7 @@ end
 
 function addContextMenu()
   self.addContextMenuItem("Change color", function(playerColor)
+    Player[playerColor].clearSelectedObjects()
     local currentClassDisplayName = listOfClassDisplayNames[getIndexOfValue(listOfClasses, class)]
     Player[playerColor].showOptionsDialog("Choose color", listOfClassDisplayNames, currentClassDisplayName,
       function(_, selectedIndex)
@@ -210,6 +211,7 @@ function addContextMenu()
   end)
 
   self.addContextMenuItem("Change 1st symbol", function(playerColor)
+    Player[playerColor].clearSelectedObjects()
     local symbolList = getSymbolList()
     Player[playerColor].showOptionsDialog("Choose symbol", listOfSymbols, symbolList[1], function(newSymbol)
       if newSymbol == "None" then
@@ -229,6 +231,7 @@ function addContextMenu()
   end)
 
   self.addContextMenuItem("Change 2nd symbol", function(playerColor)
+    Player[playerColor].clearSelectedObjects()
     local symbolList = getSymbolList()
     Player[playerColor].showOptionsDialog("Choose 2nd symbol", listOfSymbols, symbolList[2] or symbolList[1],
       function(newSymbol)

--- a/src/core/token/TokenManager.ttslua
+++ b/src/core/token/TokenManager.ttslua
@@ -211,10 +211,11 @@ do
     if tokenType == "clue" then
       offsets = internal.buildClueOffsets(card, tokenCount)
     else
-      -- only up to 12 offset tables defined (TODO: stack more than 12 tokens and generate offsets dynamically)
+      -- only up to 12 offset tables defined
       if tokenCount > 12 then
-        printToAll("Spawning maximum of 12 tokens.")
-        tokenCount = 12
+        printToAll("Attempting to spawn " .. tokenCount .. " tokens. Spawning clickable counter instead.")
+        TokenManager.spawnResourceCounterToken(card, tokenCount)
+        return
       end
       for i = 1, tokenCount do
         offsets[i] = card.positionToWorld(PLAYER_CARD_TOKEN_OFFSETS[tokenCount][i])
@@ -297,18 +298,11 @@ do
   -- Checks a card for metadata to maybe replenish it
   ---@param card tts__Object Card object to be replenished
   ---@param uses table The already decoded metadata.uses (to avoid decoding again)
-  ---@param mat tts__Object The playermat the card is placed on (for rotation and casting)
-  TokenManager.maybeReplenishCard = function(card, uses, mat)
+  TokenManager.maybeReplenishCard = function(card, uses)
     -- TODO: support for cards with multiple uses AND replenish (as of yet, no official card needs that)
     if uses[1].count and uses[1].replenish then
-      internal.replenishTokens(card, uses, mat)
+      internal.replenishTokens(card, uses)
     end
-  end
-
-  -- Delegate function to the token spawn tracker. Exists to avoid circular dependencies in some callers
-  ---@param card tts__Object Card object to reset the tokens for
-  TokenManager.resetTokensSpawned = function(card)
-    tokenSpawnTrackerApi.resetTokensSpawned(card.getGUID())
   end
 
   -- Pushes new player card data into the local copy of the Data Helper player data.
@@ -483,16 +477,16 @@ do
 
   ---@param card tts__Object Card object to be replenished
   ---@param uses table The already decoded metadata.uses (to avoid decoding again)
-  ---@param mat tts__Object The playermat the card is placed on (for rotation and casting)
-  internal.replenishTokens = function(card, uses, mat)
-    -- get current amount of resource tokens on the card
+  internal.replenishTokens = function(card, uses)
+    -- get current amount of matching resource tokens on the card
     local clickableResourceCounter = nil
     local foundTokens = 0
+    local searchType = string.lower(uses[1].type)
 
     for _, obj in ipairs(searchLib.onObject(card, "isTileOrToken")) do
       local memo = obj.getMemo()
 
-      if (stateTable[memo] or 0) > 0 then
+      if searchType == memo then
         foundTokens = foundTokens + math.abs(obj.getQuantity())
         obj.destruct()
       elseif memo == "resourceCounter" then

--- a/src/core/token/TokenSpawnTracker.ttslua
+++ b/src/core/token/TokenSpawnTracker.ttslua
@@ -22,8 +22,8 @@ function markTokensSpawned(cardGuid)
   spawnedCardGuids[cardGuid] = true
 end
 
-function resetTokensSpawned(cardGuid)
-  spawnedCardGuids[cardGuid] = nil
+function resetTokensSpawned(card)
+  spawnedCardGuids[card.getGUID()] = nil
 end
 
 function resetAll() spawnedCardGuids = {} end
@@ -52,6 +52,6 @@ end
 -- Listener to reset card token spawns when they enter a hand.
 function onObjectEnterZone(zone, enterObject)
   if zone.type == "Hand" and enterObject.type == "Card" then
-    resetTokensSpawned(enterObject.getGUID())
+    resetTokensSpawned(enterObject)
   end
 end

--- a/src/core/token/TokenSpawnTrackerApi.ttslua
+++ b/src/core/token/TokenSpawnTrackerApi.ttslua
@@ -14,8 +14,8 @@ do
     return getSpawnTracker().call("markTokensSpawned", cardGuid)
   end
 
-  TokenSpawnTracker.resetTokensSpawned = function(cardGuid)
-    return getSpawnTracker().call("resetTokensSpawned", cardGuid)
+  TokenSpawnTracker.resetTokensSpawned = function(card)
+    return getSpawnTracker().call("resetTokensSpawned", card)
   end
 
   TokenSpawnTracker.resetAllAssetAndEvents = function()

--- a/src/playercards/CardsThatRedrawTokens.ttslua
+++ b/src/playercards/CardsThatRedrawTokens.ttslua
@@ -63,9 +63,8 @@ function onLoad(savedData)
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
-  checkOptionPanel()
   createHelperXML()
-  updateDisplay()
+  checkOptionPanel()
 end
 
 function createHelperXML()

--- a/src/playercards/CardsWithHelper.ttslua
+++ b/src/playercards/CardsWithHelper.ttslua
@@ -5,6 +5,8 @@ function checkOptionPanel()
   local options = optionPanelApi.getOptions()
   if options.enableCardHelpers then
     setHelperState(true)
+  else
+    updateDisplay()
   end
 end
 

--- a/src/playercards/Tarotcard.ttslua
+++ b/src/playercards/Tarotcard.ttslua
@@ -5,7 +5,8 @@ function onLoad()
 end
 
 -- rotates the alt_view_angle
-function rotatePreview()
+function rotatePreview(playerColor)
+  Player[playerColor].clearSelectedObjects()
   local angle = self.alt_view_angle
   if angle.y == 0 then
     angle.y = 180
@@ -16,7 +17,7 @@ function rotatePreview()
 end
 
 -- rotates this card and the preview
-function rotateSelfAndPreview()
+function rotateSelfAndPreview(playerColor)
   self.setRotationSmooth(self.getRotation() + Vector(0, 180, 0))
-  rotatePreview()
+  rotatePreview(playerColor)
 end

--- a/src/playercards/cards/BookofLivingMyths.ttslua
+++ b/src/playercards/cards/BookofLivingMyths.ttslua
@@ -16,7 +16,6 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
   checkOptionPanel()
-  updateDisplay()
 end
 
 -- hide buttons and stop monitoring

--- a/src/playercards/cards/EmpiricalHypothesis.ttslua
+++ b/src/playercards/cards/EmpiricalHypothesis.ttslua
@@ -46,7 +46,6 @@ function onLoad(savedData)
     activeButtonIndex = loadedData.activeButtonIndex
   end
   checkOptionPanel()
-  updateDisplay()
 
   if activeButtonIndex > 0 then
     selectButton(activeButtonIndex)
@@ -89,6 +88,7 @@ function createButtons()
   local upgradeSheet = findUpgradeSheet()
   if upgradeSheet then
     for i = 1, 4 do
+      log(4)
       if upgradeSheet.call("isUpgradeActive", i) then
         table.insert(hypothesisList, customizableList[i])
       end
@@ -110,7 +110,7 @@ end
 
 function findUpgradeSheet()
   local matColor = playermatApi.getMatColorByPosition(self.getPosition())
-  local result = playermatApi.searchAroundPlaymat(matColor, "isCard")
+  local result = playermatApi.searchAroundPlayermat(matColor, "isCard")
   for j, card in ipairs(result) do
     local metadata = JSON.decode(card.getGMNotes()) or {}
     if metadata.id == "09041-c" then

--- a/src/playercards/cards/FamilyInheritance.ttslua
+++ b/src/playercards/cards/FamilyInheritance.ttslua
@@ -6,9 +6,21 @@ local clickableResourceCounter = nil
 local foundTokens = 0
 
 function onLoad()
-  self.addContextMenuItem("Add 4 resources", function(playerColor) add4(playerColor) end)
-  self.addContextMenuItem("Take all resources", function(playerColor) takeAll(playerColor) end)
-  self.addContextMenuItem("Discard all resources", function(playerColor) loseAll(playerColor) end)
+  self.addContextMenuItem("Add 4 resources",
+    function(playerColor)
+      Player[playerColor].clearSelectedObjects()
+      add4(playerColor)
+    end)
+  self.addContextMenuItem("Take all resources",
+    function(playerColor)
+      Player[playerColor].clearSelectedObjects()
+      takeAll(playerColor)
+    end)
+  self.addContextMenuItem("Discard all resources",
+    function(playerColor)
+      Player[playerColor].clearSelectedObjects()
+      loseAll(playerColor)
+    end)
 end
 
 function searchSelf()
@@ -35,12 +47,7 @@ function add4(playerColor)
   if clickableResourceCounter then
     clickableResourceCounter.call("updateVal", newCount)
   else
-    if newCount > 12 then
-      printToColor("Count increased to " .. newCount .. " resources. Spawning clickable counter instead.", playerColor)
-      tokenManager.spawnResourceCounterToken(self, newCount)
-    else
-      tokenManager.spawnTokenGroup(self, "resource", newCount)
-    end
+    tokenManager.spawnTokenGroup(self, "resource", newCount)
   end
 end
 

--- a/src/playercards/cards/NkosiMabati3.ttslua
+++ b/src/playercards/cards/NkosiMabati3.ttslua
@@ -61,6 +61,7 @@ end
 
 -- Create dialog window to choose sigil and create sigil-drawing button
 function chooseSigil(playerColor)
+  Player[playerColor].clearSelectedObjects()
   self.clearContextMenu()
   self.addContextMenuItem("Clear Helper", deleteButtons)
 
@@ -80,7 +81,8 @@ function chooseSigil(playerColor)
 end
 
 -- Delete button and remove sigil
-function deleteButtons()
+function deleteButtons(playerColor)
+  Player[playerColor].clearSelectedObjects()
   self.clearContextMenu()
   self.addContextMenuItem("Enable Helper", chooseSigil)
   self.UI.setXml("")

--- a/src/playercards/cards/ScrollofSecrets.ttslua
+++ b/src/playercards/cards/ScrollofSecrets.ttslua
@@ -17,6 +17,7 @@ function onLoad()
 end
 
 function contextFunc(playerColor, amount)
+  Player[playerColor].clearSelectedObjects()
   deckData = {}
   local options = {}
 

--- a/src/playercards/cards/ShortSupply.ttslua
+++ b/src/playercards/cards/ShortSupply.ttslua
@@ -5,7 +5,8 @@ function onLoad()
 end
 
 -- called by context menu entry
-function shortSupply(color)
+function shortSupply(playerColor)
+  Player[playerColor].clearSelectedObjects()
   local matColor = playermatApi.getMatColorByPosition(self.getPosition())
 
   -- get draw deck and discard position
@@ -15,20 +16,20 @@ function shortSupply(color)
 
   -- error handling
   if discardPos == nil then
-    broadcastToColor("Couldn't retrieve discard position from playermat!", color, "Red")
+    broadcastToColor("Couldn't retrieve discard position from playermat!", playerColor, "Red")
     return
   end
 
   if drawDeck == nil then
-    broadcastToColor("Deck not found!", color, "Yellow")
+    broadcastToColor("Deck not found!", playerColor, "Yellow")
     return
   elseif drawDeck.type ~= "Deck" then
-    broadcastToColor("Deck only contains a single card!", color, "Yellow")
+    broadcastToColor("Deck only contains a single card!", playerColor, "Yellow")
     return
   end
 
   -- discard cards, waiting 0.7 seconds between each discard to give players visiblity of the cards
-  broadcastToColor("Discarding top 10 cards for player color '" .. matColor .. "'.", color, "White")
+  broadcastToColor("Discarding top 10 cards for player color '" .. matColor .. "'.", playerColor, "White")
   for i = 1, 10 do
     Wait.time(function() drawDeck.takeObject({ flip = true, position = { discardPos.x, 2 + 0.075 * i, discardPos.z } }) end, .7 * (i - 1))
   end

--- a/src/playercards/cards/Tekeli-li.ttslua
+++ b/src/playercards/cards/Tekeli-li.ttslua
@@ -7,7 +7,8 @@ function onLoad()
 end
 
 -- uses the tekeli-li helper to place this card at the bottom of the deck
-function returnSelf()
+function returnSelf(playerColor)
+  Player[playerColor].clearSelectedObjects()
   local helper = getTekeliliHelper()
   if helper == nil then
     printToAll("Couldn't find Tekeli-li Helper!")
@@ -18,6 +19,7 @@ end
 
 -- places this card below the deck of the player that triggered it
 function placeBelowDeck(playerColor)
+  Player[playerColor].clearSelectedObjects()
   local matColor = playermatApi.getMatColor(playerColor)
   local deckPos = playermatApi.getDrawPosition(matColor)
   local deckRot = playermatApi.returnRotation(matColor)

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -6,6 +6,7 @@ local navigationOverlayApi        = require("core/NavigationOverlayApi")
 local searchLib                   = require("util/SearchLib")
 local tokenChecker                = require("core/token/TokenChecker")
 local tokenManager                = require("core/token/TokenManager")
+local tokenSpawnTrackerApi        = require("core/token/TokenSpawnTrackerApi")
 
 -- we use this to turn off collision handling until onLoad() is complete
 local collisionEnabled            = false
@@ -344,7 +345,7 @@ function doUpkeep(_, clickedByColor, isRightClick)
       end
 
       -- maybe replenish uses on certain cards (don't continue for cards on the deck (Norman) or in the discard pile)
-      if cardMetadata.uses ~= nil and self.positionToLocal(obj.getPosition()).x < -1 then
+      if cardMetadata.uses ~= nil and self.positionToLocal(obj.getPosition()).x > -1 then
         tokenManager.maybeReplenishCard(obj, cardMetadata.uses, self)
       end
     elseif obj.type == "Deck" and forcedLearning == false then
@@ -823,7 +824,7 @@ function onCollisionEnter(collisionInfo)
 
   local localCardPos = self.positionToLocal(object.getPosition())
   if inArea(localCardPos, DECK_DISCARD_AREA) then
-    tokenManager.resetTokensSpawned(object)
+    tokenSpawnTrackerApi.resetTokensSpawned(object)
     removeTokensFromObject(object)
   elseif shouldSpawnTokens(object) then
     spawnTokensFor(object)
@@ -867,7 +868,7 @@ function onObjectEnterContainer(container, object)
 
   local localCardPos = self.positionToLocal(object.getPosition())
   if inArea(localCardPos, DECK_DISCARD_AREA) then
-    tokenManager.resetTokensSpawned(object)
+    tokenSpawnTrackerApi.resetTokensSpawned(object)
     removeTokensFromObject(object)
   end
 end


### PR DESCRIPTION
- added "object unselection" to context menus of unlocked objects so you don't accidentally move/flip/rotate them
- added the "Family Inheritance" handling as default: attempting to spawn more than 12 tokens will spawn a clickable token instead
- removed obsolete redirection function from TokenManager
- updated "resetTokensSpawned" to use an object as argument instead of a GUID
- also includes a bugfix for the Empirical Hypothesis