### PR TITLE
edit slots by dropping Charisma/Relic Hunter

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1185,12 +1185,10 @@ function modifySlot(newSlot, cardPosition)
       table.insert(slotSnaps, snap)
     end
   end
-  cardPosition.x = tonumber(string.format("%.3f", cardPosition.x))
-  cardPosition.z = tonumber(string.format("%.3f", cardPosition.z))
+  cardPosition.y = 0
   for snapId, snap in ipairs(slotSnaps) do
-    local snapPosX = tonumber(string.format("%.3f", snap.position.x))
-    local snapPosZ = tonumber(string.format("%.3f", snap.position.z))
-    if snapPosX == cardPosition.x and snapPosZ == cardPosition.z then
+    local snapPosition = Vector(snap.position.x, 0, snap.position.z)
+    if snapPosition == cardPosition then
       slotData[snapId] = newSlot
       if Player[playerColor].seated then
         printToColor(newSlot .. " slot added to player mat", playerColor, Color.fromString(playerColor))

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1177,6 +1177,33 @@ function resetSlotSymbols()
   updateSlotSymbols()
 end
 
+function modifySlot(newSlot, cardPosition)
+  local slotSnaps = {}
+  local snaps = self.getSnapPoints()
+  for i, snap in ipairs(snaps) do
+    if inArea(snap.position, MAIN_PLAY_AREA) then
+      table.insert(slotSnaps, snap)
+    end
+  end
+  cardPosition.x = tonumber(string.format("%.3f", cardPosition.x))
+  cardPosition.z = tonumber(string.format("%.3f", cardPosition.z))
+  for snapId, snap in ipairs(slotSnaps) do
+    local snapPosX = tonumber(string.format("%.3f", snap.position.x))
+    local snapPosZ = tonumber(string.format("%.3f", snap.position.z))
+    if snapPosX == cardPosition.x and snapPosZ == cardPosition.z then
+      slotData[snapId] = newSlot
+      if Player[playerColor].seated then
+        printToColor(newSlot .. " slot added to player mat", playerColor, Color.fromString(playerColor))
+      else
+        local hostColor = Player.getPlayers()[1].color
+        printToColor(newSlot .. " slot added to player mat", hostColor, Color.fromString(hostColor))
+      end
+    end
+  end
+  updateSave()
+  updateSlotSymbols()
+end
+
 ---------------------------------------------------------
 -- playermat token spawning
 ---------------------------------------------------------
@@ -1255,6 +1282,11 @@ function onCollisionEnter(collisionInfo)
     -- main uses spawning
     if inArea(localCardPos, MAIN_PLAY_AREA) and (md.type == "Asset" or md.type == "Event") then
       spawnTokensOrShowHelper(object)
+      if md.id == "02158" or id == "01694" then
+        modifySlot("Ally", localCardPos)
+      elseif md.id == "02157" or id == "01695" then
+        modifySlot("Accessory", localCardPos)
+      end
     end
 
     -- encounter types / committed skill cards in the threat area


### PR DESCRIPTION
this adds the functionality of editing player mat slots by simply dropping either Charisma or Relic Hunter on an asset slot