### PR TITLE
Added ability to specify a download repo version for a mod version

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1928,6 +1928,15 @@ function compareVersion(request)
   -- global variable to make it accessible for other functions
   modMeta = JSON.decode(request.text)
 
+  -- maybe update SOURCE_REPO to specific version
+  if modMeta["setSpecificDownloadVersion"] then
+    local versionTable = modMeta["setSpecificDownloadVersion"][1]
+    if versionTable[MOD_VERSION] then
+      SOURCE_REPO = "https://github.com/Chr1Z93/SCED-downloads/releases/download/" .. versionTable[MOD_VERSION] .. "/"
+      log("Using download repo version: " .. versionTable[MOD_VERSION])
+    end
+  end
+
   -- stop here if on latest or newer version
   if convertVersionToNumber(MOD_VERSION) >= convertVersionToNumber(modMeta["latestVersion"]) then return end
 


### PR DESCRIPTION
This adds the ability for us to specify a specific version of the downloads repo for a specific mod version.

The specification in the modversion.json file looks like this:
```json
  "setSpecificDownloadVersion": [
    {
      "3.9.9": "v0.5.3"
    }
  ]
  ```