### PR TITLE
Reset clue spawning for locations when new scenario starts

### DIFF
--- a/src/core/MythosArea.ttslua
+++ b/src/core/MythosArea.ttslua
@@ -116,6 +116,9 @@ function fireScenarioChangedEvent()
   -- maybe update the playarea image
   local playAreaImageSelector = guidReferenceApi.getObjectByOwnerAndType("Mythos", "PlayAreaImageSelector")
   playAreaImageSelector.call("maybeUpdatePlayAreaImage", currentScenario)
+
+  -- reset the token spawning for locations
+  tokenSpawnTrackerApi.resetAllLocations()
 end
 
 -- fires if the scenario title or the difficulty changes

--- a/src/core/token/TokenSpawnTrackerApi.ttslua
+++ b/src/core/token/TokenSpawnTrackerApi.ttslua
@@ -1,34 +1,34 @@
 do
-  local TokenSpawnTracker = {}
+  local TokenSpawnTrackerApi = {}
   local guidReferenceApi = require("core/GUIDReferenceApi")
 
   local function getSpawnTracker()
     return guidReferenceApi.getObjectByOwnerAndType("Mythos", "TokenSpawnTracker")
   end
 
-  TokenSpawnTracker.hasSpawnedTokens = function(cardGuid)
+  TokenSpawnTrackerApi.hasSpawnedTokens = function(cardGuid)
     return getSpawnTracker().call("hasSpawnedTokens", cardGuid)
   end
 
-  TokenSpawnTracker.markTokensSpawned = function(cardGuid)
+  TokenSpawnTrackerApi.markTokensSpawned = function(cardGuid)
     return getSpawnTracker().call("markTokensSpawned", cardGuid)
   end
 
-  TokenSpawnTracker.resetTokensSpawned = function(card)
+  TokenSpawnTrackerApi.resetTokensSpawned = function(card)
     return getSpawnTracker().call("resetTokensSpawned", card)
   end
 
-  TokenSpawnTracker.resetAllAssetAndEvents = function()
+  TokenSpawnTrackerApi.resetAllAssetAndEvents = function()
     return getSpawnTracker().call("resetAllAssetAndEvents")
   end
 
-  TokenSpawnTracker.resetAllLocations = function()
+  TokenSpawnTrackerApi.resetAllLocations = function()
     return getSpawnTracker().call("resetAllLocations")
   end
 
-  TokenSpawnTracker.resetAll = function()
+  TokenSpawnTrackerApi.resetAll = function()
     return getSpawnTracker().call("resetAll")
   end
 
-  return TokenSpawnTracker
+  return TokenSpawnTrackerApi
 end


### PR DESCRIPTION
When playing multiple scenarios in the same savegame (and not using the Clean Up Helper), some locations won't spawn clues because they share the GUID with a location from a previous scenario. This fixes that by resetting the spawned GUIDs when a new scenario starts.