### PR TITLE
Added additional check for objects leaving a zone

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -262,7 +262,7 @@ function onObjectLeaveZone(zone, object)
 
       -- make sure that the object really left and isn't still in a hand zone
       for _, objZone in ipairs(object.getZones()) do
-        if objZone.type == "Hand" then return end
+        if objZone.isDestroyed() or objZone.type == "Hand" then return end
       end
 
       -- resync the state of the helper on the card with the option panel

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -260,6 +260,11 @@ function onObjectLeaveZone(zone, object)
       -- end here if one of the objects doesn't exist
       if zone.isDestroyed() or object.isDestroyed() then return end
 
+      -- make sure that the object really left and isn't still in a hand zone
+      for _, objZone in ipairs(object.getZones()) do
+        if objZone.type == "Hand" then return end
+      end
+
       -- resync the state of the helper on the card with the option panel
       if zone.type == "Hand" and object.hasTag("CardWithHelper") then
         object.call("syncDisplayWithOptionPanel")

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -254,25 +254,21 @@ end
 
 -- TTS event for objects that leave zones
 function onObjectLeaveZone(zone, object)
-  -- 1 frame delay to avoid error messages when exiting the game
-  Wait.frames(
-    function()
-      -- end here if one of the objects doesn't exist
-      if zone.isDestroyed() or object.isDestroyed() then return end
+  -- end here if one of the objects doesn't exist
+  if zone.isDestroyed() or object.isDestroyed() then return end
 
-      -- make sure that the object really left and isn't still in a hand zone
-      for _, objZone in ipairs(object.getZones()) do
-        if objZone.isDestroyed() or objZone.type == "Hand" then return end
-      end
+  -- make sure that the object really left and isn't still in a hand zone
+  for _, objZone in ipairs(object.getZones()) do
+    if objZone.isDestroyed() or objZone.type == "Hand" then return end
+  end
 
-      -- resync the state of the helper on the card with the option panel
-      if zone.type == "Hand" and object.hasTag("CardWithHelper") then
-        object.call("syncDisplayWithOptionPanel")
-      end
+  -- resync the state of the helper on the card with the option panel
+  if zone.type == "Hand" and object.hasTag("CardWithHelper") then
+    object.call("syncDisplayWithOptionPanel")
+  end
 
-      -- make object visible
-      object.setHiddenFrom({})
-    end, 1)
+  -- make object visible
+  object.setHiddenFrom({})
 end
 
 -- handle card drawing via number typing for multihanded gameplay


### PR DESCRIPTION
For some reason the card dealing by the Search Assistant was triggering both "onObjectEnterZone" and "OnObjectLeaveZone". This introduces an additional check for cards leaving zones.