### PR TITLE
Scripted Gift of Nodens

### DIFF
--- a/objects/AllPlayerCards.15bb07/GiftofNodens5.tdc094.json
+++ b/objects/AllPlayerCards.15bb07/GiftofNodens5.tdc094.json
@@ -33,7 +33,7 @@
   "IgnoreFoW": false,
   "LayoutGroupSortIndex": 0,
   "Locked": false,
-  "LuaScript": "",
+  "LuaScript": "require(\"playercards/cards/GiftofNodens\")",
   "LuaScriptState": "",
   "MeasureMovement": false,
   "Name": "CardCustom",

--- a/src/playercards/cards/GiftofNodens.ttslua
+++ b/src/playercards/cards/GiftofNodens.ttslua
@@ -51,7 +51,7 @@ function pullCard(cardName)
 
       for i, card in ipairs(discardDeck.getObjects()) do
         if card.name == cardName then
-          discardDeck.takeObject({ guid = card.guid, position = self.getPosition() + Vector(0.5, 0.5, 0.5) })
+          discardDeck.takeObject({ guid = card.guid, position = self.getPosition() + Vector(0.5, 0.5, 0.5), smooth = false })
           break
         end
       end

--- a/src/playercards/cards/GiftofNodens.ttslua
+++ b/src/playercards/cards/GiftofNodens.ttslua
@@ -1,4 +1,3 @@
-require("playercards/CardsWithHelper")
 local playermatApi         = require("playermat/PlayermatApi")
 local survivorSkills = {}
 

--- a/src/playercards/cards/GiftofNodens.ttslua
+++ b/src/playercards/cards/GiftofNodens.ttslua
@@ -1,0 +1,74 @@
+require("playercards/CardsWithHelper")
+local playermatApi         = require("playermat/PlayermatApi")
+local survivorSkills = {}
+
+-- intentionally global
+hasXML                 = true
+isHelperEnabled        = false
+
+function onHover()
+  readDiscardPile()
+end
+
+function readDiscardPile()
+  local matColor = playermatApi.getMatColorByPosition(self.getPosition())
+  local deckAreaObjects = playermatApi.getDeckAreaObjects(matColor)
+  survivorSkills = {}
+
+  if deckAreaObjects.discard then
+    if deckAreaObjects.discard.type == 'Card' then
+      local discardCard = deckAreaObjects.discard
+      local metadata = JSON.decode(discardCard.getGMNotes()) or {}
+
+      if metadata.type == 'Skill' and metadata.class == 'Survivor' then
+        table.insert(survivorSkills, discardCard.getName())
+      end
+    elseif deckAreaObjects.discard.type == 'Deck' then
+      local discardDeck = deckAreaObjects.discard
+
+      for i, card in ipairs(discardDeck.getObjects()) do
+        local decodedGMNotes = JSON.decode(card.gm_notes) or {}
+
+        if decodedGMNotes.type == 'Skill' and decodedGMNotes.class == 'Survivor' then
+          table.insert(survivorSkills, card.name)
+        end
+      end
+    end
+  end
+
+  generateContextMenu()
+end
+
+function pullCard(cardName)
+  local matColor = playermatApi.getMatColorByPosition(self.getPosition())
+  local deckAreaObjects = playermatApi.getDeckAreaObjects(matColor)
+
+  if deckAreaObjects.discard then
+    if deckAreaObjects.discard.type == 'Card' then
+      local discardCard = deckAreaObjects.discard
+
+      if discardCard.getName() == cardName then
+        discardCard.setPositionSmooth(self.getPosition() + Vector(0.5, 0.5, 0.5), false, true)
+      end
+    elseif deckAreaObjects.discard.type == 'Deck' then
+      local discardDeck = deckAreaObjects.discard
+
+      for i, card in ipairs(discardDeck.getObjects()) do
+        if card.name == cardName then
+          discardDeck.takeObject({ guid = card.guid, position = self.getPosition() + Vector(0.5, 0.5, 0.5) })
+          break
+        end
+      end
+    end
+  end
+end
+
+function generateContextMenu()
+  self.clearContextMenu()
+
+  for i, cardName in pairs(survivorSkills) do
+    self.addContextMenuItem(cardName, function()
+      pullCard(cardName)
+    end)
+  end     
+end

--- a/src/playercards/cards/GiftofNodens.ttslua
+++ b/src/playercards/cards/GiftofNodens.ttslua
@@ -2,10 +2,6 @@ require("playercards/CardsWithHelper")
 local playermatApi         = require("playermat/PlayermatApi")
 local survivorSkills = {}
 
--- intentionally global
-hasXML                 = true
-isHelperEnabled        = false
-
 function onHover()
   readDiscardPile()
 end


### PR DESCRIPTION
Adds scripting to Gift of Nodens that will list all of the possible targets (survivor skills in the discard pile) in the context menu by name. Once a context menu item is clicked, that card is moved near Gift of Nodens.

![nodens](https://github.com/user-attachments/assets/8a7c163b-b98a-4680-ac5c-e32438f9ca52)

![image](https://github.com/user-attachments/assets/323434b2-8fa8-487b-ae6f-3ceb95478b34)
