### PR TITLE
Added filtering to card search

### DIFF
--- a/objects/Search-A-Card.24051a.json
+++ b/objects/Search-A-Card.24051a.json
@@ -22,7 +22,7 @@
     "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/2342503777976621188/4C119690DEF2B128E6EC309A880984E55D80350C/",
     "WidthScale": 0
   },
-  "Description": "Allows searching for card(s) by name. Use the buttons to toggle the spawn / search mode.\n\nSee context menu for additional information.",
+  "Description": "Allows searching for card(s) by name or filters. Use the buttons to toggle the spawn / search mode.\n\nThe search partially supports filters in the style of ArkhamDB:\nk - Trait\no - cost\np - level\nf - class\nz - slot\nt - type\n\nTo use a filter, use the abbreviation and then an operator (:, !, < or >) followed by the filter value. Example:\nk:criminal t!investigator",
   "DragSelectable": true,
   "GMNotes": "",
   "GUID": "24051a",

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -8,6 +8,7 @@ local customSignatureDict    = {}
 local basicWeaknessList      = {}
 local uniqueWeaknessList     = {}
 local cycleIndex             = {}
+local dataCache              = {}
 
 local indexingDone           = false
 local otherCardsDetected     = false
@@ -101,6 +102,7 @@ function clearIndexes()
   customSignatureDict    = {}
   basicWeaknessList      = {}
   uniqueWeaknessList     = {}
+  dataCache              = {}
 end
 
 -- Clears the bag indexes and starts the coroutine to rebuild the indexes
@@ -508,16 +510,14 @@ function getCardsByName(params)
 end
 
 function getCardsByFilter(params)
-  local filters = params.filters
-  local exact   = params.exact
-  local results = {}
+  local filters    = params.filters
+  local exact      = params.exact
+  local results    = {}
 
   -- track cards (by ID) that we've added to avoid duplicates that may come from alternate IDs
   local addedCards = {}
   for _, cardData in pairs(cardIdIndex) do
-    if addedCards[cardData.metadata.id] then
-      goto nextCard
-    end
+    if addedCards[cardData.metadata.id] then goto nextCard end
 
     -- compare the name
     if filters.search then
@@ -527,60 +527,103 @@ function getCardsByFilter(params)
         goto nextCard
       end
     end
-    
-    log("passed name check: " .. cardData.metadata.id)
 
     -- compare trait (k)
-    if filters.k and (filters.k.operator == ":" or filters.k.operator == "!") then
+    if filters.k then
+      if not cardData.metadata.traits then goto nextCard end
+
       -- get traits from the search (separated by |)
       local searchTraits = {}
       for str in filters.k.value:gmatch("([^|]+)") do
         searchTraits[string.lower(str)] = true
       end
 
-      -- get traits for the card (like on the card, space + .)
-      local cardTraits = parseTraits(cardData.metadata.traits)
+      local cardTraits = parseTraits(cardData.metadata.id, cardData.metadata.traits)
 
       if filters.k.operator == ":" then
         for searchTrait, _ in pairs(searchTraits) do
-          if not cardTraits[searchTrait] then
-            log("Skipping " .. cardData.metadata.id .. " due to missing trait: " .. searchTrait)
-            goto nextCard
-          end
+          if not cardTraits[searchTrait] then goto nextCard end
         end
       elseif filters.k.operator == "!" then
         for searchTrait, _ in pairs(searchTraits) do
-          if cardTraits[searchTrait] then
-            log("Skipping " .. cardData.metadata.id .. " due to having trait: " .. searchTrait)
-            goto nextCard
-          end
+          if cardTraits[searchTrait] then goto nextCard end
         end
       end
     end
 
     -- compare level (p)
     if filters.p then
+      if not cardData.metadata.level then goto nextCard end
 
+      local searchLevel = tonumber(filters.p.value)
+      local cardLevel = cardData.metadata.level
+      local operator = filters.p.operator
+      if not cardLevel or
+          (operator == ":" and cardLevel ~= searchLevel) or
+          (operator == "<" and cardLevel >= searchLevel) or
+          (operator == ">" and cardLevel <= searchLevel) or
+          (operator == "!" and cardLevel == searchLevel) then
+        goto nextCard
+      end
     end
 
     -- compare cost (o)
     if filters.o then
