### PR TITLE
Updated "pingTable" calls to skip when player is grey

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1276,7 +1276,10 @@ function onClick_spawnPlaceholder(player)
   placeholder.setDescription("by " .. (item.author or "Unknown"))
   placeholder.setGMNotes(item.filename)
   placeholder.setLuaScript(dummy.getLuaScript())
-  Player.getPlayers()[1].pingTable(spawnPos)
+
+  if player.color ~= "Grey" then
+    player.pingTable(spawnPos)
+  end
 
   -- hide download window
   changeWindowVisibilityForColor(player.color, "downloadWindow", false)
@@ -1570,7 +1573,9 @@ function contentDownloadCallback(request, params)
 
         -- ping object
         local pingPlayer = params.player or Player.getPlayers()[1]
-        pingPlayer.pingTable(obj.getPosition())
+        if pingPlayer.color ~= "Grey" then
+          pingPlayer.pingTable(obj.getPosition())
+        end
       end, 0.1)
     end
   end
@@ -1694,7 +1699,9 @@ function playermatRemovalSelected(player, selectedIndex, id)
 
   if mat then
     -- confirmation dialog about deletion
-    player.pingTable(mat.getPosition())
+    if player.color ~= "Grey" then
+      player.pingTable(mat.getPosition())
+    end
     player.showConfirmDialog(
       "Do you really want to remove " .. matColor .. "'s playermat and related objects? This can't be reversed.",
       function()
@@ -1841,7 +1848,10 @@ end
 ---@return string|nil GUID GUID of the spawnedObj (or nil if object was removed)
 function spawnOrRemoveHelper(state, name, position, rotation, owner)
   if state then
-    Player.getPlayers()[1].pingTable(position)
+    local pingPlayer = Player.getPlayers()[1]
+    if pingPlayer.color ~= "Grey" then
+      pingPlayer.pingTable(position)
+    end
     local spawnedGUID = spawnHelperObject(name, position, rotation).getGUID()
     local cleanName = name:gsub("%s+", "")
     guidReferenceApi.editIndex(owner or "Mythos", cleanName, spawnedGUID)


### PR DESCRIPTION
Since the "Grey" player can't ping, these functions were failing. The UI elements are set to visibility "Admin", so we can't exclude "Grey" from that.