### PR TITLE
Added debug function to force specific option panel state

### DIFF
--- a/src/core/CampaignImporterExporter.ttslua
+++ b/src/core/CampaignImporterExporter.ttslua
@@ -171,7 +171,7 @@ function importFromToken()
   end
 
   if importData["options"] then
-    globalApi.loadOptionPanelSettings(importData["options"])
+    globalApi.loadOptionPanelState(importData["options"])
     coWaitFrames(5)
   end
 

--- a/src/core/Constants.ttslua
+++ b/src/core/Constants.ttslua
@@ -37,3 +37,27 @@ ENCOUNTER_DISCARD_POSITION = Vector(-3.85, 1.5, 10.38)
 MOD_VERSION                = "4.1.0"
 SOURCE_REPO                = "https://github.com/Chr1Z93/SCED-downloads/releases/latest/download/"
 --SOURCE_REPO              = "https://github.com/Chr1Z93/SCED-downloads/releases/download/v1.0.1/"
+
+-- these can be loaded by right-clicking the option panel button
+PREFERRED_OPTIONS          = {
+  Chr1Z = {
+    changePlayAreaImage  = true,
+    showAttachmentHelper = true,
+    showCleanUpHelper    = true,
+    showDisplacementTool = true,
+    showDrawButton       = true,
+    showHandHelper       = true,
+    showSearchAssistant  = true,
+    useResourceCounters  = "custom"
+  },
+  dscarpac = {
+    showHandHelper = true
+  }
+}
+
+-- this can be used to load specific option onLoad()
+LOAD_DEBUG_OPTION_PANEL    = false
+DEBUG_OPTION_PANEL_STATE   = {
+  showSearchAssistant = true,
+  showCleanUpHelper   = true
+}

--- a/src/core/Constants.ttslua
+++ b/src/core/Constants.ttslua
@@ -50,14 +50,14 @@ OPTION_PRESETS             = {
     showSearchAssistant  = true,
     useResourceCounters  = "custom"
   },
-  dscarpac = {
-    showHandHelper = true
+  Daniel = {
+    showHandHelper       = true,
+    showSearchAssistant  = true
   }
 }
 
 -- this can be used to load specific option onLoad()
 LOAD_DEBUG_OPTION_PANEL    = false
 DEBUG_OPTION_PANEL_STATE   = {
-  showSearchAssistant = true,
-  showCleanUpHelper   = true
+  showSearchAssistant = true
 }

--- a/src/core/Constants.ttslua
+++ b/src/core/Constants.ttslua
@@ -39,7 +39,7 @@ SOURCE_REPO                = "https://github.com/Chr1Z93/SCED-downloads/releases
 --SOURCE_REPO              = "https://github.com/Chr1Z93/SCED-downloads/releases/download/v1.0.1/"
 
 -- these can be loaded by right-clicking the option panel button
