### PR TITLE
Changed behavior of visibility of helpers

### DIFF
--- a/objects/AllPlayerCards.15bb07/Analysis.80285f.json
+++ b/objects/AllPlayerCards.15bb07/Analysis.80285f.json
@@ -42,7 +42,8 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/BookofLivingMyths.c5fb1f.json
+++ b/objects/AllPlayerCards.15bb07/BookofLivingMyths.c5fb1f.json
@@ -60,7 +60,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/ClaypoolsFurs.c1f999.json
+++ b/objects/AllPlayerCards.15bb07/ClaypoolsFurs.c1f999.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/CustomModifications.d2252d.json
+++ b/objects/AllPlayerCards.15bb07/CustomModifications.d2252d.json
@@ -42,7 +42,8 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/Dream-EnhancingSerum.98c5af.json
+++ b/objects/AllPlayerCards.15bb07/Dream-EnhancingSerum.98c5af.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/EmpiricalHypothesis.62c67d.json
+++ b/objects/AllPlayerCards.15bb07/EmpiricalHypothesis.62c67d.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/FalseCovenant2.3442f5.json
+++ b/objects/AllPlayerCards.15bb07/FalseCovenant2.3442f5.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/FamilyInheritance.394603.json
+++ b/objects/AllPlayerCards.15bb07/FamilyInheritance.394603.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/HeavyFurs.275450.json
+++ b/objects/AllPlayerCards.15bb07/HeavyFurs.275450.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/KhakuNarukami.54eaa7.json
+++ b/objects/AllPlayerCards.15bb07/KhakuNarukami.54eaa7.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Investigator",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/NkosiMabati3.6c5628.json
+++ b/objects/AllPlayerCards.15bb07/NkosiMabati3.6c5628.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/StellaClark.00e18e.json
+++ b/objects/AllPlayerCards.15bb07/StellaClark.00e18e.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Investigator",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/Strong-Armed1.294d6.json
+++ b/objects/AllPlayerCards.15bb07/Strong-Armed1.294d6.json
@@ -42,7 +42,8 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/TheRedClock2.814c79.json
+++ b/objects/AllPlayerCards.15bb07/TheRedClock2.814c79.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/TheRedClock5.696894.json
+++ b/objects/AllPlayerCards.15bb07/TheRedClock5.696894.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/ThirdTimesaCharm2.45956a.json
+++ b/objects/AllPlayerCards.15bb07/ThirdTimesaCharm2.45956a.json
@@ -42,7 +42,8 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WellConnected.66b7d5.json
+++ b/objects/AllPlayerCards.15bb07/WellConnected.66b7d5.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WellConnected3.170127.json
+++ b/objects/AllPlayerCards.15bb07/WellConnected3.170127.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Asset",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WendyAdams.fc1d17.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdams.fc1d17.json
@@ -107,7 +107,8 @@
   "Sticky": true,
   "Tags": [
     "Investigator",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/objects/AllPlayerCards.15bb07/WendyAdamsParallelBack.4232d9.json
+++ b/objects/AllPlayerCards.15bb07/WendyAdamsParallelBack.4232d9.json
@@ -43,7 +43,8 @@
   "Sticky": true,
   "Tags": [
     "Investigator",
-    "PlayerCard"
+    "PlayerCard",
+    "CardWithHelper"
   ],
   "Tooltip": true,
   "Transform": {

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1722,9 +1722,7 @@ function applyOptionPanelChange(id, state)
     
     -- option: Enable card helpers
   elseif id == "enableCardHelpers" then
-    if state == false then
-      turnOffCardHelpers()
-    end
+    toggleCardHelpers(state)
 
     -- option: Play area connection drawing
   elseif id == "playAreaConnections" then
@@ -1901,9 +1899,22 @@ function titleSplash(scenarioName)
 end
 
 -- turns off all card helpers, if they are on
-function turnOffCardHelpers()
+function toggleCardHelpers(state)
   for _, obj in ipairs(getObjectsWithTag("CardWithHelper")) do
-    obj.call("setHelperState", false)
+    local owner = guidReferenceApi.getOwnerOfObject(obj)
+    if owner == "Mythos" then return end
+
+    local mat = guidReferenceApi.getObjectByOwnerAndType(owner, "Playermat")
+    local relPos = mat.positionToLocal(obj.getPosition())
+    local metadata = JSON.decode(obj.getGMNotes())
+
+    if relPos.x > -1.5 and relPos.z > -0.3 and (metadata.type == "Asset"
+        or metadata.type == "Investigator"
+        or metadata.type == "Event") then
+        obj.call("setHelperState", state)
+    elseif relPos.x > -1.5 and relPos.z < -0.3 and (metadata.type == "Skill") then
+      obj.call("setHelperState", state)
+    end
   end
 end
 

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -235,11 +235,6 @@ function onObjectEnterZone(zone, object)
       object.flip()
     end
 
-    -- disable any helpers on the card
-    if object.hasTag("CardWithHelper") then
-      object.call("setHelperState", false)
-    end
-
     -- maybe reset data about sealed tokens (if that function exists)
     if object.hasTag("CardThatSeals") then
       local func = object.getVar("resetSealedTokens")
@@ -260,11 +255,6 @@ function onObjectLeaveZone(zone, object)
   -- make sure that the object really left and isn't still in a hand zone
   for _, objZone in ipairs(object.getZones()) do
     if objZone.isDestroyed() or objZone.type == "Hand" then return end
-  end
-
-  -- resync the state of the helper on the card with the option panel
-  if zone.type == "Hand" and object.hasTag("CardWithHelper") then
-    object.call("syncDisplayWithOptionPanel")
   end
 
   -- make object visible
@@ -1729,10 +1719,12 @@ function applyOptionPanelChange(id, state)
     -- update master clue counter
     local counter = guidReferenceApi.getObjectByOwnerAndType("Mythos", "MasterClueCounter")
     counter.setVar("useClickableCounters", state)
-
+    
     -- option: Enable card helpers
   elseif id == "enableCardHelpers" then
-    toggleCardHelpers(state)
+    if state == false then
+      turnOffCardHelpers()
+    end
 
     -- option: Play area connection drawing
   elseif id == "playAreaConnections" then
@@ -1908,10 +1900,10 @@ function titleSplash(scenarioName)
   end
 end
 
--- instructs all card helpers to update their visibility
-function toggleCardHelpers(state)
+-- turns off all card helpers, if they are on
+function turnOffCardHelpers()
   for _, obj in ipairs(getObjectsWithTag("CardWithHelper")) do
-    obj.call("setHelperState", state)
+    obj.call("setHelperState", false)
   end
 end
 

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1906,7 +1906,7 @@ function toggleCardHelpers(state)
 
     local mat = guidReferenceApi.getObjectByOwnerAndType(owner, "Playermat")
     local relPos = mat.positionToLocal(obj.getPosition())
-    local metadata = JSON.decode(obj.getGMNotes())
+    local metadata = JSON.decode(obj.getGMNotes()) or {}
 
     if relPos.x > -1.5 and relPos.z > -0.3 and (metadata.type == "Asset"
         or metadata.type == "Investigator"

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1911,7 +1911,7 @@ function toggleCardHelpers(state)
     if relPos.x > -1.5 and relPos.z > -0.3 and (metadata.type == "Asset"
         or metadata.type == "Investigator"
         or metadata.type == "Event") then
-        obj.call("setHelperState", state)
+      obj.call("setHelperState", state)
     elseif relPos.x > -1.5 and relPos.z < -0.3 and (metadata.type == "Skill") then
       obj.call("setHelperState", state)
     end

--- a/src/playercards/CardsThatRedrawTokens.ttslua
+++ b/src/playercards/CardsThatRedrawTokens.ttslua
@@ -67,6 +67,9 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
   createHelperXML()
+  if isHelperEnabled then
+    updateDisplay()
+  end
 end
 
 function createHelperXML()

--- a/src/playercards/CardsThatRedrawTokens.ttslua
+++ b/src/playercards/CardsThatRedrawTokens.ttslua
@@ -67,7 +67,6 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
   createHelperXML()
-  syncDisplayWithOptionPanel()
 end
 
 function createHelperXML()

--- a/src/playercards/CardsWithHelper.ttslua
+++ b/src/playercards/CardsWithHelper.ttslua
@@ -10,31 +10,10 @@ Instructions:
 hasXML          = true  (whether the card has an XML display)
 isHelperEnabled = false (default state of the helper, should be 'false')
 
-2) In 'onLoad()'', call 'syncDisplayWithOptionPanel()'
 ----------------------------------------------------------]]
 
 local GlobalApi = require("core/GlobalApi")
 
