### PR TITLE
Adds clickable doom counter

### DIFF
--- a/objects/Fan-MadeAccessories.aa8b38.json
+++ b/objects/Fan-MadeAccessories.aa8b38.json
@@ -21,7 +21,8 @@
     "UnderworldMarketHelper.3650ea",
     "AllEncounterCards.aa12bb",
     "Auto-failCounter.a9a321",
-    "ElderSignCounter.e62cb5"
+    "ElderSignCounter.e62cb5",
+    "DoomCounterBag.a82b88"
   ],
   "ContainedObjects_path": "Fan-MadeAccessories.aa8b38",
   "CustomMesh": {

--- a/objects/Fan-MadeAccessories.aa8b38/DoomCounterBag.a82b88.json
+++ b/objects/Fan-MadeAccessories.aa8b38/DoomCounterBag.a82b88.json
@@ -11,10 +11,10 @@
     "r": 0.30589
   },
   "ContainedObjects_order": [
-    "AttachmentHelper.d45664"
+    "DoomCounter.a7cc48"
   ],
-  "ContainedObjects_path": "AttachmentHelper.7f4976",
-  "Description": "Provides card-sized bags that are useful for cards that are attached facedown (e.g. Backpack).",
+  "ContainedObjects_path": "DoomCounterBag.a82b88",
+  "Description": "Provides a clickable doom counter.",
   "DragSelectable": true,
   "GMNotes": "",
   "GUID": "a82b88",
@@ -31,11 +31,10 @@
   "MeasureMovement": false,
   "MeshIndex": -1,
   "Name": "Infinite_Bag",
-  "Nickname": "Attachment Helper",
+  "Nickname": "Doom Counter Bag",
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "AttachmentHelperBag",
     "CleanUpHelper_ignore"
   ],
   "Tooltip": true,

--- a/objects/Fan-MadeAccessories.aa8b38/DoomCounterBag.a82b88/DoomCounter.a7cc48.json
+++ b/objects/Fan-MadeAccessories.aa8b38/DoomCounterBag.a82b88/DoomCounter.a7cc48.json
@@ -1,0 +1,60 @@
+{
+  "AltLookAngle": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "Autoraise": true,
+  "ColorDiffuse": {
+    "b": 0,
+    "g": 0,
+    "r": 1
+  },
+  "CustomImage": {
+    "CustomToken": {
+      "MergeDistancePixels": 10,
+      "Stackable": false,
+      "StandUp": false,
+      "Thickness": 0.1
+    },
+    "ImageScalar": 1,
+    "ImageSecondaryURL": "",
+    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/949592555964782208/CC876694A6684B3C2680CE2FE3259F574AE0AD97/",
+    "WidthScale": 0
+  },
+  "Description": "",
+  "DragSelectable": true,
+  "GMNotes": "",
+  "GUID": "a7cc48",
+  "Grid": true,
+  "GridProjection": false,
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "IgnoreFoW": false,
+  "LayoutGroupSortIndex": 0,
+  "Locked": false,
+  "LuaScript": "require(\"tokens/GenericCounter\")",
+  "LuaScriptState": "0",
+  "MeasureMovement": false,
+  "Memo": "DoomCounter",
+  "Name": "Custom_Token",
+  "Nickname": "Doom Counter",
+  "Snap": true,
+  "Sticky": true,
+  "Tags": [
+    "CleanUpHelper_ignore"
+  ],
+  "Tooltip": true,
+  "Transform": {
+    "posX": -5.3,
+    "posY": 1.633,
+    "posZ": 0.378,
+    "rotX": 0,
+    "rotY": 270,
+    "rotZ": 0,
+    "scaleX": 0.42,
+    "scaleY": 1,
+    "scaleZ": 0.42
+  },
+  "Value": 0
+}

--- a/src/mythos/DoomInPlayCounter.ttslua
+++ b/src/mythos/DoomInPlayCounter.ttslua
@@ -53,9 +53,9 @@ function toggleSubtractDoom(override)
   updateSave()
 
   if subtractDoom then
-    printToAll("Doom in play: Subtract from the total doom count.", "Orange")
+    broadcastToAll("Doom in play: Now subtracts from the total doom count.", "Orange")
   else
-    printToAll("Doom in play: Add to the total doom count.", "Orange")
+    broadcastToAll("Doom in play: Now adds to the total doom count.", "Orange")
   end
 end
 
@@ -89,6 +89,9 @@ function getDoomAmount(obj, disregardIgnoreTag)
       and (not obj.hasTag(IGNORE_TAG) or disregardIgnoreTag)
       and inArea(obj.getPosition(), TOTAL_PLAY_AREA) then
     return math.abs(obj.getQuantity())
+  elseif obj.getMemo() == "DoomCounter" and (not obj.hasTag(IGNORE_TAG) or disregardIgnoreTag) 
+    and inArea(obj.getPosition(), TOTAL_PLAY_AREA) then
+      return obj.getVar("val")
   else
     return 0
   end
@@ -117,7 +120,11 @@ function removeDoomFromList(objList)
   for _, obj in ipairs(objList) do
     local amount = getDoomAmount(obj, true)
     if amount > 0 then
-      TRASH.putObject(obj)
+      if obj.getMemo() == "DoomCounter" then
+        obj.call("updateVal", 0)
+      else
+        TRASH.putObject(obj)
+      end
       count = count + amount
     end
   end

--- a/src/tokens/GenericCounter.ttslua
+++ b/src/tokens/GenericCounter.ttslua
@@ -26,6 +26,12 @@ function onLoad(savedData)
     position = { 0, 0.06, 0.1 }
   elseif tokenType == "ElderSignCounter" or tokenType == "AutofailCounter" then
     position = { 0, 0.1, 0 }
+  elseif tokenType == "DoomCounter" then
+      position       = { 0, 0.06, 0 }
+      height         = 800
+      width          = 800
+      font_size      = 650
+      font_color     = { 1, 1, 1, 95 }
   end
 
   self.createButton({
@@ -34,11 +40,11 @@ function onLoad(savedData)
     function_owner = self,
     position = position,
     rotation = rotation or { 0, 0, 0 },
-    height = 600,
-    width = 1000,
+    height = height or 600,
+    width = width or 1000,
     scale = { 1.5, 1.5, 1.5 },
-    font_size = 600,
-    font_color = { 1, 1, 1, 100 },
+    font_size = font_size or 600,
+    font_color = font_color or { 1, 1, 1, 100 },
     color = { 0, 0, 0, 0 }
   })
 


### PR DESCRIPTION
This creates a new counter that is able to be read by the main Doom In Play scripts. For now, it is in the set aside barrel, but should be spawned by scenarios and campaigns if necessary. Could be incorporated in the future by e.g. David Renfield if clickable counters are turned on.