+      if not cardData.metadata.cost then goto nextCard end
 
+      local searchCost = tonumber(filters.o.value)
+      local cardCost = cardData.metadata.cost
+      local operator = filters.o.operator
+      if (operator == ":" and cardCost ~= searchCost) or
+          (operator == "<" and cardCost >= searchCost) or
+          (operator == ">" and cardCost <= searchCost) or
+          (operator == "!" and cardCost == searchCost) then
+        goto nextCard
+      end
     end
 
     -- compare slot (z)
     if filters.z then
+      if not cardData.metadata.slot then goto nextCard end
 
+      local searchSlot   = string.lower(filters.z.value)
+      local cardSlot     = string.lower(cardData.metadata.slot)
+      local operator     = filters.z.operator
+      local containsSlot = string.find(cardSlot, searchSlot, 1, true)
+
+      if (operator == ":" and not containsSlot) or
+          (operator == "!" and containsSlot) then
+        goto nextCard
+      end
     end
 
     -- compare class (f)
     if filters.f then
+      if not cardData.metadata.class then goto nextCard end
 
+      local searchClass   = string.lower(filters.f.value)
+      local cardClass     = string.lower(cardData.metadata.class)
+      local operator      = filters.f.operator
+      local containsClass = string.find(cardClass, searchClass, 1, true)
+
+      if (operator == ":" and not containsClass) or
+          (operator == "!" and containsClass) then
+        goto nextCard
+      end
     end
 
     -- compare type (t)
     if filters.t then
+      if not cardData.metadata.type then goto nextCard end
 
+      local searchType = string.lower(filters.t.value)
+      local cardType   = string.lower(cardData.metadata.type)
+      local operator   = filters.t.operator
+
+      if (operator == ":" and cardType ~= searchType) or
+          (operator == "!" and cardType == searchType) then
+        goto nextCard
+      end
     end
 
     -- card has passed all filters and thus gets added
@@ -593,11 +636,21 @@ function getCardsByFilter(params)
   return results
 end
 
-function parseTraits(traitsString)
+function parseTraits(cardId, traitsString)
+  if dataCache.traits and dataCache.traits[cardId] then
+    return dataCache.traits[cardId]
+  end
+
   local traits = {}
   for str in traitsString:gmatch("[^.]+") do
     traits[string.lower(str:match("^%s*(.-)%s*$"))] = true
   end
+
+  if not dataCache.traits then
+    dataCache.traits = {}
+  end
+
+  dataCache.traits[cardId] = traits
   return traits
 end
 

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -520,8 +520,8 @@ function getCardsByFilter(params)
 
     -- compare the name
     if filters.search and cardMatches then
-      local searchname = string.lower(filters.search)
-      local cardname   = string.lower(cardData.data.Nickname)
+      local searchname   = string.lower(filters.search)
+      local cardname     = string.lower(cardData.data.Nickname)
       if (exact and cardname ~= searchname) or not string.find(cardname, searchname, 1, true) then
         cardMatches = false
       end
@@ -533,9 +533,10 @@ function getCardsByFilter(params)
         cardMatches = false
       else
         local searchTraits = parseSearchValue(filters.k.value)
+        local cardTraits   = string.lower(cardData.metadata.traits)
         local operator     = filters.k.operator
         for _, searchTrait in ipairs(searchTraits) do
-          local containsTrait = string.find(cardData.metadata.traits, searchTrait, 1, true)
+          local containsTrait = string.find(cardTraits, searchTrait, 1, true)
           if (operator == ":" and not containsTrait) or (operator == "!" and containsTrait) then
             cardMatches = false
             break

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -8,7 +8,6 @@ local customSignatureDict    = {}
 local basicWeaknessList      = {}
 local uniqueWeaknessList     = {}
 local cycleIndex             = {}
-local dataCache              = {}
 
 local indexingDone           = false
 local otherCardsDetected     = false
@@ -102,7 +101,6 @@ function clearIndexes()
   customSignatureDict    = {}
   basicWeaknessList      = {}
   uniqueWeaknessList     = {}
-  dataCache              = {}
 end
 
 -- Clears the bag indexes and starts the coroutine to rebuild the indexes
@@ -510,147 +508,145 @@ function getCardsByName(params)
 end
 
 function getCardsByFilter(params)