--- if the respective option is enabled in onLoad(), enable the helper
-function syncDisplayWithOptionPanel()
-  self.addTag("CardWithHelper")
-
-  -- check if this card is in a hand zone (because we're loading a saved game)
-  for _, zone in ipairs(self.getZones()) do
-    if zone.type == "Hand" then
-      setHelperState(false)
-      return
-    end
-  end
-
-  -- get state of the option panel
-  local options = GlobalApi.getOptionPanelState()
-  if options.enableCardHelpers then
-    setHelperState(true)
-  else
-    updateDisplay()
-  end
-end
 
 -- forces a new state
 function setHelperState(newState)
@@ -67,4 +46,8 @@ function actualDisplayUpdate()
     if hasXML then self.UI.hide("Helper") end
     if shutOff then shutOff() end
   end
+end
+
+function onPickUp()
+  setHelperState(false)
 end

--- a/src/playercards/CardsWithHelper.ttslua
+++ b/src/playercards/CardsWithHelper.ttslua
@@ -10,20 +10,27 @@ Instructions:
 hasXML          = true  (whether the card has an XML display)
 isHelperEnabled = false (default state of the helper, should be 'false')
 
+2) Add "CardWithHelper" tag to .json for the card object itself.
+
+3) Add `if isHelperEnabled then updateDisplay() end` to onLoad()
+
 ----------------------------------------------------------]]
