### PR TITLE
Fixed tooltip position for XML windows

### DIFF
--- a/xml/Global/DownloadWindow.xml
+++ b/xml/Global/DownloadWindow.xml
@@ -63,6 +63,7 @@
         color="clear"
         icon="close"
         tooltip="Close"
+        tooltipOffset="20"
         tooltipPosition="Right"
         tooltipBackgroundColor="rgba(0,0,0,1)"
         onClick="onClick_toggleUi(downloadWindow)"/>

--- a/xml/Global/PlayAreaGallery.xml
+++ b/xml/Global/PlayAreaGallery.xml
@@ -77,6 +77,7 @@
         color="clear"
         icon="close"
         tooltip="Close"
+        tooltipOffset="20"
         tooltipPosition="Right"
         tooltipBackgroundColor="rgba(0,0,0,1)"
         onClick="onClick_toggleUi(playAreaGallery)"/>


### PR DESCRIPTION
Without this fix the tooltips are offset 300 units to the left because the buttons are for some reason inheriting the value from some other element when it isn't explicitely set.