-  local filters    = params.filters
-  local exact      = params.exact
-  local results    = {}
+  local filters = params.filters
+  local exact   = params.exact
+  local results = {}
 
   -- track cards (by ID) that we've added to avoid duplicates that may come from alternate IDs
   local addedCards = {}
   for _, cardData in pairs(cardIdIndex) do
-    if addedCards[cardData.metadata.id] then goto nextCard end
+    local cardMatches = true
+    if addedCards[cardData.metadata.id] then cardMatches = false end
 
     -- compare the name
-    if filters.search then
+    if filters.search and cardMatches then
       local searchname = string.lower(filters.search)
       local cardname   = string.lower(cardData.data.Nickname)
       if (exact and cardname ~= searchname) or not string.find(cardname, searchname, 1, true) then
-        goto nextCard
+        cardMatches = false
       end
     end
 
     -- compare trait (k)
-    if filters.k then
-      if not cardData.metadata.traits then goto nextCard end
-
-      -- get traits from the search (separated by |)
-      local searchTraits = {}
-      for str in filters.k.value:gmatch("([^|]+)") do
-        searchTraits[string.lower(str)] = true
-      end
-
-      local cardTraits = parseTraits(cardData.metadata.id, cardData.metadata.traits)
-
-      if filters.k.operator == ":" then
-        for searchTrait, _ in pairs(searchTraits) do
-          if not cardTraits[searchTrait] then goto nextCard end
+    if filters.k and cardMatches then
+      if not cardData.metadata.traits then
+        cardMatches = false
+      else
+        -- get traits from the search (separated by |)
+        local searchTraits = {}
+        for str in filters.k.value:gmatch("([^|]+)") do
+          searchTraits[string.lower(str)] = true
         end
-      elseif filters.k.operator == "!" then
+
+        local cardTraits = parseTraits(cardData.metadata.traits)
         for searchTrait, _ in pairs(searchTraits) do
-          if cardTraits[searchTrait] then goto nextCard end
+          if (filters.k.operator == ":" and not cardTraits[searchTrait]) or
+              (filters.k.operator == "!" and cardTraits[searchTrait]) then
+            cardMatches = false
+            break
+          end
         end
       end
     end
 
     -- compare level (p)
-    if filters.p then
-      if not cardData.metadata.level then goto nextCard end
-
-      local searchLevel = tonumber(filters.p.value)
-      local cardLevel = cardData.metadata.level
-      local operator = filters.p.operator
-      if not cardLevel or
-          (operator == ":" and cardLevel ~= searchLevel) or
-          (operator == "<" and cardLevel >= searchLevel) or
-          (operator == ">" and cardLevel <= searchLevel) or
-          (operator == "!" and cardLevel == searchLevel) then
-        goto nextCard
+    if filters.p and cardMatches then
+      if not cardData.metadata.level then
+        cardMatches = false
+      else
+        local searchLevel = tonumber(filters.p.value)
+        local cardLevel = cardData.metadata.level
+        local operator = filters.p.operator
+        if (operator == ":" and cardLevel ~= searchLevel) or
+            (operator == "<" and cardLevel >= searchLevel) or
+            (operator == ">" and cardLevel <= searchLevel) or
+            (operator == "!" and cardLevel == searchLevel) then
+          cardMatches = false
+        end
       end
     end
 
     -- compare cost (o)
-    if filters.o then
-      if not cardData.metadata.cost then goto nextCard end
-
-      local searchCost = tonumber(filters.o.value)
-      local cardCost = cardData.metadata.cost
-      local operator = filters.o.operator
-      if (operator == ":" and cardCost ~= searchCost) or
-          (operator == "<" and cardCost >= searchCost) or
-          (operator == ">" and cardCost <= searchCost) or
-          (operator == "!" and cardCost == searchCost) then
-        goto nextCard
+    if filters.o and cardMatches then
+      if not cardData.metadata.cost then
+        cardMatches = false
+      else
+        local searchCost = tonumber(filters.o.value)
+        local cardCost = cardData.metadata.cost
+        local operator = filters.o.operator
+        if (operator == ":" and cardCost ~= searchCost) or
+            (operator == "<" and cardCost >= searchCost) or
+            (operator == ">" and cardCost <= searchCost) or
+            (operator == "!" and cardCost == searchCost) then
+          cardMatches = false
+        end
       end
     end
 
     -- compare slot (z)
