### PR TITLE
Fixed 'Discard 1' Button Flickering

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -210,6 +210,7 @@ function onLoad(savedData)
   buttonParameters.label = "Discard 1"
   buttonParameters.click_function = "doDiscardOne"
   buttonParameters.tooltip = "Discard one random card from hand (hidden cards are excluded)."
+  buttonParameters.position.y = 0.15
   buttonParameters.position.z = 0.92
   self.createButton(buttonParameters)
 


### PR DESCRIPTION
The 'Discard 1' button on the green and red playermats was flickering because it was partially clipping into the object at certain camera angles.  Just slightly increased the button height to fix the issue