### PR TITLE
Bugfix: Upkeep button should ignore investigator cards

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -394,8 +394,8 @@ function doUpkeep(_, clickedByColor, isRightClick)
       obj.call("doInUpkeep")
     end
 
-    if obj.type == "Card" and not inArea(self.positionToLocal(obj.getPosition()), INVESTIGATOR_AREA) and not obj.hasTag("Investigator") then
-      -- do not continue for cards in investigator card area
+    if obj.type == "Card" and not obj.hasTag("Investigator") then
+      -- do not continue for investigator cards
       local cardMetadata = JSON.decode(obj.getGMNotes()) or {}
 
       if not (obj.getVar("do_not_ready") or obj.hasTag("DoNotReady")) then

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -394,7 +394,7 @@ function doUpkeep(_, clickedByColor, isRightClick)
       obj.call("doInUpkeep")
     end
 
-    if obj.type == "Card" and not inArea(self.positionToLocal(obj.getPosition()), INVESTIGATOR_AREA) then
+    if obj.type == "Card" and not inArea(self.positionToLocal(obj.getPosition()), INVESTIGATOR_AREA) and not obj.hasTag("Investigator") then
       -- do not continue for cards in investigator card area
       local cardMetadata = JSON.decode(obj.getGMNotes()) or {}
 


### PR DESCRIPTION
Prevents e.g. Hank's set aside bonded cards from rotating.