### PR TITLE
Play Area: improved "ready cards" message

### DIFF
--- a/src/core/PlayArea.ttslua
+++ b/src/core/PlayArea.ttslua
@@ -560,12 +560,12 @@ function readyCards(player, clickType)
     end
   end
 
-  local cardString = " cards "
+  local cardString = " cards"
   if count == 1 then
-    cardString = " card "
+    cardString = " card"
   end
 
-  broadcastToAll("Readied " .. count .. cardString .. " in Play Area")
+  broadcastToAll("Play Area: Readied " .. count .. cardString)
 end
 
 ---------------------------------------------------------


### PR DESCRIPTION
There was a double space character in the message and this makes the message a bit easier to parse