### PR TITLE
Added a Minicard sync feature

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -370,8 +370,21 @@ function onObjectDestroy(obj)
   maybeUpdateActionTrackerTokens(obj, 3)
 end
 
-function onObjectDrop(_, obj)
-  maybeUpdateActionTrackerTokens(obj, 20)
+function onObjectDrop(playerColor, obj)
+  if obj.hasTag("Minicard") then
+    for _, card in ipairs(searchLib.belowPosition(obj.getPosition(), "isCard")) do
+      local md = JSON.decode(card.getGMNotes()) or {}
+      if md.type == "Investigator" and (md.id or md.TtsZoopGuid) then
+        local miniMd = JSON.decode(obj.getGMNotes()) or {}
+        miniMd.type = "Minicard"
+        miniMd.id = (md.id or md.TtsZoopGuid) .. "-m"
+        obj.setGMNotes(JSON.encode_pretty(miniMd))
+        printToColor("Updated minicard ID to match investigator", playerColor, "Green")
+      end
+    end
+  else
+    maybeUpdateActionTrackerTokens(obj, 20)
+  end
 end
 
 function onObjectPickUp(_, object)


### PR DESCRIPTION
By dropping a minicard on an investigator you can update the minicard metadata to match the investigator. This can be useful for all the ways we now have to swap your investigator or playing custom content that did not use the correct Zoop settings.