### PR TITLE
Added additional condition to destroy Token Remover Zone

### DIFF
--- a/src/util/TokenRemover.ttslua
+++ b/src/util/TokenRemover.ttslua
@@ -43,3 +43,7 @@ end
 function onPickUp()
   disable()
 end
+
+function onDestroy()
+  disable()
+end


### PR DESCRIPTION
Without this change the zone will persist if the Token Remover is destroyed (e.g. by removing the whole playermat with its objects).