### PR TITLE
Use memo as identifier instead of name

### DIFF
--- a/objects/Fan-MadeAccessories.aa8b38/Auto-failCounter.a9a321.json
+++ b/objects/Fan-MadeAccessories.aa8b38/Auto-failCounter.a9a321.json
@@ -36,6 +36,7 @@
   "LuaScript": "require(\"core/GenericCounter\")",
   "LuaScriptState": "0",
   "MeasureMovement": false,
+  "Memo": "AutofailCounter",
   "Name": "Custom_Tile",
   "Nickname": "Auto-fail Counter",
   "Snap": true,

--- a/objects/Fan-MadeAccessories.aa8b38/ElderSignCounter.e62cb5.json
+++ b/objects/Fan-MadeAccessories.aa8b38/ElderSignCounter.e62cb5.json
@@ -36,6 +36,7 @@
   "LuaScript": "require(\"core/GenericCounter\")",
   "LuaScriptState": "0",
   "MeasureMovement": false,
+  "Memo": "ElderSignCounter",
   "Name": "Custom_Tile",
   "Nickname": "Elder Sign Counter",
   "Snap": true,

--- a/src/core/GenericCounter.ttslua
+++ b/src/core/GenericCounter.ttslua
@@ -9,17 +9,17 @@ function onLoad(savedData)
     val = JSON.decode(savedData)
   end
 
-  self.max_typed_number = 99
+  self.max_typed_number = MAX_VALUE
 
-  local name = self.getName()
+  local tokenType = self.getMemo()
   local position = { 0, 0.06, 0 }
 
   -- set position of label depending on object
-  if name == "Damage" or name == "Resources" or name == "Resource Counter" then
+  if tokenType == "damage" or tokenType == "resource" or tokenType == "resourceCounter" then
     position = { 0, 0.06, 0.1 }
-  elseif name == "Horror" then
+  elseif tokenType == "horror" then
     position = { -0.025, 0.06, -0.025 }
-  elseif name == "Elder Sign Counter" or name == "Auto-fail Counter" then
+  elseif tokenType == "ElderSignCounter" or tokenType == "AutofailCounter" then
     position = { 0, 0.1, 0 }
   end
 


### PR DESCRIPTION
Memo is more robust since it can't be easily edited (and this allows other tokens to use this too despite having different names, e.g. the Memories in Dark Matter can use the "horror" position).