### PR TITLE
Added doom spawning as replenish via hotkey

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -3226,8 +3226,10 @@ function TokenManager.replenishTokens(card, useInfo)
     end
   elseif useInfo.token == "doom" then
     for _, obj in ipairs(searchLib.onObject(card, "isDoom", 0.8)) do
-      foundTokens = foundTokens + math.abs(obj.getQuantity())
-      table.insert(maybeDeleteThese, obj)
+      if not obj.hasTag("DoomCounter_ignore") then
+        foundTokens = foundTokens + math.abs(obj.getQuantity())
+        table.insert(maybeDeleteThese, obj)
+      end
     end
   else
     -- search for the token instead if there's no special resource state for it
@@ -3389,6 +3391,9 @@ end
 
 function addTagToToken(obj, tag)
   obj.addTag(tag)
+  if tag == "DoomCounter_ignore" then
+    obj.highlightOn({ 0.67, 0.11, 0 })
+  end
 end
 
 function updateUniversalActionAbilityToken(obj, params)

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -3306,6 +3306,11 @@ function TokenManager.addUseToCard(params)
     end
   end
 
+  -- if there are no uses at all, add "empty" uses for fake replenishing on other cards for doom only
+  if params.useType == "doom" and metadata.uses == nil then
+    metadata.uses = { { token = "doom" } }
+  end
+
   local match = false
   for _, useInfo in ipairs(metadata.uses or {}) do
     if useInfo.token == useType then

--- a/src/tokens/TokenSpawnTool.ttslua
+++ b/src/tokens/TokenSpawnTool.ttslua
@@ -42,6 +42,10 @@ function onScriptingButtonDown(index, playerColor)
       local status = tokenManagerApi.addUseToCard(card, tokenType)
       if status == true then return end
     end
+  elseif tokenType == "doom" then
+    local card = getTargetCard(playerColor, position)
+    local status = tokenManagerApi.addUseToCard(card, tokenType)
+    if status == true then return end
 
     -- check hovered object for "resourceCounter" tokens and increase them instead
   elseif tokenType == "resourceCounter" then


### PR DESCRIPTION
Allows for neater organization of doom on cards. Press "7" over cards that do not have "uses" in their metadata or have "doom" in their metadata to perform the replenish ability.

Could allow for clickable counter or dynamic token in the future.

Tokens with "ignore doom" tag are left alone.

![image](https://github.com/user-attachments/assets/39537c9b-d89c-4c30-8684-290c76a59473)