-
-local GlobalApi = require("core/GlobalApi")
-
 
 -- forces a new state
 function setHelperState(newState)
+  if doNotTurnOff == true then return end
   isHelperEnabled = newState
   updateSave()
   updateDisplay()
 end
 
 -- toggles the current state
-function toggleHelper()
+function toggleHelper(manual)
+  if manual and isHelperEnabled == true then -- do not allow helper to be forced to turn on
+    doNotTurnOff = true
+  elseif manual and isHelperEnabled == false then -- return to default behavior
+    doNotTurnOff = false
+  end
   isHelperEnabled = not isHelperEnabled
   updateSave()
   updateDisplay()

--- a/src/playercards/cards/BookofLivingMyths.ttslua
+++ b/src/playercards/cards/BookofLivingMyths.ttslua
@@ -22,6 +22,7 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
     loopId = loadedData.loopId
   end
+  if isHelperEnabled then updateDisplay() end
 end
 
 function shutOff()

--- a/src/playercards/cards/BookofLivingMyths.ttslua
+++ b/src/playercards/cards/BookofLivingMyths.ttslua
@@ -22,7 +22,6 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
     loopId = loadedData.loopId
   end
-  syncDisplayWithOptionPanel()
 end
 
 function shutOff()

--- a/src/playercards/cards/DreamEnhancingSerum.ttslua
+++ b/src/playercards/cards/DreamEnhancingSerum.ttslua
@@ -18,7 +18,6 @@ function onLoad(savedData)
   end
   updateColors()
   createHelperXML()
-  syncDisplayWithOptionPanel()
 end
 
 function initialize()

--- a/src/playercards/cards/DreamEnhancingSerum.ttslua
+++ b/src/playercards/cards/DreamEnhancingSerum.ttslua
@@ -17,7 +17,11 @@ function onLoad(savedData)
     loopId = loadedData.loopId
   end
   updateColors()
-  createHelperXML()
+  
+  if isHelperEnabled then
+    updateDisplay()
+    createHelperXML()
+  end
 end
 
 function initialize()

