### PR TITLE
Added additional delay to objects unlocking after texture change

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1341,9 +1341,11 @@ function updateTexture(overrideName)
 
     -- unlock objects when mat is reloaded
     Wait.condition(function()
-      for _, obj in ipairs(objectsToUnlock) do
-        obj.setLock(false)
-      end
+      Wait.frames(function()
+        for _, obj in ipairs(objectsToUnlock) do
+          obj.setLock(false)
+        end
+      end, 5)
     end, function() return reloadedMat.loading_custom == false end)
   end
 end


### PR DESCRIPTION
This ensures that cards don't "fall through"