### PR TITLE
Added handling for discarding cloned chaos tokens

### DIFF
--- a/src/core/GameKeyHandler.ttslua
+++ b/src/core/GameKeyHandler.ttslua
@@ -134,23 +134,29 @@ function discardObject(playerColor, hoveredObject)
 end
 
 -- actually performs the discarding of the object and tokens / tiles on it
-function performDiscard(playerColor, hoveredObject)
+function performDiscard(playerColor, targetObject)
+  -- destroy temporary chaos tokens instead
+  if targetObject.hasTag("tempToken") then
+    targetObject.destruct()
+    return
+  end
+
   -- initialize list of objects to discard
-  local discardTheseObjects = { hoveredObject }
+  local discardTheseObjects = { targetObject }
 
   -- discard tokens / tiles on cards / decks
-  if hoveredObject.type ~= "Tile" then
-    for _, obj in ipairs(searchLib.onObject(hoveredObject, "isTileOrToken")) do
+  if targetObject.type ~= "Tile" then
+    for _, obj in ipairs(searchLib.onObject(targetObject, "isTileOrToken")) do
       table.insert(discardTheseObjects, obj)
     end
   end
 
   -- update playarea connections
-  if hoveredObject.type == "Card" then
-    playAreaApi.maybeUntrackLocation(hoveredObject)
+  if targetObject.type == "Card" then
+    playAreaApi.maybeUntrackLocation(targetObject)
   end
 
-  local discardForMatColor = getColorToDiscardFor(hoveredObject, playerColor)
+  local discardForMatColor = getColorToDiscardFor(targetObject, playerColor)
   playermatApi.discardListOfObjects(discardForMatColor, discardTheseObjects)
 end
 


### PR DESCRIPTION
This shouldn't happen normally, but if someone uses the discard hotkey on a temporary chaos token, this destroys the token instead of returning it to the chaos bag.