--- a/src/playercards/cards/EmpiricalHypothesis.ttslua
+++ b/src/playercards/cards/EmpiricalHypothesis.ttslua
@@ -51,8 +51,6 @@ function onLoad(savedData)
   if activeButtonIndex > 0 then
     selectButton(activeButtonIndex)
   end
-
-  syncDisplayWithOptionPanel()
 end
 
 function initialize()

--- a/src/playercards/cards/EmpiricalHypothesis.ttslua
+++ b/src/playercards/cards/EmpiricalHypothesis.ttslua
@@ -46,15 +46,18 @@ function onLoad(savedData)
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
     activeButtonIndex = loadedData.activeButtonIndex
+    if isHelperEnabled then updateDisplay() end
   end
-
-  if activeButtonIndex > 0 then
+  if activeButtonIndex > -1 then
     selectButton(activeButtonIndex)
   end
 end
 
 function initialize()
   createButtons()
+  if activeButtonIndex > -1 then
+    selectButton(activeButtonIndex)
+  end
 end
 
 function shutOff()
@@ -73,6 +76,7 @@ function selectButton(index)
     end
     self.editButton({ index = i, color = buttonColor })
   end
+  updateSave()
 end
 
 -- create buttons based on the button parameters
@@ -81,9 +85,6 @@ function createButtons()
 
   -- reset the list in case of addition of checkboxes or Refine
   hypothesisList = { 'Succeed by 3 or more', 'Fail by 2 or more' }
-
-  -- set activeButtonIndex to restore state onLoad ("-1" -> nothing selected)
-  activeButtonIndex = -1
 
   -- get the upgradesheet and check for more conditions
   local upgradeSheet = findUpgradeSheet()

--- a/src/playercards/cards/FamilyInheritance.ttslua
+++ b/src/playercards/cards/FamilyInheritance.ttslua
@@ -17,6 +17,7 @@ function onLoad(savedData)
   if savedData and savedData ~= "" then
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
+    if isHelperEnabled then updateDisplay() end
   end
 end
 

--- a/src/playercards/cards/FamilyInheritance.ttslua
+++ b/src/playercards/cards/FamilyInheritance.ttslua
@@ -18,7 +18,6 @@ function onLoad(savedData)
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
-  syncDisplayWithOptionPanel()
 end
 
 function searchSelf()

--- a/src/playercards/cards/KohakuNarukami.ttslua
+++ b/src/playercards/cards/KohakuNarukami.ttslua
@@ -30,6 +30,7 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
     loopId = loadedData.loopId
   end
+  if isHelperEnabled then updateDisplay() end
 end
 
 function initialize()

--- a/src/playercards/cards/KohakuNarukami.ttslua
+++ b/src/playercards/cards/KohakuNarukami.ttslua
@@ -30,7 +30,6 @@ function onLoad(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
     loopId = loadedData.loopId
   end
-  syncDisplayWithOptionPanel()
 end
 
 function initialize()

--- a/src/playercards/cards/NkosiMabati3.ttslua
+++ b/src/playercards/cards/NkosiMabati3.ttslua
@@ -30,11 +30,15 @@ function onLoad(savedData)
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
     sigil = loadedData.sigil
-    if sigil and sigil ~= nil then
-      makeXMLButton()
+    if isHelperEnabled then
+      if sigil and sigil ~= nil then
+        makeXMLButton()
+      else
+        updateDisplay()
+      end
+      self.clearContextMenu()
+      self.addContextMenuItem("Clear Helper", toggleHelper)
     end
-    self.clearContextMenu()
-    self.addContextMenuItem("Clear Helper", toggleHelper)
   end
 end
 
@@ -64,6 +68,23 @@ function makeXMLButton()
         textColor = "White"
       },
       value = "Resolve"
+    },
+    {
+      tag = "Button",
+      attributes = {
+        height = 200,
+        width = 500,
+        rotation = "0 0 180",
+        scale = "0.1 0.1 1",
+        position = "65 125 -22",
+        padding = "30 30 30 30",
+        font = "font_teutonic-arkham",
+        fontSize = 110,
+        onClick = "chooseSigil",
+        color = tokenColor[sigil],
+        textColor = "White"
+      },
+      value = "Reset Sigil"
     }
   }
   )
