### PR TITLE
Updated token stack size display and discard button search size

### DIFF
--- a/src/playercards/CardsThatSealTokens.ttslua
+++ b/src/playercards/CardsThatSealTokens.ttslua
@@ -383,6 +383,12 @@ function updateStackSize()
   local topToken = getObjectFromGUID(sealedTokens[#sealedTokens])
   if topToken == nil then return end
 
+  -- handling for two-digit numbers
+  local fontsize = 380
+  if #sealedTokens > 9 then
+    fontsize = 360
+  end
+
   topToken.UI.setXmlTable({
     {
       tag = "Panel",
@@ -397,7 +403,7 @@ function updateStackSize()
       children = {
         tag = "Text",
         attributes = {
-          fontSize = "380",
+          fontSize = fontsize,
           font = "font_teutonic-arkham",
           color = "#ffffff",
           outline = "#000000",

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -46,7 +46,7 @@ local collisionEnabled            = false
 local currentlyEditingSlots       = false
 
 -- for stopping multiple collisions of the same object
-local collisionTable = {}
+local collisionTable              = {}
 
 -- x-Values for discard buttons
 local DISCARD_BUTTON_X_START      = -1.365
@@ -308,11 +308,11 @@ end
 ---@param id number Index of the discard button (from left to right, must be unique)
 function makeDiscardButton(id)
   local xValue = DISCARD_BUTTON_X_START + (id - 1) * DISCARD_BUTTON_X_OFFSET
-  local position = { xValue, 0.1, -0.94 }
-  local searchPosition = { -position[1], position[2], position[3] + 0.32 }
+  local position = Vector(xValue, 0.1, -0.94)
+  local searchPosition = Vector(-position[1], 1, position[3] + 0.32)
   local handlerName = 'handler' .. id
   self.setVar(handlerName, function()
-    local cardSizeSearch = { 2, 1, 3.2 }
+    local cardSizeSearch = Vector(2, 2, 3.2)
     local globalSearchPosition = self.positionToWorld(searchPosition)
     local searchResult = searchArea(globalSearchPosition, cardSizeSearch)
     return discardListOfObjects(searchResult)
@@ -331,13 +331,12 @@ end
 
 -- build a hybrid button to discard from searchPosition or move a card/deck to empty threat area on right click
 function makeDrawAreaButton()
-  local position = { -1.365, 0.1, -0.94 }
   self.createButton({
     label = "Discard / ➜",
     click_function = "discardOrMove",
     tooltip = "Right-click to move to threat area",
     function_owner = self,
-    position = position,
+    position = { -1.365, 0.1, -0.94 },
     scale = { 0.12, 0.12, 0.12 },
     width = 1190,
     height = 350,
@@ -346,8 +345,8 @@ function makeDrawAreaButton()
 end
 
 function discardOrMove(_, playerColor, isRightClick)
-  local searchPosition = { 1.365, 0.1, -0.62 }
-  local cardSizeSearch = { 2, 1, 3.2 }
+  local searchPosition = Vector(1.365, 1, -0.62)
+  local cardSizeSearch = Vector(2, 2, 3.2)
   local globalSearchPosition = self.positionToWorld(searchPosition)
   local searchResult = searchArea(globalSearchPosition, cardSizeSearch)
 
@@ -1296,12 +1295,10 @@ function onCollisionEnter(collisionInfo)
       -- this is mostly for helpers like Stella and Kohaku
       spawnTokensOrShowHelper(object)
     end
-
   elseif inArea(localCardPos, DECK_DISCARD_AREA) then
     GlobalApi.handleTokenDetaching(object)
     tokenSpawnTrackerApi.resetTokensSpawned(object)
     GlobalApi.removeTokensFromObject(object, matColor)
-
   elseif object.is_face_down == false then
     -- main uses spawning
     if inArea(localCardPos, MAIN_PLAY_AREA) and (md.type == "Asset" or md.type == "Event") then


### PR DESCRIPTION
Changes are needed for the advanced Serpents of Yig that can seal 11 tokens

![image](https://github.com/user-attachments/assets/2d492190-864b-42f9-b80f-9710ed0649bd)

