### PR TITLE
Unselect object after using sealed tokens context menus

### DIFF
--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -250,6 +250,7 @@ function releaseOneToken(playerColor)
     putTokenAway(table.remove(sealedTokens))
     updateSave()
   end
+  Player[playerColor].clearSelectedObjects()
 end
 
 -- release up to multiple tokens at once with no minimum
@@ -269,6 +270,7 @@ function releaseMultipleTokens(playerColor)
   end
   updateSave()
   printToColor("Releasing " .. numRemoved .. " tokens", playerColor)
+  Player[playerColor].clearSelectedObjects()
 end
 
 -- releases all sealed tokens
@@ -284,6 +286,7 @@ function releaseAllTokens(playerColor)
     sealedTokens = {}
     updateSave()
   end
+  Player[playerColor].clearSelectedObjects()
 end
 
 -- returns multiple tokens at once to the token pool
@@ -297,6 +300,7 @@ function returnMultipleTokens(playerColor)
   else
     printToColor("Not enough tokens sealed.", playerColor)
   end
+  Player[playerColor].clearSelectedObjects()
 end
 
 -- returns the token (referenced by GUID) to the chaos bag
@@ -328,7 +332,7 @@ function returnToken(guid)
 end
 
 -- resolves sealed token as if it came from the chaos bag
-function resolveSealed()
+function resolveSealed(playerColor)
   if #sealedTokens == 0 then
     broadcastToAll("No tokens sealed.", "Red")
     return
@@ -341,6 +345,7 @@ function resolveSealed()
   updateStackSize()
   updateSave()
   chaosBagApi.drawChaosToken(mat, true, _, guidToBeResolved)
+  Player[playerColor].clearSelectedObjects()
 end
 
 function updateStackSize()


### PR DESCRIPTION
E.g. after resolving a Curse token from Favor of the Moon, deselects Favor of the Moon automatically so that if Blasphemous Covenant is hovered and rotated, Favor of the Moon is not rotated again.