### PR TITLE
Additional way of stopping objects from falling through the playermat

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1449,6 +1449,7 @@ function updateTexture(overrideName)
       Wait.frames(function()
         for _, obj in ipairs(objectsToUnlock) do
           obj.setLock(false)
+          obj.resting = true
         end
       end, 5)
     end, function() return reloadedMat.loading_custom == false end)


### PR DESCRIPTION
Couldn't replicate the falling through locally (I think it's mostly happening in multiplayer?), so it's worth keeping an eye open about this.