### PR TITLE
Upgradesheets / Cards with Helpers bugfixes

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -266,6 +266,13 @@ do
       local upgradesheet = allCardsBagApi.getCardById(cardId .. "-c")
       if upgradesheet ~= nil then
         slots[cardId .. "-c"] = 1
+      elseif string.sub(cardId, -2) == "-t" then
+        -- if this is a taboo'd card, get the basic upgradesheet as fallback
+        local baseId = string.sub(cardId, 1, -3) -- Remove the last 2 characters
+        local upgradesheetBase = allCardsBagApi.getCardById(baseId .. "-c")
+        if upgradesheetBase ~= nil then
+          slots[baseId .. "-c"] = 1
+        end
       end
     end
   end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -240,6 +240,14 @@ function onObjectEnterZone(zone, object)
       end
     end
 
+    -- maybe disable card helpers
+    if object.hasTag("CardWithHelper") then
+      local func = object.getVar("setHelperState")
+      if func ~= nil then
+        object.call("setHelperState", false)
+      end
+    end
+
     applyHidingToCard(object, zone.getValue())
   end
 end


### PR DESCRIPTION
- makes sure to disable helpers in hands (since cards can be drawn without triggering the `onPickUp()` event)
- loads the basic upgradesheet for taboo'd customizables if there is no taboo'd upgradesheet