### PR TITLE
Attachment Helper: use metadata for matching and load rotation

### DIFF
--- a/src/accessories/AttachmentHelper.ttslua
+++ b/src/accessories/AttachmentHelper.ttslua
@@ -3,96 +3,113 @@ local fontColor, lastRejectedName
 local BACKGROUNDS = {
   {
     title     = "Ancestral Knowledge",
+    id        = "07303",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1915746489207287888/2F9F6F211ED0F98E66C9D35D93221E4C7FB6DD3C/",
     fontcolor = { 1, 1, 1 },
     icons     = true
   },
   {
     title     = "Astronomical Atlas",
+    id        = "08067",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1754695853007989004/9153BC204FC707AE564ECFAC063A11CB8C2B5D1E/",
     fontcolor = { 1, 1, 1 },
     icons     = true
   },
   {
     title     = "Backpack",
+    id        = "04037",
+    id2       = "53011",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2018212896278691928/F55BEFFC2540109C6333179532F583B367FF2EBC/",
     fontcolor = { 0, 0, 0 },
     icons     = false
   },
   {
     title     = "Bewitching",
+    id        = "10079",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2342503480966345423/F2070B5479C814F35780373966D77D91767A97CC/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Binder's Jar",
+    id        = "09089",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2021606446228642191/4C149527851C1DBB3015F93DE91667937A3F91DD/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Crystallizer of Dreams",
+    id        = "06024",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1915746489207280958/100F16441939E5E23818651D1EB5C209BF3125B9/",
     fontcolor = { 1, 1, 1 },
     icons     = true
   },
   {
     title     = "Diana Stanley",
+    id        = "05004",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1754695635919071208/1AB7222850201630826BFFBA8F2BD0065E2D572F/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Gloria Goldberg",
+    id        = "98019",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1754695635919102502/453D4426118C8A6DE2EA281184716E26CA924C84/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Hunting Jacket",
+    id        = "10121",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2450601762292308846/0E171E3F3F0D016EEC574F3CA25738A46D95595C/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Ikiaq",
+    id        = "07267",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2021606446228198966/5A408D8D760221DEA164E986B9BE1F79C4803071/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Katja Eastbank",
+    id        = "09114",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2021606446228203475/62EEE12F4DB1EB80D79B087677459B954380215F/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Ravenous",
+    id        = "89002",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2021606446228208075/EAC598A450BEE504A7FE179288F1FBBF7ABFA3E0/",
     fontcolor = { 0, 0, 0 },
     icons     = false
   },
   {
     title     = "Sefina Rousseau",
+    id        = "03003",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1754695635919099826/3C3CBFFAADB2ACA9957C736491F470AE906CC953/",
     fontcolor = { 0, 0, 0 },
     icons     = false
   },
   {
     title     = "Stick to the Plan",
+    id        = "03264",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2018214163838897493/8E38B96C5A8D703A59009A932432CBE21ABE63A2/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Subject 5U-21",
+    id        = "89001",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/2021606446228199363/CE43D58F37C9F48BDD6E6E145FE29BADEFF4DBC5/",
     fontcolor = { 1, 1, 1 },
     icons     = false
   },
   {
     title     = "Wooden Sledge",
+    id        = "08615",
     url       = "https://steamusercontent-a.akamaihd.net/ugc/1750192233783143973/D526236AAE16BDBB98D3F30E27BAFC1D3E21F4AC/",
     fontcolor = { 0, 0, 0 },
     icons     = false
@@ -135,16 +152,20 @@ function onDrop(playerColor)
   local pos = self.getPosition():setAt("y", 2)
   local searchResult = searchLib.belowPosition(pos, "isCard")
   if #searchResult == 0 then return end
-  local syncName = searchResult[1].getName()
 
-  -- remove level information from syncName
-  syncName = syncName:gsub("%s%(%d%)", "")
+  -- assume the first eligible object as intended sync object
+  local syncObj = searchResult[1]
+  local syncName = syncObj.getName()
+  local notes = syncObj.getGMNotes()
+  local metadata = JSON.decode(notes) or {}
+  local syncId = metadata.id
 
   -- loop through background table
   for _, bgInfo in ipairs(BACKGROUNDS) do
-    if bgInfo.title == syncName then
+    if bgInfo.id == syncId or bgInfo.id2 == syncId then
       printToColor("Background for '" .. syncName .. "' loaded!", playerColor, "Green")
       showIcons = bgInfo.icons
+      self.setRotation(syncObj.getRotation())
       updateImage(bgInfo.url)
       return
     end

--- a/src/accessories/AttachmentHelper.ttslua
+++ b/src/accessories/AttachmentHelper.ttslua
@@ -157,15 +157,22 @@ function onDrop(playerColor)
   local syncObj = searchResult[1]
   local syncName = syncObj.getName()
   local notes = syncObj.getGMNotes()
-  local metadata = JSON.decode(notes) or {}
-  local syncId = metadata.id
+  local md = JSON.decode(notes) or {}
 
   -- loop through background table
   for _, bgInfo in ipairs(BACKGROUNDS) do
-    if bgInfo.id == syncId or bgInfo.id2 == syncId then
+    if bgInfo.id == md.id or bgInfo.id2 == md.id then
       printToColor("Background for '" .. syncName .. "' loaded!", playerColor, "Green")
       showIcons = bgInfo.icons
-      self.setRotation(syncObj.getRotation())
+
+      -- update rotation
+      local syncRotY = syncObj.getRotation().y
+      if md.type == "Investigator" then
+        syncRotY = syncRotY + 90
+      end
+      self.setRotation(self.getRotation():setAt("y", syncRotY))
+
+      -- update the image
       updateImage(bgInfo.url)
       return
     end


### PR DESCRIPTION
This will use the metadata (specifically: the ID) to match cards for the Attachment Helper. Main reason is to support localized cards.
Additionally, loading an image via dropping will also rotate the AH the same way as the card.

To-Do:
- [x] handling for investigators (+90° rotation)