### PR TITLE
Bug Fixes to the Victory Display

### DIFF
--- a/src/core/VictoryDisplay.ttslua
+++ b/src/core/VictoryDisplay.ttslua
@@ -77,6 +77,7 @@ end
 
 -- removing an object from the victory display
 function onCollisionExit()
+  log("Stopped Colliding!")
   startUpdate()
 end
 
@@ -98,7 +99,11 @@ end
 
 -- destroying a clue or location
 function onObjectDestroy(obj)
-  maybeUpdate(obj)
+  if countedVP[obj] then
+    startUpdate()
+  else
+    maybeUpdate(obj)
+  end
 end
 
 ---------------------------------------------------------
@@ -138,6 +143,17 @@ end
 
 -- counts the VP in the victory display and request the VP count from the play area
 function updateCount()
+  -- Turn off highlighting in case any cards are going to stop being tracked
+  local tempHighlightingGreen = false
+  local tempHighlightingRed = false
+  if highlightCounted then
+    highlightCountedVP()
+    tempHighlightingGreen = true
+  end
+  if highlightMissing then
+    highlightMissingData()
+    tempHighlightingRed = true
+  end
   missingData            = {}
   countedVP              = {}
   local victoryPoints    = {}
@@ -151,7 +167,7 @@ function updateCount()
       local VP = getCardVP(obj, JSON.decode(obj.getGMNotes()))
       victoryPoints.display = victoryPoints.display + VP
       if VP > 0 then
-        table.insert(countedVP, obj)
+        countedVP[obj] = true
       end
 
       -- handling for stacked cards
@@ -165,7 +181,7 @@ function updateCount()
         end
       end
       if VP > 0 then
-        table.insert(countedVP, obj)
+        countedVP[obj] = true
       end
     end
   end
@@ -174,6 +190,14 @@ function updateCount()
   self.editButton({ index = 0, label = victoryPoints.display })
   self.editButton({ index = 1, label = victoryPoints.playArea })
   self.editButton({ index = 2, label = victoryPoints.display + victoryPoints.playArea })
+
+  -- if highlighting was on, turn it back on, including any new cards now being tracked
+  if tempHighlightingGreen then
+    highlightCountedVP()
+  end
+  if tempHighlightingRed then
+    highlightMissingData()
+  end
 
   -- allow new update calls
   pendingCall = false
@@ -196,7 +220,7 @@ function getCardVP(obj, notes)
       end
     end
     if (cardVP or 0) > 0 then
-      table.insert(countedVP, obj)
+      countedVP[obj] = true
     end
   else
     table.insert(missingData, obj)
@@ -229,7 +253,7 @@ function highlightCountedVP()
     index = 4,
     tooltip = (highlightCounted and "Enable" or "Disable") .. " highlighting of cards with VP."
   })
-  for _, obj in pairs(countedVP) do
+  for obj, _ in pairs(countedVP) do
     if obj ~= nil then
       if highlightCounted then
         obj.highlightOff("Green")

--- a/src/core/VictoryDisplay.ttslua
+++ b/src/core/VictoryDisplay.ttslua
@@ -77,7 +77,6 @@ end
 
 -- removing an object from the victory display
 function onCollisionExit()
-  log("Stopped Colliding!")
   startUpdate()
 end
 


### PR DESCRIPTION
- Fixed Victory Display not updating when cards deleted from the Victory Display
- Fixed new cards getting added to Victory Points not being highlighted if highlighting was on
- Fixed cards getting removed from Victory Display not getting highlighting turned off