@@ -122,7 +143,6 @@ end
 
 function shutOff()
   self.UI.setXml("")
-  sigil = nil
   updateSave()
 end
 

--- a/src/playercards/cards/NkosiMabati3.ttslua
+++ b/src/playercards/cards/NkosiMabati3.ttslua
@@ -36,7 +36,6 @@ function onLoad(savedData)
     self.clearContextMenu()
     self.addContextMenuItem("Clear Helper", toggleHelper)
   end
-  syncDisplayWithOptionPanel()
 end
 
 function makeXMLButton()

--- a/src/playercards/cards/StellaClark.ttslua
+++ b/src/playercards/cards/StellaClark.ttslua
@@ -31,6 +31,7 @@ function onLoad(savedData)
   else
     state = { Action = true, ElderSign = true }
   end
+  if isHelperEnabled then updateDisplay() end
 end
 
 function initialize()

--- a/src/playercards/cards/StellaClark.ttslua
+++ b/src/playercards/cards/StellaClark.ttslua
@@ -31,7 +31,6 @@ function onLoad(savedData)
   else
     state = { Action = true, ElderSign = true }
   end
-  syncDisplayWithOptionPanel()
 end
 
 function initialize()

--- a/src/playercards/cards/TheRedClock.ttslua
+++ b/src/playercards/cards/TheRedClock.ttslua
@@ -17,7 +17,6 @@ function onLoad(savedData)
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
-  syncDisplayWithOptionPanel()
 end
 
 function updateSave()

--- a/src/playercards/cards/TheRedClock.ttslua
+++ b/src/playercards/cards/TheRedClock.ttslua
@@ -17,6 +17,7 @@ function onLoad(savedData)
     local loadedData = JSON.decode(savedData)
     isHelperEnabled = loadedData.isHelperEnabled
   end
+  if isHelperEnabled then updateDisplay() end
 end
 
 function updateSave()

--- a/src/playercards/cards/WellConnected.ttslua
+++ b/src/playercards/cards/WellConnected.ttslua
@@ -29,7 +29,6 @@ function onLoad(savedData)
   end
 
   createHelperXML()
-  syncDisplayWithOptionPanel()
 end
 
 function initialize()

--- a/src/playercards/cards/WellConnected.ttslua
+++ b/src/playercards/cards/WellConnected.ttslua
@@ -28,7 +28,10 @@ function onLoad(savedData)
     modValue = 4
   end
 
-  createHelperXML()
+  if isHelperEnabled then
+    createHelperXML()
+    updateDisplay()
+  end
 end
 
 function initialize()

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1197,24 +1197,26 @@ function onCollisionEnter(collisionInfo)
   syncCustomizableMetadata(object)
   
   local localCardPos = self.positionToLocal(object.getPosition())
-  if not inArea(localCardPos, DECK_DISCARD_AREA) and object.hasTag("CardWithHelper") then
-    -- get state of the option panel
-    local options = GlobalApi.getOptionPanelState()
-    if options.enableCardHelpers then
-      object.call("setHelperState", true)
-    end
-  end
-
   if inArea(localCardPos, DECK_DISCARD_AREA) then
     tokenSpawnTrackerApi.resetTokensSpawned(object)
     removeTokensFromObject(object)
-  elseif shouldSpawnTokens(object) then
-    spawnTokensFor(object)
+  else
+    if shouldSpawnTokensOrShowHelper(object) then
+      if object.hasTag("CardWithHelper") then
+        -- get state of the option panel
+        local options = GlobalApi.getOptionPanelState()
+        if options.enableCardHelpers then
+          object.call("setHelperState", true)
+        end
+      else
+        spawnTokensFor(object)
+      end
+    end
   end
 end
 
 -- checks if tokens should be spawned for the provided card
-function shouldSpawnTokens(card)
+function shouldSpawnTokensOrShowHelper(card)
   if card.is_face_down then return false end
 
   local localCardPos = self.positionToLocal(card.getPosition())
