### PR TITLE
Ability Tokens: Turned "randomize" into a context menu entry instead of using the TTS event

### DIFF
--- a/src/core/UniversalActionAbilityToken.ttslua
+++ b/src/core/UniversalActionAbilityToken.ttslua
@@ -248,6 +248,8 @@ function addContextMenu()
         end
       end)
   end)
+
+  self.addContextMenuItem("Randomize", randomize)
 end
 
 function updateClass(newClass)
@@ -292,7 +294,7 @@ function isClassName(str)
   return false
 end
 
-function onRandomize()
+function randomize()
   local newSymbol = listOfSymbols[math.random(1, #listOfSymbols)]
 
   while newSymbol == "None" do


### PR DESCRIPTION
To stop people from accidentally randomizing