### PR TITLE
Added message variation to token drawing stats

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1,25 +1,25 @@
 require("core/Constants")
-local blessCurseManagerApi          = require("chaosbag/BlessCurseManagerApi")
-local guidReferenceApi              = require("core/GUIDReferenceApi")
-local mythosAreaApi                 = require("mythos/MythosAreaApi")
-local navigationOverlayApi          = require("core/NavigationOverlayApi")
-local playAreaApi                   = require("playarea/PlayAreaApi")
-local playermatApi                  = require("playermat/PlayermatApi")
-local searchLib                     = require("util/SearchLib")
-local soundCubeApi                  = require("core/SoundCubeApi")
-local tokenArrangerApi              = require("tokens/TokenArrangerApi")
-local tokenChecker                  = require("tokens/TokenChecker")
-local tokenSpawnTrackerApi          = require("tokens/TokenSpawnTrackerApi")
+local blessCurseManagerApi        = require("chaosbag/BlessCurseManagerApi")
+local guidReferenceApi            = require("core/GUIDReferenceApi")
+local mythosAreaApi               = require("mythos/MythosAreaApi")
+local navigationOverlayApi        = require("core/NavigationOverlayApi")
+local playAreaApi                 = require("playarea/PlayAreaApi")
+local playermatApi                = require("playermat/PlayermatApi")
+local searchLib                   = require("util/SearchLib")
+local soundCubeApi                = require("core/SoundCubeApi")
+local tokenArrangerApi            = require("tokens/TokenArrangerApi")
+local tokenChecker                = require("tokens/TokenChecker")
+local tokenSpawnTrackerApi        = require("tokens/TokenSpawnTrackerApi")
 
 ---------------------------------------------------------
 -- general setup
 ---------------------------------------------------------
 
 -- wait ids for various functions
-local waitIds                       = {}
+local waitIds                     = {}
 
 -- GUIDs that will not be interactable (e.g. parts of the table)