-PREFERRED_OPTIONS          = {
+OPTION_PRESETS             = {
   Chr1Z = {
     changePlayAreaImage  = true,
     showAttachmentHelper = true,

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -113,6 +113,7 @@ local tabIdTable                  = {
 
 -- optionPanel data (intentionally not local!)
 optionPanel                       = {}
+local sentOptionPanelMessage      = {}
 local LANGUAGES                   = {
   { code = "zh_CN", name = "简体中文" },
   { code = "zh_TW", name = "繁體中文" },
@@ -1474,6 +1475,11 @@ function onClick_toggleOptionPanel(player, clickType)
       changeWindowVisibilityForColor(player.color, "actionTracker", false)
       changeWindowVisibilityForColor(player.color, "navPanelFull", false)
       changeWindowVisibilityForColor(player.color, "navPanelPlay", false)
+
+      if not sentOptionPanelMessage[player.color] then
+        printToColor("Right-click the Option Panel button to show presets.", player.color)
+        sentOptionPanelMessage[player.color] = true
+      end
     else
       if blurseVisibility[player.color] then
         changeWindowVisibilityForColor(player.color, "blessCurseManager", blurseVisibility[player.color])

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -1483,9 +1483,21 @@ function onClick_toggleOptionPanel(player, clickType)
       end
       navigationOverlayApi.updateVisibility()
     end
-  else
-    -- for right-/middle-click attempt to load options
-    local options = PREFERRED_OPTIONS[player.steam_name]
+  elseif clickType == "-2" then
+    -- right-click: show option presets
+    local presetNames = {}
+    for name, _ in pairs(OPTION_PRESETS) do
+      table.insert(presetNames, name)
+    end
+
+    player.showOptionsDialog("Choose an option preset", presetNames, 1,
+      function (presetName)
+        loadOptionPanelState(OPTION_PRESETS[presetName])
+        printToAll("Loaded option preset: " .. presetName, "Green")
+      end)
+  elseif clickType == "-3" then
+    -- middle-click: directly load mods for your name
+    local options = OPTION_PRESETS[player.steam_name]
     if options then
       loadOptionPanelState(options)
       printToAll("Loaded " .. player.steam_name .. "'s preferred options.", "Green")

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -15,12 +15,6 @@ local tokenSpawnTrackerApi        = require("tokens/TokenSpawnTrackerApi")
 -- general setup
 ---------------------------------------------------------
 
-local loadDebugOptionPanelState   = false
-local debugOptionPanelState       = {
-  showSearchAssistant = true,
-  showCleanUpHelper   = true
-}
-
 -- wait ids for various functions
 local waitIds                     = {}
 
@@ -242,8 +236,8 @@ function onLoad(savedData)
   end, 1)
 
   -- load specific option panel state for debugging / developing
-  if loadDebugOptionPanelState then
-    Wait.frames(function() loadOptionPanelState(debugOptionPanelState) end, 90)
+  if LOAD_DEBUG_OPTION_PANEL then
+    Wait.frames(function() loadOptionPanelState(DEBUG_OPTION_PANEL_STATE) end, 90)
   end
 end
 
@@ -1469,24 +1463,10 @@ function onClick_spawnPlaceholder(player)
   changeWindowVisibilityForColor(player.color, "downloadWindow", false)
 end
 
--- toggles the visibility of the respective UI
----@param player tts__Player Player that triggered this
----@param windowId string Name of the UI to toggle
-function onClick_toggleUi(player, windowId)
-  -- let the Navigation Overlay handle the toggling of its visibility modes
-  if windowId == "Navigation Overlay" then
-    navigationOverlayApi.cycleVisibility(player.color)
-    changeWindowVisibilityForColor(player.color, "optionPanel", false)
-    return
-  end
-
-  -- hide the playAreaGallery / downloadWindow if visible
-  if windowId == "downloadWindow" then
-    changeWindowVisibilityForColor(player.color, "playAreaGallery", false)
-  elseif windowId == "playAreaGallery" then
-    changeWindowVisibilityForColor(player.color, "downloadWindow", false)
-  elseif windowId == "optionPanel" then
-    local newState = changeWindowVisibilityForColor(player.color, windowId)
+function onClick_toggleOptionPanel(player, clickType)
+  if clickType == "-1" then
+    -- regular behaviour for left-click
+    local newState = changeWindowVisibilityForColor(player.color, "optionPanel")
 
     -- show/hide secondary windows
     if newState == true then
@@ -1503,7 +1483,34 @@ function onClick_toggleUi(player, windowId)
       end
       navigationOverlayApi.updateVisibility()
     end
+  else
+    -- for right-/middle-click attempt to load options
+    local options = PREFERRED_OPTIONS[player.steam_name]
+    if options then
+      loadOptionPanelState(options)
+      printToAll("Loaded " .. player.steam_name .. "'s preferred options.", "Green")
+    else
+      printToAll("Didn't find " .. player.steam_name .. "'s preferred options.", "Yellow")
+    end
+  end
+end
+
+-- toggles the visibility of the respective UI
+---@param player tts__Player Player that triggered this
+---@param windowId string Name of the UI to toggle
+function onClick_toggleUi(player, windowId)
+  -- let the Navigation Overlay handle the toggling of its visibility modes
+  if windowId == "Navigation Overlay" then
+    navigationOverlayApi.cycleVisibility(player.color)
+    changeWindowVisibilityForColor(player.color, "optionPanel", false)
     return
+  end
+
+  -- hide the playAreaGallery / downloadWindow if visible
+  if windowId == "downloadWindow" then
+    changeWindowVisibilityForColor(player.color, "playAreaGallery", false)
+  elseif windowId == "playAreaGallery" then
+    changeWindowVisibilityForColor(player.color, "downloadWindow", false)
   elseif windowId == "blessCurseManager" then
     -- store the state of the Bless/Curse Manager UI to restore it onLoad()
     blurseVisibility[player.color] = changeWindowVisibilityForColor(player.color, "blessCurseManager")

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -15,6 +15,12 @@ local tokenSpawnTrackerApi        = require("tokens/TokenSpawnTrackerApi")
 -- general setup
 ---------------------------------------------------------
 
+local loadDebugOptionPanelState   = false
+local debugOptionPanelState       = {
+  showSearchAssistant = true,
+  showCleanUpHelper   = true
+}
+
 -- wait ids for various functions
 local waitIds                     = {}
 
@@ -234,6 +240,11 @@ function onLoad(savedData)
   Wait.time(function()
     WebRequest.get(SOURCE_REPO .. 'library.json', libraryDownloadCallback)
   end, 1)
+
+  -- load specific option panel state for debugging / developing
+  if loadDebugOptionPanelState then
+    Wait.frames(function() loadOptionPanelState(debugOptionPanelState) end, 90)
+  end
 end
 
 -- makes objects with the "NotInteractable" tag not interactable
@@ -2359,7 +2370,7 @@ end
 
 -- loads saved options
 ---@param newOptions table Contains the new state for the option panel
-function loadSettings(newOptions)
+function loadOptionPanelState(newOptions)
   for id, state in pairs(newOptions) do
     if optionPanel[id] ~= state then
       optionPanel[id] = state

--- a/src/core/GlobalApi.ttslua
+++ b/src/core/GlobalApi.ttslua
@@ -76,8 +76,8 @@ do
 
   -- loads saved options
   ---@param options table Set a new state for the option table
-  function GlobalApi.loadOptionPanelSettings(options)
-    Global.call("loadSettings", options)
+  function GlobalApi.loadOptionPanelState(options)
+    Global.call("loadOptionPanelState", options)
   end
 
   -- gets the current state of the option panel

--- a/xml/Global/BottomBar.xml
+++ b/xml/Global/BottomBar.xml
@@ -50,5 +50,5 @@
   <Button class="navbar"
     icon="option-gear"
     tooltip="Options"
-    onClick="onClick_toggleUi(optionPanel)"/>
+    onClick="onClick_toggleOptionPanel"/>
 </VerticalLayout>


### PR DESCRIPTION
In the Constants file there can now be a set of options specified to be loaded automatically.

Additionally, there can be preferred options included that a player can load by right-clicking the option panel button.