### PR TITLE
fix for cleanup helper changing doomSubtractMode

### DIFF
--- a/src/core/DoomInPlayCounter.ttslua
+++ b/src/core/DoomInPlayCounter.ttslua
@@ -41,7 +41,7 @@ end
 
 function toggleSubtractDoom(override)
   local previousState = subtractDoom
-  if override then
+  if override ~= nil then
     subtractDoom = override
   else
     subtractDoom = not subtractDoom


### PR DESCRIPTION
This change in DoomInPlayCounter fixes the issue of the cleanup helper toggling the doom subtract mode on and off, instead of just disabling it