### PR TITLE
Fixed playermat script states + Deck Importer Bug

### DIFF
--- a/objects/Playermat1White.8b081b.luascriptstate
+++ b/objects/Playermat1White.8b081b.luascriptstate
@@ -1,7 +1,8 @@
 {
   "activeInvestigatorData": {
     "class": "Neutral",
-    "id": "00000"
+    "id": "00000",
+    "miniId": "00000-m"
   },
   "isClassTextureEnabled": true,
   "isDrawButtonVisible": false,

--- a/objects/Playermat2Orange.bd0ff4.luascriptstate
+++ b/objects/Playermat2Orange.bd0ff4.luascriptstate
@@ -1,7 +1,8 @@
 {
   "activeInvestigatorData": {
     "class": "Neutral",
-    "id": "00000"
+    "id": "00000",
+    "miniId": "00000-m"
   },
   "isClassTextureEnabled": true,
   "isDrawButtonVisible": false,

--- a/objects/Playermat3Green.383d8b.luascriptstate
+++ b/objects/Playermat3Green.383d8b.luascriptstate
@@ -1,7 +1,8 @@
 {
   "activeInvestigatorData": {
     "class": "Neutral",
-    "id": "00000"
+    "id": "00000",
+    "miniId": "00000-m"
   },
   "isClassTextureEnabled": true,
   "isDrawButtonVisible": false,

--- a/objects/Playermat4Red.0840d5.luascriptstate
+++ b/objects/Playermat4Red.0840d5.luascriptstate
@@ -1,7 +1,8 @@
 {
   "activeInvestigatorData": {
     "class": "Neutral",
-    "id": "00000"
+    "id": "00000",
+    "miniId": "00000-m"
   },
   "isClassTextureEnabled": true,
   "isDrawButtonVisible": false,

--- a/src/arkhamdb/DeckImporter.ttslua
+++ b/src/arkhamdb/DeckImporter.ttslua
@@ -487,6 +487,7 @@ function removeBusyZones(playerColor, zoneDecks)
       zoneDecks["SetAside" .. i] = nil
       zoneDecks["Blank" .. i] = nil
     end
+    zoneDecks["UnderSetAside3"] = nil
     zoneDecks["Deck"] = nil
     printToAll("Skipped deck import", playerColor)
   end


### PR DESCRIPTION
Scriptstate fixes add the "miniId" field to the saved data.
Deck Importer fix is to clear the "UnderSetAside3" zone too when skipping deck import.