### PR TITLE
Fixed scope for Generic Counter

### DIFF
--- a/src/tokens/GenericCounter.ttslua
+++ b/src/tokens/GenericCounter.ttslua
@@ -1,4 +1,4 @@
-local MIN_VALUE, MAX_VALUE = 0, 99
+MIN_VALUE, MAX_VALUE = 0, 99
 
 function onDestroy()
   updateSave()


### PR DESCRIPTION
Without this change, counters like the ActiveInvestigatorCounter aren't able to set their own max / min value