### PR TITLE
Token Attaching updates

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -3212,7 +3212,7 @@ function handleTokenAttaching(params)
   local cardPos = card.getPosition()
   local eligibleTokens = {}
   for _, token in ipairs(searchResult) do
-    if not token.locked and token.getPosition().y > (cardPos.y + 0.025) then
+    if not token.locked and token.getPosition().y > (cardPos.y + 0.01) then
       table.insert(eligibleTokens, token)
     end
   end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -2790,6 +2790,8 @@ function TokenManager.spawnTokensFromUses(card, extraUses)
   local uses = TokenManager.getUses(card)
   if uses == nil then return end
 
+  card.resting = true
+
   -- go through tokens to spawn
   local tokenCount
   for i, useInfo in ipairs(uses) do
@@ -2818,10 +2820,12 @@ function TokenManager.spawnTokensFromDataHelper(card)
   TokenManager.initDataHelperData()
   local playerData = TokenManager.getPlayerCardData(card)
   if playerData ~= nil then
+    card.resting = true
     TokenManager.spawnPlayerCardTokensFromDataHelper(card, playerData)
   end
   local specificLocationData = TokenManager.getLocationData(card)
   if specificLocationData ~= nil then
+    card.resting = true
     TokenManager.spawnLocationTokensFromDataHelper(card, specificLocationData)
   end
 end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -3241,7 +3241,9 @@ function handleTokenAttaching(params)
       else
         return true
       end
-    end
+    end,
+    3,
+    function() handleTokenDetaching({ card = card }) end
   )
 end
 

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1298,8 +1298,6 @@ function onCollisionEnter(collisionInfo)
   collisionTable[object] = true
   Wait.frames(function() collisionTable[object] = nil end, 1)
 
-  GlobalApi.handleTokenDetaching(object)
-
   local md = JSON.decode(object.getGMNotes()) or {}
   syncCustomizableMetadata(object, md)
 

--- a/src/util/Trashcan.ttslua
+++ b/src/util/Trashcan.ttslua
@@ -9,3 +9,9 @@ function emptyTrash()
     self.takeObject().destruct()
   end
 end
+
+function onObjectLeaveContainer(container, object)
+  if container == self then
+    object.setLock(false)
+  end
+end


### PR DESCRIPTION
- more generous y-difference check to allow tiles to stick
- unlock objects leaving the trashcan
- added a time out
- stop cards from moving when spawning tokens
- stop playermats from detaching on first collision