-    if filters.z then
-      if not cardData.metadata.slot then goto nextCard end
+    if filters.z and cardMatches then
+      if not cardData.metadata.slot then
+        cardMatches = false
+      else
+        local searchSlot   = string.lower(filters.z.value)
+        local cardSlot     = string.lower(cardData.metadata.slot)
+        local operator     = filters.z.operator
+        local containsSlot = string.find(cardSlot, searchSlot, 1, true)
 
-      local searchSlot   = string.lower(filters.z.value)
-      local cardSlot     = string.lower(cardData.metadata.slot)
-      local operator     = filters.z.operator
-      local containsSlot = string.find(cardSlot, searchSlot, 1, true)
-
-      if (operator == ":" and not containsSlot) or
-          (operator == "!" and containsSlot) then
-        goto nextCard
+        if (operator == ":" and not containsSlot) or
+            (operator == "!" and containsSlot) then
+          cardMatches = false
+        end
       end
     end
 
     -- compare class (f)
-    if filters.f then
-      if not cardData.metadata.class then goto nextCard end
+    if filters.f and cardMatches then
+      if not cardData.metadata.class then
+        cardMatches = false
+      else
+        local searchClass   = string.lower(filters.f.value)
+        local cardClass     = string.lower(cardData.metadata.class)
+        local operator      = filters.f.operator
+        local containsClass = string.find(cardClass, searchClass, 1, true)
 
-      local searchClass   = string.lower(filters.f.value)
-      local cardClass     = string.lower(cardData.metadata.class)
-      local operator      = filters.f.operator
-      local containsClass = string.find(cardClass, searchClass, 1, true)
-
-      if (operator == ":" and not containsClass) or
-          (operator == "!" and containsClass) then
-        goto nextCard
+        if (operator == ":" and not containsClass) or
+            (operator == "!" and containsClass) then
+          cardMatches = false
+        end
       end
     end
 
     -- compare type (t)
-    if filters.t then
-      if not cardData.metadata.type then goto nextCard end
+    if filters.t and cardMatches then
+      if not cardData.metadata.type then
+        cardMatches = false
+      else
+        local searchType = string.lower(filters.t.value)
+        local cardType   = string.lower(cardData.metadata.type)
+        local operator   = filters.t.operator
 
-      local searchType = string.lower(filters.t.value)
-      local cardType   = string.lower(cardData.metadata.type)
-      local operator   = filters.t.operator
-
-      if (operator == ":" and cardType ~= searchType) or
-          (operator == "!" and cardType == searchType) then
-        goto nextCard
+        if (operator == ":" and cardType ~= searchType) or
+            (operator == "!" and cardType == searchType) then
+          cardMatches = false
+        end
       end
     end
 
     -- card has passed all filters and thus gets added
-    table.insert(results, cardData)
-    addedCards[cardData.metadata.id] = true
-
-    -- jump mark at the end of the loop
-    ::nextCard::
+    if cardMatches then
+      table.insert(results, cardData)
+      addedCards[cardData.metadata.id] = true
+    end
   end
   return results
 end
 
-function parseTraits(cardId, traitsString)
-  if dataCache.traits and dataCache.traits[cardId] then
-    return dataCache.traits[cardId]
-  end
-
+function parseTraits(traitsString)
   local traits = {}
   for str in traitsString:gmatch("[^.]+") do
     traits[string.lower(str:match("^%s*(.-)%s*$"))] = true
   end
-
-  if not dataCache.traits then
-    dataCache.traits = {}
-  end
-
-  dataCache.traits[cardId] = traits
   return traits
 end
 

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -489,9 +489,9 @@ end
 --   name: String or string fragment to search for names
 --   exact: Whether the name match should be exact
 function getCardsByName(params)
-  local name = params.name
-  local exact = params.exact
-  local results = {}
+  local name       = params.name
+  local exact      = params.exact
+  local results    = {}
 
   -- Track cards (by ID) that we've added to avoid duplicates that may come from alternate IDs
   local addedCards = {}
@@ -505,6 +505,100 @@ function getCardsByName(params)
     end
   end
   return results
