### PR TITLE
Updated Playarea Image Gallery

### DIFF
--- a/src/core/PlayAreaImageData.ttslua
+++ b/src/core/PlayAreaImageData.ttslua
@@ -902,8 +902,16 @@ PLAYAREA_IMAGE_DATA = {
         URL = "https://steamusercontent-a.akamaihd.net/ugc/2279446315725512402/37F34A14CEEA9D2F889F7B97B065C0193F268FE1/"
       },
       {
+        Name = "Return to Consternation on the Constellation",
+        URL = "https://github.com/ArkhamDotCards/returntoconsternationontheconstellation/blob/main/product/enUS/constellation-playmat.png?raw=true"
+      },
+      {
         Name = "Monstrosity from the Ravenwoods",
         URL = "https://i.imgur.com/U9J6zm8.jpeg"
+      },
+      {
+        Name = "Return to the Wendigo",
+        URL = "https://github.com/ArkhamDotCards/returntothewendigo/blob/main/product/enUS/wendigo-playmat.png?raw=true"
       },
       {
         Name = "Symphony of Erich Zann",
@@ -913,6 +921,10 @@ PLAYAREA_IMAGE_DATA = {
   },
   ["Other Images"] = {
     ["Arkham Locations"] = {
+      {
+        Name = "Desk (by pi.ontheline)",
+        URL = "https://steamusercontent-a.akamaihd.net/ugc/62581198340495003/80A6E3F7D53775717B909D62473B3C7CA06DBF85/"
+      },
       {
         Name = "Downtown 1",
         URL = "https://steamusercontent-a.akamaihd.net/ugc/2279446315725516086/53F48F8AA9CFE4BF544BF03A616AC12A5344615C/"


### PR DESCRIPTION
Closes https://github.com/argonui/SCED/issues/967

- [ ] remove duplicate image in Dunwich (Lost in Time and Space)
- [ ] add new image by pi.ontheline (https://discord.com/channels/704806269923491941/743173993720184902/1303842024210042940)
- [ ] add images for Hemlock
- [ ] add 2024 digital playmats