-local NOT_INTERACTABLE              = {
+local NOT_INTERACTABLE            = {
   "6161b4", -- Decoration-Map
   "9f334f", -- MythosArea
   "463022", -- Panel behind tentacle stand
@@ -31,23 +31,52 @@ local NOT_INTERACTABLE              = {
   "975c39", -- vertical border right
 }
 
-local chaosTokens                   = {}
-local chaosTokensLastMatGUID        = nil
+local chaosTokens                 = {}
+local chaosTokensLastMatGUID      = nil
 
 -- chaos token stat tracking
-local tokenDrawingStats             = { ["Overall"] = {} }
-local lastDrawnTokens               = {}
+local tokenDrawingStats           = { ["Overall"] = {} }
+local lastDrawnTokens             = {}
+local autoFailMessages            = {
+  "<Name> has mastered the art of failure!",
+  "The auto-fail seems to have <Name>'s address.",
+  "If there's an auto-fail in the bag, <Name> will find it.",
+  "Failure is <Name>'s best friend.",
+  "The auto-fail token loves <Name>—too much.",
+  "It's official: <Name> is cursed!",
+  "Nobody attracts disaster quite like <Name>.",
+  "The auto-fail just can't resist <Name>.",
+  "<Name> is the patron saint of bad luck.",
+  "Some call it bad luck, <Name> calls it <Day>.",
+  "<Name> is the auto-fail whisperer.",
+  "<Name> is an auto-fail magnet."
+}
 
-local bagSearchers                  = {}
-local lastZoneEnterObject           = nil
+local elderSignMessages           = {
+  "<Name> is blessed by the elder gods!",
+  "Luck flows through <Name>'s veins.",
+  "<Name> is the chosen one!",
+  "When there's an Elder Sign to draw, <Name> delivers.",
+  "Fate smiles upon <Name>.",
+  "<Name> is a certified miracle worker.",
+  "The Elder Sign practically leaps into <Name>'s hand.",
+  "All hail <Name>, master of fortune!",
+  "<Name> bends luck to their will.",
+  "Is <Name> lucky, or is it magic? Nobody knows.",
+  "<Name> is the Elder Sign whisperer.",
+  "<Name> is the luckiest investigator in Arkham."
+}
+
+local bagSearchers                = {}
+local lastZoneEnterObject         = nil
 
 -- online functionality related variables
 local library, requestObj, modMeta, searchFilter, authorFilter
-local acknowledgedUpgradeVersions   = {}
-local authorList                    = {}
-local contentToShow                 = "campaign"
-local currentListItem               = 1
-local tabIdTable                    = {
+local acknowledgedUpgradeVersions = {}
+local authorList                  = {}
+local contentToShow               = "campaign"
+local currentListItem             = 1
+local tabIdTable                  = {
   tab1 = "campaign",
   tab2 = "scenario",
   tab3 = "fanmade-campaign",
@@ -56,8 +85,8 @@ local tabIdTable                    = {
 }
 
 -- optionPanel data (intentionally not local!)
-optionPanel                         = {}
-local LANGUAGES                     = {
+optionPanel                       = {}
+local LANGUAGES                   = {
   { code = "zh_CN", name = "简体中文" },
   { code = "zh_TW", name = "繁體中文" },
   { code = "de", name = "Deutsch" },
@@ -66,27 +95,27 @@ local LANGUAGES                     = {
   { code = "fr", name = "Français" },
   { code = "it", name = "Italiano" }
 }
-local RESOURCE_OPTIONS              = {
+local RESOURCE_OPTIONS            = {
   "enabled",
   "custom",
   "disabled"
 }
 
 -- track player-specific visibilities
-local actionTrackerVisibility       = {}
-local blurseVisibility              = {}
-local handVisibility                = {}
+local actionTrackerVisibility     = {}
+local blurseVisibility            = {}
+local handVisibility              = {}
 
 -- track cards' tokens
-local cardTokens                    = {}
-local cardSettings                  = {}
+local cardTokens                  = {}
+local cardSettings                = {}
 
 ---------------------------------------------------------
 -- data for tokens
 ---------------------------------------------------------
 
-TokenManager                        = {}
-local tokenOffsets                  = {}
+TokenManager                      = {}
+local tokenOffsets                = {}
 
 -- Table of data extracted from the token source bag, keyed by the Memo on each token which
 -- should match the token type keys ("resource", "clue", etc)
@@ -94,7 +123,7 @@ local tokenTemplates
 local playerCardData, locationData
 
 -- stateIDs for the multi-stated resource tokens
-local stateTable                    = {
+local stateTable                  = {
   ["resource"] = 1,
   ["ammo"]     = 2,
   ["bounty"]   = 3,
@@ -173,7 +202,8 @@ function onLoad(savedData)
         }
       }
     })
-    statTracker.addContextMenuItem("Print my stats", function(playerColor) handleStatTrackerClick(Player[playerColor], "-3") end)
+    statTracker.addContextMenuItem("Print my stats",
+      function(playerColor) handleStatTrackerClick(Player[playerColor], "-3") end)
   end
   Wait.frames(createActionTrackerUI, 10)
 
@@ -557,7 +587,7 @@ function returnAndRedraw(_, tokenGUID)
   end
 
   -- perform the actual token replacing
-  trackChaosToken(tokenName, mat.getGUID(), true)
+  trackChaosToken(tokenName, mat.getMemo(), true)
   local params = { token = returnedToken, fromBag = true }
   returnChaosTokenToBag(params)
 
@@ -684,7 +714,7 @@ function drawChaosToken(params)
     local tokenData = mythosAreaApi.returnTokenData().tokenData or {}
     local specificData = tokenData[name] or {}
     token.setDescription(specificData.description or "")
-    trackChaosToken(name, matGUID)
+    trackChaosToken(name, params.mat.getMemo())
 
     if not params.takeParameters then
       table.insert(chaosTokens, token)
@@ -714,19 +744,19 @@ end
 -- chaos token stat tracker
 ---------------------------------------------------------
 
-function trackChaosToken(tokenName, matGUID, subtract)
+function trackChaosToken(tokenName, matColor, subtract)
   -- initialize tables
-  if not tokenDrawingStats[matGUID] then tokenDrawingStats[matGUID] = {} end
+  if not tokenDrawingStats[matColor] then tokenDrawingStats[matColor] = {} end
 
   -- increase stats by 1 (or decrease if token is returned)
   local modifier                          = (subtract and -1 or 1)
   tokenName                               = getReadableTokenName(tokenName)
   tokenDrawingStats["Overall"][tokenName] = (tokenDrawingStats["Overall"][tokenName] or 0) + modifier
-  tokenDrawingStats[matGUID][tokenName]   = (tokenDrawingStats[matGUID][tokenName] or 0) + modifier
+  tokenDrawingStats[matColor][tokenName]  = (tokenDrawingStats[matColor][tokenName] or 0) + modifier
 
   -- add to list of last drawn tokens (if not subtracting)
   if not subtract then
-    table.insert(lastDrawnTokens, { tokenName = tokenName, matGUID = matGUID })
+    table.insert(lastDrawnTokens, { tokenName = tokenName, matColor = matColor })
     if #lastDrawnTokens > 5 then
       table.remove(lastDrawnTokens, 1)
     end
@@ -741,27 +771,31 @@ function handleStatTrackerClick(player, clickType, _)
     return
   end
 
-  local squidKing     = "Nobody"
-  local maxSquid      = 0
-  local foundAnyStats = false
+  local mostAutoFails, mostElderSigns = "Nobody", "Nobody"
+  local maxAutoFails, maxElderSigns   = 0, 0
+  local foundAnyStats                 = false
 
-  for key, personalStats in pairs(tokenDrawingStats) do
+  for matColor, personalStats in pairs(tokenDrawingStats) do
     -- skip if middle-clicked and not the color of the clicking player
-    if clickType ~= "-3" or guidReferenceApi.getOwnerOfObject(getObjectFromGUID(key)) == playermatApi.getMatColor(player.color) then
+    if clickType ~= "-3" or matColor == playermatApi.getMatColor(player.color) then
       local playerColor, playerName
 
-      if key == "Overall" then
+      if matColor == "Overall" then
         playerColor = "White"
-        playerName = "Overall"
+        playerName  = "Overall"
       else
-        local matColor = playermatApi.getMatColorByPosition(getObjectFromGUID(key).getPosition())
         playerColor = playermatApi.getPlayerColor(matColor)
-        playerName = Player[playerColor].steam_name or playerColor
+        playerName  = Player[playerColor].steam_name or playerColor
 
-        local playerSquidCount = personalStats["Auto-fail"] or 0
-        if playerSquidCount > maxSquid then
-          squidKing = playerName
-          maxSquid = playerSquidCount
+        -- track auto-fails / elder signs
+        if (personalStats["Auto-fail"] or 0) > maxAutoFails then
+          mostAutoFails = playerColor
+          maxAutoFails  = personalStats["Auto-fail"]
+        end
+
+        if (personalStats["Elder Sign"] or 0) > maxElderSigns then
+          mostElderSigns = playerColor
+          maxElderSigns  = personalStats["Elder Sign"]
         end
       end
 
@@ -809,13 +843,12 @@ function handleStatTrackerClick(player, clickType, _)
     if #lastDrawnTokens > 0 then
       local tokenStr = ""
       for _, data in ipairs(lastDrawnTokens) do
-        local mat = getObjectFromGUID(data.matGUID)
-        if mat ~= nil then
-          local handColor = mat.getVar("playerColor")
-          tokenStr = tokenStr .. "[" .. Color.fromString(handColor):toHex() .. "]" .. data.tokenName .. "[-], "
-        else
-          tokenStr = tokenStr .. data.tokenName .. " ,"
+        local handColor = playermatApi.getPlayerColor(data.matColor)
+        local tokenName = data.tokenName
+        if handColor ~= nil then
+          tokenName = "[" .. Color.fromString(handColor):toHex() .. "]" .. tokenName .. "[-]"
         end
+        tokenStr = tokenStr .. tokenName .. ", "
       end
 
       -- remove last delimiter
@@ -823,10 +856,18 @@ function handleStatTrackerClick(player, clickType, _)
       printToAll("Last 5 (old to new): " .. tokenStr)
     end
 
-    printToAll(squidKing .. " is an auto-fail magnet.", { 255, 0, 0 })
+    -- print the player with the most auto-fails / elder signs
+    outputRandomMessage(mostAutoFails, autoFailMessages, { 215, 30, 60 })
+    outputRandomMessage(mostElderSigns, elderSignMessages, { 30, 185, 215 })
   else
     printToAll("No tokens have been drawn yet.", "Yellow")
   end
+end
+
+function outputRandomMessage(playerColor, list, msgColor)
+  if playerColor == "Nobody" then return end
+  local playerName = getColoredName(playerColor)
+  printToAll(list[math.random(#list)]:gsub("<Name>", playerName):gsub("<Day>", os.date("%A")), msgColor)
 end
 
 -- resets the count for each token to 0
@@ -1418,8 +1459,9 @@ function onClick_toggleUi(player, windowId)
     return
   elseif windowId == "actionTracker" then
     -- store the state of the Action Tracker UI to restore it onLoad()
-    actionTrackerVisibility[player.color] = changeWindowVisibilityForColor(player.color, "actionTracker")
-    printToColor("Action Tracker " .. (actionTrackerVisibility[player.color] and "enabled." or "disabled."), player.color)
+    local visibility = changeWindowVisibilityForColor(player.color, "actionTracker")
+    actionTrackerVisibility[player.color] = visibility
+    printToColor("Action Tracker " .. (visibility and "enabled." or "disabled."), player.color)
 
     changeWindowVisibilityForColor(player.color, "optionPanel", false)
     return
@@ -1644,22 +1686,22 @@ function createActionTrackerUI()
   local actionTrackerXml = {
     tag = "TableLayout",
     attributes = {
-      id            = "actionTracker",
-      color         = "black",
-      visibility    = visibilityString,
-      active        = visibilityString ~= "",
-      height        = 30 * #usedMatColors,
-      width         = "300",
-      offsetXY      = "-2 396",
-      columnWidths  = "0 25 25 25 25 25",
-      padding       = "4 4 4 4",
-      cellSpacing   = "5",
-      allowDragging = true,
+      id                                   = "actionTracker",
+      color                                = "black",
+      visibility                           = visibilityString,
+      active                               = visibilityString ~= "",
+      height                               = 30 * #usedMatColors,
+      width                                = "300",
+      offsetXY                             = "-2 396",
+      columnWidths                         = "0 25 25 25 25 25",
+      padding                              = "4 4 4 4",
+      cellSpacing                          = "5",
+      allowDragging                        = true,
       returnToOriginalPositionWhenReleased = false,
-      rectAlignment = "LowerRight",
-      raycastTarget = true,
-      outlineSize   = "2 2",
-      outline       = "#303030"
+      rectAlignment                        = "LowerRight",
+      raycastTarget                        = true,
+      outlineSize                          = "2 2",
+      outline                              = "#303030"
     },
     children = {}
   }
@@ -2696,15 +2738,12 @@ end
 
 -- Spawns a single token at the given global position by copying it from the template bag.
 function TokenManager.spawnToken(params)
-  local position       = params.position
   local rotation       = params.rotation
   local tokenType      = params.tokenType
   local callbackName   = params.callbackName
   local callbackParams = params.callbackParams
   local scriptstate    = params.scriptstate
-
-  -- initialize data table
-  local spawnData = { position = position }
+  local spawnData      = { position = params.position }
 
   -- maybe set callback function
   if callbackName then
@@ -3240,10 +3279,9 @@ function handleTokenAttaching(params)
   local card = params.card
   if card == nil then return end
 
-  local player       = params.player
-  local searchResult = searchLib.onObject(card, "isTileOrToken", 0.9)
-
-  local cardPos = card.getPosition()
+  local player         = params.player
+  local searchResult   = searchLib.onObject(card, "isTileOrToken", 0.9)
+  local cardPos        = card.getPosition()
   local eligibleTokens = {}
   for _, token in ipairs(searchResult) do
     if not token.locked and token.getPosition().y > (cardPos.y + 0.01) then

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -37,22 +37,30 @@ local chaosTokensLastMatGUID      = nil
 -- chaos token stat tracking
 local tokenDrawingStats           = { ["Overall"] = {} }
 local lastDrawnTokens             = {}
-local autoFailMessages            = {
+local autoFailMessages = {
   "<Name> has mastered the art of failure!",
-  "The auto-fail seems to have <Name>'s address.",
-  "If there's an auto-fail in the bag, <Name> will find it.",
+  "The Auto-fail seems to have <Name>'s address.",
+  "If there's an Auto-fail in the bag, <Name> will find it.",
   "Failure is <Name>'s best friend.",
-  "The auto-fail token loves <Name>—too much.",
+  "The Auto-fail token loves <Name>—too much.",
   "It's official: <Name> is cursed!",
   "Nobody attracts disaster quite like <Name>.",
-  "The auto-fail just can't resist <Name>.",
+  "The Auto-fail just can't resist <Name>.",
   "<Name> is the patron saint of bad luck.",
   "Some call it bad luck, <Name> calls it <Day>.",
-  "<Name> is the auto-fail whisperer.",
-  "<Name> is an auto-fail magnet."
+  "<Name> is the Auto-fail whisperer.",
+  "<Name> is an Auto-fail magnet.",
+  "Destiny has chosen <Name>... for failure.",
+  "<Name> collects Auto-fails like they’re souvenirs.",
+  "The Auto-fail token simply adores <Name>.",
+  "Some call it unlucky, <Name> calls it a challenge.",
+  "The chaos bag has a vendetta against <Name>.",
+  "If failing were an art, <Name> would be a master painter.",
+  "Auto-fails are like moths to <Name>'s flame.",
+  "It's not bad luck—it’s a lifestyle for <Name>."
 }
 
-local elderSignMessages           = {
+local elderSignMessages = {
   "<Name> is blessed by the elder gods!",
   "Luck flows through <Name>'s veins.",
   "<Name> is the chosen one!",
@@ -64,7 +72,38 @@ local elderSignMessages           = {
   "<Name> bends luck to their will.",
   "Is <Name> lucky, or is it magic? Nobody knows.",
   "<Name> is the Elder Sign whisperer.",
-  "<Name> is the luckiest investigator in Arkham."
+  "<Name> is the luckiest investigator in Arkham.",
+  "Providence shines upon <Name>. Truly inspiring!",
+  "<Name> might as well own the Elder Sign.",
+  "The Elder Sign knows exactly where <Name> is.",
+  "When <Name> plays, the Elder Sign is a sure thing.",
+  "With <Name> in the group, victory is inevitable.",
+  "Chaos itself bows to <Name>'s luck.",
+  "<Name>'s touch turns chaos into triumph.",
+  "Elder Signs follow <Name> like moths to a flame."
+}
+
+local dualMessages = {
+  "<Name> rides the rollercoaster of luck!",
+  "<Name> is both cursed and blessed—it’s complicated.",
+  "The chaos bag doesn’t know what to make of <Name>.",
+  "<Name> proves you can fail and succeed spectacularly in equal measure.",
+  "Fortune and disaster are <Name>'s constant companions.",
+  "<Name> truly embodies the chaos of Arkham.",
+  "Both the Elder Sign and Auto-fail have chosen <Name> as their champion.",
+  "No one walks the line between luck and disaster quite like <Name>.",
+  "<Name> can fail gloriously and win miraculously—all in the same turn.",
+  "<Name> is a chaotic force of nature.",
+  "With <Name>, it’s all or nothing—and sometimes both!",
+  "<Name> keeps the group guessing: triumph or disaster?",
+  "Somehow, <Name> is both the luckiest and unluckiest player.",
+  "The chaos bag is in love with <Name>—but can’t decide how.",
+  "<Name> lives life on the edge of chaos.",
+  "<Name> redefines unpredictability!",
+  "The Elder Sign and Auto-fail battle over <Name>'s fate.",
+  "With <Name>, the chaos bag swings wildly between doom and glory.",
+  "<Name> keeps everyone on their toes: lucky or cursed?",
+  "One moment a hero, the next a failure—that’s <Name> for you."
 }
 
 local bagSearchers                = {}
@@ -767,7 +806,7 @@ end
 function handleStatTrackerClick(player, clickType, _)
   if clickType == "-2" then
     -- right-clicked
-    resetChaosTokenStatTracker()
+    resetChaosTokenStatTracker(player)
     return
   end
 
@@ -857,8 +896,12 @@ function handleStatTrackerClick(player, clickType, _)
     end
 
     -- print the player with the most auto-fails / elder signs
-    outputRandomMessage(mostAutoFails, autoFailMessages, { 215, 30, 60 })
-    outputRandomMessage(mostElderSigns, elderSignMessages, { 30, 185, 215 })
+    if mostAutoFails == mostElderSigns then
+      outputRandomMessage(mostAutoFails, dualMessages, { r = 200 / 255, g = 100 / 255, b = 255 / 255 })
+    else
+      outputRandomMessage(mostAutoFails, autoFailMessages, { r = 215 / 255, g = 30 / 255, b = 60 / 255 })
+      outputRandomMessage(mostElderSigns, elderSignMessages, { r = 30 / 255, g = 185 / 255, b = 215 / 255 })
+    end
   else
     printToAll("No tokens have been drawn yet.", "Yellow")
   end
@@ -871,10 +914,14 @@ function outputRandomMessage(playerColor, list, msgColor)
 end
 
 -- resets the count for each token to 0
-function resetChaosTokenStatTracker()
-  printToAll("Chaos Token stat tracker has been reset.")
-  lastDrawnTokens = {}
-  tokenDrawingStats = { ["Overall"] = {} }
+function resetChaosTokenStatTracker(player)
+  player.showConfirmDialog("Are you sure you want to reset the Chaos Token stats?",
+    function()
+      printToAll("Chaos Token stat tracker has been reset.")
+      lastDrawnTokens = {}
+      tokenDrawingStats = { ["Overall"] = {} }
+    end
+  )
 end
 
 ---------------------------------------------------------
@@ -1867,11 +1914,23 @@ end
 -- returns the display name (steam name or investigator)
 function getDisplayName(matColor)
   local playerColor = playermatApi.getPlayerColor(matColor)
+
+  -- if the mat was removed or something wierd happened, just return the matColor
+  if not playerColor then return matColor end
+
+  -- return steam name if there's a seated player
   if Player[playerColor] and Player[playerColor].steam_name then
     return Player[playerColor].steam_name
-  else
-    return playermatApi.getInvestigatorName(matColor)
   end
+
+  -- return investigator name if possible
+  local investigatorName = playermatApi.getInvestigatorName(matColor)
+  if investigatorName ~= "" then
+    return investigatorName
+  end
+
+  -- default to playerColor
+  return playerColor
 end
 
 -- this helper function updates the global XML while preserving the visibility of windows
@@ -3227,12 +3286,18 @@ function isTableEmpty(tbl)
   end
 end
 
--- returns the colored steam name or color
+-- returns the colored steam name, investigator name or color
 ---@param playerColor string Color of the player
 function getColoredName(playerColor)
   local displayName = playerColor
   if playerColor ~= "Grey" and Player[playerColor].steam_name then
     displayName = Player[playerColor].steam_name
+  else
+    local matColor = playermatApi.getMatColor(playerColor)
+    local investigatorName = playermatApi.getInvestigatorName(matColor)
+    if investigatorName ~= "" then
+      displayName = investigatorName
+    end
   end
 
   -- add bb-code

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -84,27 +84,28 @@ local elderSignMessages = {
 }
 
 local dualMessages = {
-  "<Name> rides the rollercoaster of luck!",
-  "<Name> is both cursed and blessed—it’s complicated.",
-  "The chaos bag doesn’t know what to make of <Name>.",
-  "<Name> proves you can fail and succeed spectacularly in equal measure.",
-  "Fortune and disaster are <Name>'s constant companions.",
-  "<Name> truly embodies the chaos of Arkham.",
-  "Both the Elder Sign and Auto-fail have chosen <Name> as their champion.",
-  "No one walks the line between luck and disaster quite like <Name>.",
-  "<Name> can fail gloriously and win miraculously—all in the same turn.",
-  "<Name> is a chaotic force of nature.",
-  "With <Name>, it’s all or nothing—and sometimes both!",
-  "<Name> keeps the group guessing: triumph or disaster?",
-  "Somehow, <Name> is both the luckiest and unluckiest player.",
-  "The chaos bag is in love with <Name>—but can’t decide how.",
-  "<Name> lives life on the edge of chaos.",
-  "<Name> redefines unpredictability!",
-  "The Elder Sign and Auto-fail battle over <Name>'s fate.",
-  "With <Name>, the chaos bag swings wildly between doom and glory.",
-  "<Name> keeps everyone on their toes: lucky or cursed?",
-  "One moment a hero, the next a failure—that’s <Name> for you."
+  "<Name> is the embodiment of extreme luck—both good and bad!",
+  "No one has soared so high and fallen so hard as <Name>.",
+  "Fate can’t decide what to do with <Name>—miracle one moment, disaster the next!",
+  "<Name> has been both the chosen one and the forsaken one.",
+  "No player has ever been as blessed and as cursed as <Name>.",
+  "<Name> is a walking paradox: the luckiest and unluckiest at the same time.",
+  "When <Name> wins, they *win big*. When they lose… well, you get the idea.",
+  "The chaos bag giveth, and the chaos bag taketh away—just ask <Name>.",
+  "<Name> has been on the wildest ride of fate ever seen in Arkham.",
+  "The only constant in <Name>'s journey is unpredictability.",
+  "Destiny can’t make up its mind about <Name>: ultimate triumph or crushing defeat?",
+  "From utter devastation to legendary victories, <Name> has seen it all this game.",
+  "<Name> is the luckiest unlucky player—or the unluckiest lucky player?",
+  "The gods of chaos have taken a *special* interest in <Name> today.",
+  "One moment, <Name> is a hero; the next, a tragic cautionary tale.",
+  "If luck were a rollercoaster, <Name> just rode it with no safety bar.",
+  "Arkham’s fate played favorites with <Name>—but kept changing its mind!",
+  "Never before has someone been so blessed *and* so doomed as <Name>.",
+  "<Name> defied the odds in *both* directions this game!",
+  "Legend will speak of <Name>’s ridiculous streak of fortune *and* disaster."
 }
+
 
 local bagSearchers                = {}
 local lastZoneEnterObject         = nil


### PR DESCRIPTION
1) The "auto-fail magnet" message has been updated with about 20 other versions:
```
  "<Name> has mastered the art of failure!",
  "The auto-fail seems to have <Name>'s address.",
  "If there's an auto-fail in the bag, <Name> will find it.",
  "Failure is <Name>'s best friend.",
  "The auto-fail token loves <Name>—too much.",
  "It's official: <Name> is cursed!",
  "Nobody attracts disaster quite like <Name>.",
  "The auto-fail just can't resist <Name>.",
  "<Name> is the patron saint of bad luck.",
  "Some call it bad luck, <Name> calls it <Day>.",
  "<Name> is the auto-fail whisperer.",
  "<Name> is an auto-fail magnet."
  ...
```

2) There is a similar message for the Elder Sign too (and special messages if someone meets both criteria!)

3) Both now include the colored player name (rest of the message is red / blue) - this defaults to the investigator name for unseated mats

4) Token drawing stats now uses the matColor instead of the GUID

5) Global has been slightly reformatted