+end
+
+function getCardsByFilter(params)
+  local filters = params.filters
+  local exact   = params.exact
+  local results = {}
+
+  -- track cards (by ID) that we've added to avoid duplicates that may come from alternate IDs
+  local addedCards = {}
+  for _, cardData in pairs(cardIdIndex) do
+    if addedCards[cardData.metadata.id] then
+      goto nextCard
+    end
+
+    -- compare the name
+    if filters.search then
+      local searchname = string.lower(filters.search)
+      local cardname   = string.lower(cardData.data.Nickname)
+      if (exact and cardname ~= searchname) or not string.find(cardname, searchname, 1, true) then
+        goto nextCard
+      end
+    end
+    
+    log("passed name check: " .. cardData.metadata.id)
+
+    -- compare trait (k)
+    if filters.k and (filters.k.operator == ":" or filters.k.operator == "!") then
+      -- get traits from the search (separated by |)
+      local searchTraits = {}
+      for str in filters.k.value:gmatch("([^|]+)") do
+        searchTraits[string.lower(str)] = true
+      end
+
+      -- get traits for the card (like on the card, space + .)
+      local cardTraits = parseTraits(cardData.metadata.traits)
+
+      if filters.k.operator == ":" then
+        for searchTrait, _ in pairs(searchTraits) do
+          if not cardTraits[searchTrait] then
+            log("Skipping " .. cardData.metadata.id .. " due to missing trait: " .. searchTrait)
+            goto nextCard
+          end
+        end
+      elseif filters.k.operator == "!" then
+        for searchTrait, _ in pairs(searchTraits) do
+          if cardTraits[searchTrait] then
+            log("Skipping " .. cardData.metadata.id .. " due to having trait: " .. searchTrait)
+            goto nextCard
+          end
+        end
+      end
+    end
+
+    -- compare level (p)
+    if filters.p then
+
+    end
+
+    -- compare cost (o)
+    if filters.o then
+
+    end
+
+    -- compare slot (z)
+    if filters.z then
+
+    end
+
+    -- compare class (f)
+    if filters.f then
+
+    end
+
+    -- compare type (t)
+    if filters.t then
+
+    end
+
+    -- card has passed all filters and thus gets added
+    table.insert(results, cardData)
+    addedCards[cardData.metadata.id] = true
+
+    -- jump mark at the end of the loop
+    ::nextCard::
+  end
+  return results
+end
+
+function parseTraits(traitsString)
+  local traits = {}
+  for str in traitsString:gmatch("[^.]+") do
+    traits[string.lower(str:match("^%s*(.-)%s*$"))] = true
+  end
+  return traits
 end
 
 -- Gets a random basic weakness from the bag. Once a given ID has been returned it will be

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -532,16 +532,11 @@ function getCardsByFilter(params)
       if not cardData.metadata.traits then
         cardMatches = false
       else
-        -- get traits from the search (separated by |)
-        local searchTraits = {}
-        for str in filters.k.value:gmatch("([^|]+)") do
-          searchTraits[string.lower(str)] = true
-        end
-
-        local cardTraits = parseTraits(cardData.metadata.traits)
-        for searchTrait, _ in pairs(searchTraits) do
-          if (filters.k.operator == ":" and not cardTraits[searchTrait]) or
-              (filters.k.operator == "!" and cardTraits[searchTrait]) then
+        local searchTraits = parseSearchValue(filters.k.value)
+        local operator     = filters.k.operator
+        for _, searchTrait in ipairs(searchTraits) do
+          local containsTrait = string.find(cardData.metadata.traits, searchTrait, 1, true)
+          if (operator == ":" and not containsTrait) or (operator == "!" and containsTrait) then
             cardMatches = false
             break
           end
@@ -554,9 +549,9 @@ function getCardsByFilter(params)
       if not cardData.metadata.level then
         cardMatches = false
       else
-        local searchLevel = tonumber(filters.p.value)
-        local cardLevel = cardData.metadata.level
-        local operator = filters.p.operator
+        local searchLevel  = tonumber(filters.p.value)
+        local cardLevel    = cardData.metadata.level
+        local operator     = filters.p.operator
         if (operator == ":" and cardLevel ~= searchLevel) or
             (operator == "<" and cardLevel >= searchLevel) or
             (operator == ">" and cardLevel <= searchLevel) or
@@ -572,8 +567,8 @@ function getCardsByFilter(params)
         cardMatches = false
       else
         local searchCost = tonumber(filters.o.value)