@@ -1228,7 +1230,14 @@ function shouldSpawnTokens(card)
   -- Spawn tokens for assets and events on the main area
   if inArea(localCardPos, MAIN_PLAY_AREA)
       and (metadata.type == "Asset"
-        or metadata.type == "Event") then
+        or metadata.type == "Event")
+          then
+    return true
+  end
+
+  if inArea(localCardPos, INVESTIGATOR_AREA)
+      and (metadata.type == "Investigator") -- this is mostly for helpers like Stella and Kohaku
+        then
     return true
   end
 
@@ -1236,7 +1245,9 @@ function shouldSpawnTokens(card)
   if inArea(localCardPos, THREAT_AREA)
       and (metadata.type == "Treachery"
         or metadata.type == "Enemy"
-        or metadata.weakness) then
+        or metadata.type == "Skill"
+        or metadata.weakness)
+         then
     return true
   end
 

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1195,8 +1195,16 @@ function onCollisionEnter(collisionInfo)
 
   maybeUpdateActiveInvestigator(object)
   syncCustomizableMetadata(object)
-
+  
   local localCardPos = self.positionToLocal(object.getPosition())
+  if inArea(localCardPos, MAIN_PLAY_AREA) and object.hasTag("CardWithHelper") then
+    -- get state of the option panel
+    local options = GlobalApi.getOptionPanelState()
+    if options.enableCardHelpers then
+      object.call("setHelperState", true)
+    end
+  end
+
   if inArea(localCardPos, DECK_DISCARD_AREA) then
     tokenSpawnTrackerApi.resetTokensSpawned(object)
     removeTokensFromObject(object)

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1197,7 +1197,7 @@ function onCollisionEnter(collisionInfo)
   syncCustomizableMetadata(object)
   
   local localCardPos = self.positionToLocal(object.getPosition())
-  if inArea(localCardPos, MAIN_PLAY_AREA) and object.hasTag("CardWithHelper") then
+  if not inArea(localCardPos, DECK_DISCARD_AREA) and object.hasTag("CardWithHelper") then
     -- get state of the option panel
     local options = GlobalApi.getOptionPanelState()
     if options.enableCardHelpers then

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1229,16 +1229,14 @@ function shouldSpawnTokensOrShowHelper(card)
 
   -- Spawn tokens for assets and events on the main area
   if inArea(localCardPos, MAIN_PLAY_AREA)
-      and (metadata.type == "Asset"
-        or metadata.type == "Event")
-          then
-    return true
+    and (metadata.type == "Asset"
+    or metadata.type == "Event") then
+      return true
   end
 
   if inArea(localCardPos, INVESTIGATOR_AREA)
-      and (metadata.type == "Investigator") -- this is mostly for helpers like Stella and Kohaku
-        then
-    return true
+    and (metadata.type == "Investigator") then -- this is mostly for helpers like Stella and Kohaku
+      return true
   end
 
   -- Spawn tokens for all encounter types in the threat area
@@ -1246,8 +1244,7 @@ function shouldSpawnTokensOrShowHelper(card)
       and (metadata.type == "Treachery"
         or metadata.type == "Enemy"
         or metadata.type == "Skill"
-        or metadata.weakness)
-         then
+        or metadata.weakness) then
     return true
   end
 

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1229,14 +1229,14 @@ function shouldSpawnTokensOrShowHelper(card)
 
   -- Spawn tokens for assets and events on the main area
   if inArea(localCardPos, MAIN_PLAY_AREA)
-    and (metadata.type == "Asset"
-    or metadata.type == "Event") then
-      return true
+      and (metadata.type == "Asset"
+        or metadata.type == "Event") then
+    return true
   end
 
   if inArea(localCardPos, INVESTIGATOR_AREA)
-    and (metadata.type == "Investigator") then -- this is mostly for helpers like Stella and Kohaku
-      return true
+      and (metadata.type == "Investigator") then -- this is mostly for helpers like Stella and Kohaku
+    return true
   end
 
   -- Spawn tokens for all encounter types in the threat area


### PR DESCRIPTION
Now only shows helpers when placed on playermats. TO DO: add functionality for PlayArea, but only when we have helpers for encounter cards or player cards that attach (would prefer to avoid helper clutter if unnecessary).