### PR TITLE
Added a global XML UI for the Bless/Curse Manager

### DIFF
--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -105,14 +105,9 @@
     "URL": "https://steamusercontent-a.akamaihd.net/ugc/2450610458480705628/FE3FD9F32E8704BEB7DD6327225D9D8244115A48/"
   },
   {
-    "Name": "arrow-down",
+    "Name": "blurse",
     "Type": 0,
-    "URL": "https://steamusercontent-a.akamaihd.net/ugc/2448359292156394304/63B2D48BB94DD4CD4F897D8528E049D521298B02/"
-  },
-  {
-    "Name": "caret",
-    "Type": 0,
-    "URL": "https://steamusercontent-a.akamaihd.net/ugc/2448359292156394421/CFAF0262FEDE662D399A5D786E7450B49B952C99/"
+    "URL": "https://steamusercontent-a.akamaihd.net/ugc/2448359292169458161/DDF4F777B738E2BDD9AF7B3B98AF200DB12485C0/"
   },
   {
     "Name": "Exit",

--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -105,6 +105,16 @@
     "URL": "https://steamusercontent-a.akamaihd.net/ugc/2450610458480705628/FE3FD9F32E8704BEB7DD6327225D9D8244115A48/"
   },
   {
+    "Name": "arrow-down",
+    "Type": 0,
+    "URL": "https://steamusercontent-a.akamaihd.net/ugc/2448359292156394304/63B2D48BB94DD4CD4F897D8528E049D521298B02/"
+  },
+  {
+    "Name": "caret",
+    "Type": 0,
+    "URL": "https://steamusercontent-a.akamaihd.net/ugc/2448359292156394421/CFAF0262FEDE662D399A5D786E7450B49B952C99/"
+  },
+  {
     "Name": "Exit",
     "Type": 0,
     "URL": "https://i.imgur.com/8qmTXwt.png"

--- a/objects/LuaScriptState.luascriptstate
+++ b/objects/LuaScriptState.luascriptstate
@@ -1,5 +1,6 @@
 {
   "acknowledgedUpgradeVersions": [],
+  "blurseVisibility": [],
   "chaosTokensGUID": [],
   "handVisibility": [],
   "optionPanel": {

--- a/src/chaosbag/BlessCurseManager.ttslua
+++ b/src/chaosbag/BlessCurseManager.ttslua
@@ -89,12 +89,23 @@ function initializeState()
     end
   end
 
-  updateButtonLabels()
+  -- delay this update to make sure the XML is ready
+  Wait.time(updateButtonLabels, 2)
 end
 
+-- updates the Lua and XML labels with the current bless / curse count
 function updateButtonLabels()
-  self.editButton({ index = 2, label = formatTokenCount("Bless", true) })
-  self.editButton({ index = 3, label = formatTokenCount("Curse", true) })
+  -- get formatted labels
+  local blessLabel = formatTokenCount("Bless", true)
+  local curseLabel = formatTokenCount("Curse", true)
+
+  -- edit Lua buttons on the helper
+  self.editButton({ index = 2, label = blessLabel })
+  self.editButton({ index = 3, label = curseLabel })
+
+  -- edit global XML buttons
+  Global.UI.setAttribute("countBless", "text", blessLabel)
+  Global.UI.setAttribute("countCurse", "text", curseLabel)
 end
 
 function broadcastCount(token)
@@ -185,6 +196,13 @@ end
 ---------------------------------------------------------
 -- click functions
 ---------------------------------------------------------
+
+function xmlClick(player, clickType, id)
+  playerColor = player.color
+  local isRightClick = (clickType == "-2")
+  local tokenType = string.sub(id, 6)
+  callFunctions(tokenType, isRightClick)
+end
 
 function clickBless(_, color, isRightClick)
   playerColor = color

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1176,25 +1176,25 @@ function onClick_spawnPlaceholder(player)
   changeWindowVisibilityForColor(player.color, "downloadWindow", false)
 end
 
--- toggles the visibility of the bless / curse manager UI
-function showHideBlurse(player)
-  local visibility = changeWindowVisibilityForColor(player.color, "blessCurseManager")
-  changeWindowVisibilityForColor(player.color, "hideBlurse", visibility)
-  blurseVisibility[player.color] = visibility
-end
-
 -- toggles the visibility of the respective UI
 ---@param player tts__Player Player that triggered this
 ---@param windowId string Name of the UI to toggle
 function onClick_toggleUi(player, windowId)
+  -- let the Navigation Overlay handle the toggling of its visibility modes
   if windowId == "Navigation Overlay" then
     navigationOverlayApi.cycleVisibility(player.color)
     return
   end
 
   -- hide the playAreaGallery / downloadWindow if visible
-  if windowId == "downloadWindow" or windowId == "playAreaGallery" then
-    changeWindowVisibilityForColor(player.color, windowId, false)
+  if windowId == "downloadWindow" then
+    changeWindowVisibilityForColor(player.color, "playAreaGallery", false)
+  elseif windowId == "playAreaGallery" then
+    changeWindowVisibilityForColor(player.color, "downloadWindow", false)
+  elseif windowId == "blessCurseManager" then
+    -- store the state of the Bless/Curse Manager UI to restore it onLoad()
+    blurseVisibility[player.color] = changeWindowVisibilityForColor(player.color, "blessCurseManager")
+    return
   end
 
   changeWindowVisibilityForColor(player.color, windowId)
@@ -1900,16 +1900,13 @@ function applyHidingToCard(card, handColor)
   end
 end
 
+-- loads the visibility of the Bless/Curse Manager XML from the internal variable
 function updateBlurseVisibility()
-  function coroBlurse()
-    for playerColor, state in pairs(blurseVisibility) do
-      changeWindowVisibilityForColor(playerColor, "blessCurseManager", state)
-      changeWindowVisibilityForColor(playerColor, "hideBlurse", state)
-      coroutine.yield()
-    end
-    return 1
+  local count = 1
+  for playerColor, state in pairs(blurseVisibility) do
+    Wait.frames(function() changeWindowVisibilityForColor(playerColor, "blessCurseManager", state) end, count)
+    count = count + 3
   end
-  startLuaCoroutine(Global, "coroBlurse")
 end
 
 ---------------------------------------------------------

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1172,6 +1172,13 @@ function onClick_spawnPlaceholder(player)
   changeWindowVisibilityForColor(player.color, "downloadWindow", false)
 end
 
+-- toggles the visbility of the bless / curse manager UI
+function showHideBlurse(player)
+  local visibility = changeWindowVisibilityForColor(player.color, "blessCurseManager")
+  changeWindowVisibilityForColor(player.color, "hideBlurse", visibility)
+  changeWindowVisibilityForColor(player.color, "showBlurse", not visibility)
+end
+
 -- toggles the visibility of the respective UI
 ---@param player tts__Player Player that triggered this
 ---@param windowId string Name of the UI to toggle

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -71,8 +71,9 @@ local RESOURCE_OPTIONS              = {
   "disabled"
 }
 
--- tracks the visibility of each hand
+-- track player-specific visibilities
 local handVisibility                = {}
+local blurseVisibility              = {}
 
 ---------------------------------------------------------
 -- data for tokens
@@ -137,6 +138,7 @@ function onSave()
     acknowledgedUpgradeVersions = acknowledgedUpgradeVersions,
     chaosTokensLastMatGUID      = chaosTokensLastMatGUID,
     chaosTokensGUID             = chaosTokensGUID,
+    blurseVisibility            = blurseVisibility,
     handVisibility              = handVisibility,
     optionPanel                 = optionPanel
   })
@@ -147,6 +149,7 @@ function onLoad(savedData)
     local loadedData            = JSON.decode(savedData)
     acknowledgedUpgradeVersions = loadedData.acknowledgedUpgradeVersions
     chaosTokensLastMatGUID      = loadedData.chaosTokensLastMatGUID
+    blurseVisibility            = loadedData.blurseVisibility
     handVisibility              = loadedData.handVisibility
     optionPanel                 = loadedData.optionPanel
 
@@ -165,6 +168,7 @@ function onLoad(savedData)
 
   getModVersion()
   updateHandVisibility()
+  updateBlurseVisibility()
   math.randomseed(os.time())
   TokenManager.initialiize()
 
@@ -1172,11 +1176,11 @@ function onClick_spawnPlaceholder(player)
   changeWindowVisibilityForColor(player.color, "downloadWindow", false)
 end
 
--- toggles the visbility of the bless / curse manager UI
+-- toggles the visibility of the bless / curse manager UI
 function showHideBlurse(player)
   local visibility = changeWindowVisibilityForColor(player.color, "blessCurseManager")
   changeWindowVisibilityForColor(player.color, "hideBlurse", visibility)
-  changeWindowVisibilityForColor(player.color, "showBlurse", not visibility)
+  blurseVisibility[player.color] = visibility
 end
 
 -- toggles the visibility of the respective UI
@@ -1894,6 +1898,18 @@ function applyHidingToCard(card, handColor)
   else
     card.setHiddenFrom({})
   end
+end
+
+function updateBlurseVisibility()
+  function coroBlurse()
+    for playerColor, state in pairs(blurseVisibility) do
+      changeWindowVisibilityForColor(playerColor, "blessCurseManager", state)
+      changeWindowVisibilityForColor(playerColor, "hideBlurse", state)
+      coroutine.yield()
+    end
+    return 1
+  end
+  startLuaCoroutine(Global, "coroBlurse")
 end
 
 ---------------------------------------------------------

--- a/xml/Global/BlessCurseManager.xml
+++ b/xml/Global/BlessCurseManager.xml
@@ -1,0 +1,71 @@
+<Defaults>
+  <Text font="font_teutonic-arkham"
+    alignment="MiddleCenter"
+    rectAlignment="MiddleCenter"/>
+  <Panel class="showHide"
+    color="black"
+    height="30"
+    width="30"
+    rectAlignment="MiddleRight"
+    offsetXY="0 72"
+    outlineSize="2 2"
+    outline="#303030"/>
+</Defaults>
+
+<!-- hide button for the Bless / Curse Manager -->
+<Panel class="showHide"
+  active="false"
+  id="hideBlurse">
+  <Button onClick="showHideBlurse"
+    color="White"
+    image="caret"/>
+</Panel>
+
+<!-- show button for the Bless / Curse Manager -->
+<Panel class="showHide"
+  active="true"
+  id="showBlurse">
+  <Button onClick="showHideBlurse"
+    color="White"
+    image="arrow-down"/>
+</Panel>
+
+<!-- window to control bless / curse tokens in chaos bag -->
+<!-- height = row heights + 2x outline + spacing -->
+<TableLayout id="blessCurseManager"
+  color="black"
+  active="false"
+  height="110"
+  width="150"
+  rectAlignment="MiddleRight"
+  raycastTarget="true"
+  cellSpacing="5"
+  outlineSize="2 2"
+  outline="#303030">
+  <!-- token counts -->
+  <Row preferredHeight="31">
+    <Cell>
+      <Text id="countBless"
+        fontSize="25"
+        text="0 + 0"/>
+    </Cell>
+    <Cell>
+      <Text id="countCurse"
+        fontSize="25"
+        text="0 + 0"/>
+    </Cell>
+  </Row>
+  <!-- token buttons -->
+  <Row preferredHeight="70">
+    <Cell>
+      <Button image="token-bless"
+        id="imageBless"
+        onClick="5933fb/xmlClick"/>
+    </Cell>
+    <Cell>
+      <Button image="token-curse"
+        id="imageCurse"
+        onClick="5933fb/xmlClick"/>
+    </Cell>
+  </Row>
+</TableLayout>

--- a/xml/Global/BlessCurseManager.xml
+++ b/xml/Global/BlessCurseManager.xml
@@ -10,29 +10,7 @@
     offsetXY="0 69"
     outlineSize="2 2"
     outline="#303030"/>
-  <Button class="blurseButton"
-    onClick="showHideBlurse"
-    tooltipPosition="Left"
-    tooltipBackgroundColor="rgba(0,0,0,1)"
-    color="White" />
 </Defaults>
-
-<!-- show button for the Bless / Curse Manager -->
-<Panel class="showHide"
-  id="showBlurse">
-  <Button class="blurseButton"
-    tooltip="Show Bless/Curse Manager"
-    image="arrow-down"/>
-</Panel>
-
-<!-- hide button for the Bless / Curse Manager -->
-<Panel class="showHide"
-  active="false"
-  id="hideBlurse">
-  <Button class="blurseButton"
-    tooltip="Hide Bless/Curse Manager"
-    image="caret"/>
-</Panel>
 
 <!-- window to control bless / curse tokens in chaos bag -->
 <!-- height = row heights + 2x outline -->
@@ -41,7 +19,8 @@
   active="false"
   height="104"
   width="144"
-  rectAlignment="MiddleRight"
+  offsetXY="-1 250"
+  rectAlignment="LowerRight"
   raycastTarget="true"
   outlineSize="2 2"
   outline="#303030">

--- a/xml/Global/BlessCurseManager.xml
+++ b/xml/Global/BlessCurseManager.xml
@@ -7,27 +7,31 @@
     height="30"
     width="30"
     rectAlignment="MiddleRight"
-    offsetXY="0 67"
+    offsetXY="0 69"
     outlineSize="2 2"
     outline="#303030"/>
+  <Button class="blurseButton"
+    onClick="showHideBlurse"
+    tooltipPosition="Left"
+    tooltipBackgroundColor="rgba(0,0,0,1)"
+    color="White" />
 </Defaults>
+
+<!-- show button for the Bless / Curse Manager -->
+<Panel class="showHide"
+  id="showBlurse">
+  <Button class="blurseButton"
+    tooltip="Show Bless/Curse Manager"
+    image="arrow-down"/>
+</Panel>
 
 <!-- hide button for the Bless / Curse Manager -->
 <Panel class="showHide"
   active="false"
   id="hideBlurse">
-  <Button onClick="showHideBlurse"
-    color="White"
+  <Button class="blurseButton"
+    tooltip="Hide Bless/Curse Manager"
     image="caret"/>
-</Panel>
-
-<!-- show button for the Bless / Curse Manager -->
-<Panel class="showHide"
-  active="true"
-  id="showBlurse">
-  <Button onClick="showHideBlurse"
-    color="White"
-    image="arrow-down"/>
 </Panel>
 
 <!-- window to control bless / curse tokens in chaos bag -->
@@ -35,14 +39,14 @@
 <TableLayout id="blessCurseManager"
   color="black"
   active="false"
-  height="100"
+  height="104"
   width="144"
   rectAlignment="MiddleRight"
   raycastTarget="true"
   outlineSize="2 2"
   outline="#303030">
   <!-- token counts -->
-  <Row preferredHeight="26">
+  <Row preferredHeight="30">
     <Cell>
       <Text id="countBless"
         fontSize="25"

--- a/xml/Global/BlessCurseManager.xml
+++ b/xml/Global/BlessCurseManager.xml
@@ -7,7 +7,7 @@
     height="30"
     width="30"
     rectAlignment="MiddleRight"
-    offsetXY="0 72"
+    offsetXY="0 67"
     outlineSize="2 2"
     outline="#303030"/>
 </Defaults>
@@ -31,19 +31,18 @@
 </Panel>
 
 <!-- window to control bless / curse tokens in chaos bag -->
-<!-- height = row heights + 2x outline + spacing -->
+<!-- height = row heights + 2x outline -->
 <TableLayout id="blessCurseManager"
   color="black"
   active="false"
-  height="110"
-  width="150"
+  height="100"
+  width="144"
   rectAlignment="MiddleRight"
   raycastTarget="true"
-  cellSpacing="5"
   outlineSize="2 2"
   outline="#303030">
   <!-- token counts -->
-  <Row preferredHeight="31">
+  <Row preferredHeight="26">
     <Cell>
       <Text id="countBless"
         fontSize="25"
@@ -58,14 +57,18 @@
   <!-- token buttons -->
   <Row preferredHeight="70">
     <Cell>
-      <Button image="token-bless"
-        id="imageBless"
-        onClick="5933fb/xmlClick"/>
+      <Panel padding="4 4 4 4">
+        <Button image="token-bless"
+          id="imageBless"
+          onClick="5933fb/xmlClick"/>
+      </Panel>
     </Cell>
     <Cell>
-      <Button image="token-curse"
-        id="imageCurse"
-        onClick="5933fb/xmlClick"/>
+      <Panel padding="4 4 4 4">
+        <Button image="token-curse"
+          id="imageCurse"
+          onClick="5933fb/xmlClick"/>
+      </Panel>
     </Cell>
   </Row>
 </TableLayout>

--- a/xml/Global/BottomBar.xml
+++ b/xml/Global/BottomBar.xml
@@ -1,20 +1,28 @@
 <Defaults>
   <Button class="navbar"
+    tooltipOffset="-135"
     tooltipPosition="Left"
     tooltipBackgroundColor="rgba(0,0,0,1)"
     color="clear"/>
+  <VerticalLayout class="navbar"
+    width="800"
+    padding="70 70 70 70"
+    scale="0.05 0.05 1"
+    color="#000000"
+    outlineSize="20 20"
+    outline="#303030"
+    rectAlignment="LowerRight"/>
 </Defaults>
 
-<!-- Buttons at the bottom right (height: n * width + spacing) -->
-<VerticalLayout visibility="Admin"
-  color="#000000"
-  outlineSize="1 1"
-  outline="#303030"
-  rectAlignment="LowerRight"
-  width="38"
-  height="78"
-  offsetXY="-1 123"
-  spacing="2">
+<!-- Buttons at the bottom right (height: n * width) -->
+<VerticalLayout class="navbar"
+  visibility="Admin"
+  height="2400"
+  offsetXY="-1 120">
+  <Button class="navbar"
+    icon="blurse"
+    tooltip="Bless/Curse Manager"
+    onClick="onClick_toggleUi(blessCurseManager)"/>
   <Button class="navbar"
     icon="devourer"
     tooltip="Downloadable Content"
@@ -25,17 +33,12 @@
     onClick="onClick_toggleUi(optionPanel)"/>
 </VerticalLayout>
 
-<!-- Navigation Overlay button (not visibly to Grey and Black) -->
-<Panel visibility="White|Brown|Red|Orange|Yellow|Green|Teal|Blue|Purple|Pink"
-  color="#000000"
-  outlineSize="1 1"
-  outline="#303030"
-  rectAlignment="LowerRight"
-  width="38"
-  height="38"
-  offsetXY="-1 85">
+<!-- Navigation Overlay button -->
+<VerticalLayout class="navbar"
+  height="800"
+  offsetXY="-1 80">
   <Button class="navbar"
     icon="NavigationOverlayIcon"
     tooltip="Navigation Overlay"
     onClick="onClick_toggleUi(Navigation Overlay)"/>
-</Panel>
+</VerticalLayout>

--- a/xml/Global/BottomBar.xml
+++ b/xml/Global/BottomBar.xml
@@ -1,6 +1,6 @@
 <Defaults>
   <Button class="navbar"
-    tooltipOffset="-135"
+    tooltipOffset="-300"
     tooltipPosition="Left"
     tooltipBackgroundColor="rgba(0,0,0,1)"
     color="clear"/>

--- a/xml/Global/Global.xml
+++ b/xml/Global/Global.xml
@@ -11,3 +11,4 @@
 <Include src="Global/NavigationOverlay.xml"/>
 <Include src="Global/OptionPanel.xml"/>
 <Include src="Global/UpdateNotification.xml"/>
+<Include src="Global/BlessCurseManager.xml"/>

--- a/xml/Global/Global.xml
+++ b/xml/Global/Global.xml
@@ -9,6 +9,6 @@
 <Include src="Global/PlayAreaGallery.xml"/>
 <Include src="Global/TitleSplash.xml"/>
 <Include src="Global/NavigationOverlay.xml"/>
+<Include src="Global/BlessCurseManager.xml"/>
 <Include src="Global/OptionPanel.xml"/>
 <Include src="Global/UpdateNotification.xml"/>
-<Include src="Global/BlessCurseManager.xml"/>


### PR DESCRIPTION
This is in addition (and in sync) with the existing Bless / Curse Manager.
We could remove it at a later point, but I am not sure yet if we want to force the global XML on everyone.
It features an "accordion" button to collapse / expand it.

Closes https://github.com/argonui/SCED/issues/870

![image](https://github.com/user-attachments/assets/438d7e84-dd7b-4e6b-b5c7-fc0f38731694)