### PR TITLE
Better custom card detection for Card Index

### DIFF
--- a/objects/AdditionalPlayerCards.2cba6b/FineClothes3.5cb973.gmnotes
+++ b/objects/AdditionalPlayerCards.2cba6b/FineClothes3.5cb973.gmnotes
@@ -6,5 +6,5 @@
   "level": 3,
   "traits": "Item. Clothing.",
   "agilityIcons": 1,
-  "cycle": "Standalone"
+  "cycle": "Beta"
 }

--- a/objects/AdditionalPlayerCards.2cba6b/SwordCane2.9c32e2.gmnotes
+++ b/objects/AdditionalPlayerCards.2cba6b/SwordCane2.9c32e2.gmnotes
@@ -6,5 +6,5 @@
   "level": 2,
   "traits": "Item. Relic. Weapon. Melee.",
   "combatIcons": 1,
-  "cycle": "Standalone"
+  "cycle": "Beta"
 }

--- a/objects/AllPlayerCards.15bb07/WendysAmulet.664b70.gmnotes
+++ b/objects/AllPlayerCards.15bb07/WendysAmulet.664b70.gmnotes
@@ -7,5 +7,5 @@
   "traits": "Item. Relic.",
   "willpowerIcons": 1,
   "wildIcons": 2,
-  "cycle": "Red Ride Rising"
+  "cycle": "Red Tide Rising"
 }

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -30,7 +30,37 @@ local classesInOrder         = {
   "Survivor",
   "Neutral"
 }
-
+local OFFICIAL_CYCLE_LIST = {
+	-- campaigns
+	["investigator packs"] = true,
+	["core"] = true,
+	["the dunwich legacy"] = true,
+	["the path to carcosa"] = true,
+	["the forgotten age"] = true,
+	["the circle undone"] = true,
+	["the dream-eaters"] = true,
+	["the innsmouth conspiracy"] = true,
+	["edge of the earth"] = true,
+	["the scarlet keys"] = true,
+	["the feast of hemlock vale"] = true,
+	["the drowned city"] = true,
+	-- standalones / parallels etc.
+	["standalone"] = true,
+	["the blob that ate everything else"] = true,
+	["all or nothing"] = true,
+	["bad blood"] = true,
+	["read or die"] = true,
+	["by the book"] = true,
+	["red tide rising"] = true,
+	["on the road again"] = true,
+	["laid to rest"] = true,
+	["path of the righteous"] = true,
+	["relics of the past"] = true,
+	["hunting for answers"] = true,
+	["pistols and pearls"] = true,
+	["beta"] = true,
+	["promo"] = true
+}
 -- conversion tables to simplify type sorting
 local typeConversion         = {
   Investigator = 1,
@@ -235,7 +265,6 @@ function buildSupplementalIndexes()
       end
 
       -- check if card is not from an official cycle
-      log(cardId)
       if OFFICIAL_CYCLE_LIST[cycleName] ~= true then
         otherCardsDetected = true
 

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -209,7 +209,7 @@ function buildSupplementalIndexes()
         end
       end
 
-      -- add to cycle index
+      -- start parsing the cycle data
       local cycleName = card.metadata.cycle
 
       -- if this is a minicard without cycle, check the parent card for cycle data
@@ -232,6 +232,11 @@ function buildSupplementalIndexes()
       else
         -- track cards without defined cycle (should only be fan-made cards)
         cycleName = "other"
+      end
+
+      -- check if card is not from an official cycle
+      log(cardId)
+      if OFFICIAL_CYCLE_LIST[cycleName] ~= true then
         otherCardsDetected = true
 
         -- maybe add to special investigator / minicard index
@@ -254,7 +259,7 @@ function buildSupplementalIndexes()
         end
       end
 
-      -- maybe initialize table
+      -- add to cycle index
       writeToNestedTable(cycleIndex, cycleName, cardId)
     end
   end

--- a/src/playercards/PlayerCardPanelData.ttslua
+++ b/src/playercards/PlayerCardPanelData.ttslua
@@ -58,6 +58,37 @@ EVOLVED_WEAKNESSES = {
 	"53015",
 }
 
+OFFICIAL_CYCLE_LIST = {
+	-- campaigns
+	["Investigator Packs"] = true,
+	["Core"] = true,
+	["The Dunwich Legacy"] = true,
+	["The Path to Carcosa"] = true,
+	["The Forgotten Age"] = true,
+	["The Circle Undone"] = true,
+	["The Dream-Eaters"] = true,
+	["The Innsmouth Conspiracy"] = true,
+	["Edge of the Earth"] = true,
+	["The Scarlet Keys"] = true,
+	["The Feast of Hemlock Vale"] = true,
+	["The Drowned City"] = true,
+	-- standalones / parallels etc.
+	["Standalone"] = true,
+	["The Blob That Ate Everything ELSE"] = true,
+	["All or Nothing"] = true,
+	["Bad Blood"] = true,
+	["Read or Die"] = true,
+	["By the Book"] = true,
+	["Red Tide Rising"] = true,
+	["On the Road Again"] = true,
+	["Laid to Rest"] = true,
+	["Path of the Righteous"] = true,
+	["Relics of the Past"] = true,
+	["Hunting for Answers"] = true,
+	["Pistols and Pearls"] = true,
+	["Beta"] = true,
+	["Promo"] = true
+}
 ------------------ START INVESTIGATOR DATA DEFINITION ------------------
 INVESTIGATOR_GROUPS = {
 	["Guardian"] = {

--- a/src/playercards/PlayerCardPanelData.ttslua
+++ b/src/playercards/PlayerCardPanelData.ttslua
@@ -58,37 +58,6 @@ EVOLVED_WEAKNESSES = {
 	"53015",
 }
 
-OFFICIAL_CYCLE_LIST = {
-	-- campaigns
-	["Investigator Packs"] = true,
-	["Core"] = true,
-	["The Dunwich Legacy"] = true,
-	["The Path to Carcosa"] = true,
-	["The Forgotten Age"] = true,
-	["The Circle Undone"] = true,
-	["The Dream-Eaters"] = true,
-	["The Innsmouth Conspiracy"] = true,
-	["Edge of the Earth"] = true,
-	["The Scarlet Keys"] = true,
-	["The Feast of Hemlock Vale"] = true,
-	["The Drowned City"] = true,
-	-- standalones / parallels etc.
-	["Standalone"] = true,
-	["The Blob That Ate Everything ELSE"] = true,
-	["All or Nothing"] = true,
-	["Bad Blood"] = true,
-	["Read or Die"] = true,
-	["By the Book"] = true,
-	["Red Tide Rising"] = true,
-	["On the Road Again"] = true,
-	["Laid to Rest"] = true,
-	["Path of the Righteous"] = true,
-	["Relics of the Past"] = true,
-	["Hunting for Answers"] = true,
-	["Pistols and Pearls"] = true,
-	["Beta"] = true,
-	["Promo"] = true
-}
 ------------------ START INVESTIGATOR DATA DEFINITION ------------------
 INVESTIGATOR_GROUPS = {
 	["Guardian"] = {


### PR DESCRIPTION
Now any cycle name on custom cards is supported by comparing to a pre-defined list of official cycles.