-        local cardCost = cardData.metadata.cost
-        local operator = filters.o.operator
+        local cardCost   = cardData.metadata.cost
+        local operator   = filters.o.operator
         if (operator == ":" and cardCost ~= searchCost) or
             (operator == "<" and cardCost >= searchCost) or
             (operator == ">" and cardCost <= searchCost) or
@@ -592,9 +587,7 @@ function getCardsByFilter(params)
         local cardSlot     = string.lower(cardData.metadata.slot)
         local operator     = filters.z.operator
         local containsSlot = string.find(cardSlot, searchSlot, 1, true)
-
-        if (operator == ":" and not containsSlot) or
-            (operator == "!" and containsSlot) then
+        if (operator == ":" and not containsSlot) or (operator == "!" and containsSlot) then
           cardMatches = false
         end
       end
@@ -609,9 +602,7 @@ function getCardsByFilter(params)
         local cardClass     = string.lower(cardData.metadata.class)
         local operator      = filters.f.operator
         local containsClass = string.find(cardClass, searchClass, 1, true)
-
-        if (operator == ":" and not containsClass) or
-            (operator == "!" and containsClass) then
+        if (operator == ":" and not containsClass) or (operator == "!" and containsClass) then
           cardMatches = false
         end
       end
@@ -625,9 +616,7 @@ function getCardsByFilter(params)
         local searchType = string.lower(filters.t.value)
         local cardType   = string.lower(cardData.metadata.type)
         local operator   = filters.t.operator
-
-        if (operator == ":" and cardType ~= searchType) or
-            (operator == "!" and cardType == searchType) then
+        if (operator == ":" and cardType ~= searchType) or (operator == "!" and cardType == searchType) then
           cardMatches = false
         end
       end
@@ -642,12 +631,13 @@ function getCardsByFilter(params)
   return results
 end
 
-function parseTraits(traitsString)
-  local traits = {}
-  for str in traitsString:gmatch("[^.]+") do
-    traits[string.lower(str:match("^%s*(.-)%s*$"))] = true
+-- get parts of the search value (separated by |)
+function parseSearchValue(searchValue)
+  local tbl = {}
+  for str in searchValue:gmatch("([^|]+)") do
+    table.insert(tbl, string.lower(str))
   end
-  return traits
+  return tbl
 end
 
 -- Gets a random basic weakness from the bag. Once a given ID has been returned it will be

--- a/src/playercards/AllCardsBagApi.ttslua
+++ b/src/playercards/AllCardsBagApi.ttslua
@@ -64,6 +64,13 @@ do
     return deepCopy(getAllCardsBag().call("getCardsByName", { name = name, exact = exact }))
   end
 
+  -- Searches the bag for cards which match the given filters.
+  ---@param filters table Contains the filters
+  ---@param exact boolean Whether the name match should be exact
+  AllCardsBagApi.getCardsByFilter = function(filters, exact)
+    return deepCopy(getAllCardsBag().call("getCardsByFilter", { filters = filters, exact = exact }))
+  end
+
   AllCardsBagApi.isBagPresent = function()
     return getAllCardsBag() and true
   end

--- a/src/playercards/Search-A-Card.ttslua
+++ b/src/playercards/Search-A-Card.ttslua
@@ -153,14 +153,80 @@ end
 
 function parseSearchString(input)
   local filters = {}
+  local searchTerm = {}
+  local i = 1
+  local length = #input
 
-  for key, operator, value in input:gmatch("(%a)([:<>!])([^%s]+)") do
+  local function skipWhitespace()
+    while i <= length and input:sub(i, i):match("%s") do
+      i = i + 1
+    end
+  end
+
+  local function parseQuotedValue()
+    local start = i
+    i = i + 1 -- Skip the opening quote
+    while i <= length and input:sub(i, i) ~= '"' do
+      i = i + 1
+    end
+    if i > length then
+      printToAll("Unclosed quoted value")
+    end
+    local value = input:sub(start + 1, i - 1)
+    i = i + 1 -- Skip the closing quote
+    return value
+  end
+
+  local function parseUnquotedValue()
+    local start = i
+    while i <= length and not input:sub(i, i):match("[%s\"<>:!]") do
+      i = i + 1
+    end
+    return input:sub(start, i - 1)
+  end
+
+  local function parseFilter()
+    local key = input:sub(i, i)
+    i = i + 1
+    local operator = input:sub(i, i)
+    if not operator:match("[:<>!]") then
+      printToAll("Invalid operator: " .. operator)
+    end
+    i = i + 1
+    skipWhitespace()
+    local value
+    if input:sub(i, i) == '"' then
+      value = parseQuotedValue()
+    else
+      value = parseUnquotedValue()
+    end
     filters[key] = { operator = operator, value = value }
   end
 
-  local mainSearchTerm = input:gsub("(%a[:<>!][^%s]+)", ""):match("^%s*(.-)%s*$")
-  if mainSearchTerm ~= "" then
-    filters.search = mainSearchTerm
+  skipWhitespace()
+  while i <= length do
+    local char = input:sub(i, i)
+    if char:match("%a") then
+      if i + 1 <= length and input:sub(i + 1, i + 1):match("[:<>!]") then
+        parseFilter()
+      else
+        -- Treat as part of the main search term
+        searchTerm[#searchTerm + 1] = char
+        i = i + 1
+      end
+    elseif char:match("[%s\"]") then
+      searchTerm[#searchTerm + 1] = char
+      i = i + 1
+    else
+      printToAll("Unexpected character: " .. char)
+    end
+    skipWhitespace()
+  end
+
+  -- Combine the search term parts into a single string
+  local term = table.concat(searchTerm):match("^%s*(.-)%s*$")
+  if term ~= "" then
+    filters.search = term
   end
 
   return filters

--- a/src/playercards/Search-A-Card.ttslua
+++ b/src/playercards/Search-A-Card.ttslua
@@ -91,7 +91,7 @@ end
 function sanitizeInput(input)
   input = input:gsub("%\n", "")
   inputParameters.value = input:match("^%s*(.-)%s*$")
-  self.removeInput(0)
+  self.clearInputs()
   self.createInput(inputParameters)
   updateSave()
 end
@@ -120,11 +120,15 @@ function startSearch()
       return
     end
   else
+    -- this is called here since the search could be started from the button
     sanitizeInput(inputParameters.value)
   end
 
+  -- parse search filters
+  local parsedFilters = parseSearchString(inputParameters.value)
+
   -- search all objects in bag
-  local cardList = allCardsBagApi.getCardsByName(inputParameters.value, searchExact)
+  local cardList = allCardsBagApi.getCardsByFilter(parsedFilters, searchExact)
   if cardList == nil or #cardList == 0 then
     printToAll("No match found.", "Red")
     return
@@ -145,4 +149,19 @@ function spawnCardList(cardList)
   local rot = self.getRotation()
   local pos = self.positionToWorld(Vector(0, 2, -0.08))
   Spawner.spawnCards(cardList, pos, rot, true)
+end
+
+function parseSearchString(input)
+  local filters = {}
+
+  for key, operator, value in input:gmatch("(%a)([:<>!])([^%s]+)") do
+    filters[key] = { operator = operator, value = value }
+  end
+
+  local mainSearchTerm = input:gsub("(%a[:<>!][^%s]+)", ""):match("^%s*(.-)%s*$")
+  if mainSearchTerm ~= "" then
+    filters.search = mainSearchTerm
+  end
+
+  return filters
 end

--- a/src/playercards/Search-A-Card.ttslua
+++ b/src/playercards/Search-A-Card.ttslua
@@ -211,11 +211,11 @@ function parseSearchString(input)
         parseFilter()
       else
         -- Treat as part of the main search term
-        searchTerm[#searchTerm + 1] = char
+        table.insert(searchTerm, char)
         i = i + 1
       end
     elseif char:match("[%s\"]") then
-      searchTerm[#searchTerm + 1] = char
+      table.insert(searchTerm, char)
       i = i + 1
     else
       printToAll("Unexpected character: " .. char)


### PR DESCRIPTION
Closes: https://github.com/argonui/SCED/issues/762
Note: This supports `|` as "logical and" for traits - not implemented for other filters.

To-Do:
- [x] implement cost
- [x] implement type
- [x] implement level
- [x] implement slot
- [x] implement class
- [x] implement trait
- [x] handling for multiclass / multislot
- [x] handling for search values with spaces (`z:"hand x2"`)
- [x] add explanation / description