### PR TITLE
Kohaku helper

### DIFF
--- a/src/playercards/cards/KohakuNarukami.ttslua
+++ b/src/playercards/cards/KohakuNarukami.ttslua
@@ -106,11 +106,13 @@ function maybeUpdateButtonState()
 
   if numInBag.Bless <= numInBag.Curse and numInBag.Bless < 10 then
     state.Bless = true
-    state.ElderSign = true
   end
 
   if numInBag.Curse <= numInBag.Bless and numInBag.Curse < 10 then
     state.Curse = true
+  end
+
+  if numInBag.Bless < 10 or numInBag.Curse < 10 then
     state.ElderSign = true
   end
 

--- a/src/playercards/cards/KohakuNarukami.ttslua
+++ b/src/playercards/cards/KohakuNarukami.ttslua
@@ -4,6 +4,7 @@ local guidReferenceApi     = require("core/GUIDReferenceApi")
 local playermatApi         = require("playermat/PlayermatApi")
 local searchLib            = require("util/SearchLib")
 local tokenManagerApi      = require("tokens/TokenManagerApi")
+local zones                = require("playermat/Zones")
 
 -- intentionally global
 hasXML                     = true
@@ -144,4 +145,29 @@ function errorMessage(_, _, triggeringButton)
   else
     broadcastToAll("There are more Curse tokens than Bless tokens in the chaos bag.", "Red")
   end
+end
+
+-- get reaction token on investigator card
+function getReactionToken()
+  local reactionToken
+  local matColor = playermatApi.getMatColorByPosition(self.getPosition())
+  local pos = zones.getZonePosition(matColor, "Investigator")
+  local searchResult = searchLib.atPosition(pos, "isCardOrDeck")
+  if #searchResult == 1 then
+    local reaction = searchLib.onObject(searchResult[1], "isTileOrToken")
+    if #reaction == 1 then
+      if string.sub(reaction[1].getData().Nickname, -8, -1) == "Reaction" then
+        reactionToken = reaction[1]
+      end
+    end
+  end
+
+  return reactionToken
+end
+
+-- make reaction token face down
+function faceDownReactionToken()
+  local obj = getReactionToken()
+  if obj == nil then return end
+  if not obj.is_face_down then obj.flip() end
 end

--- a/src/playercards/cards/KohakuNarukami.ttslua
+++ b/src/playercards/cards/KohakuNarukami.ttslua
@@ -141,9 +141,9 @@ function errorMessage(_, _, triggeringButton)
   elseif numInBag.Bless == 10 and numInBag.Curse == 10 then
     broadcastToAll("No more tokens can be added to the chaos bag.", "Red")
   elseif numInBag.Bless < numInBag.Curse then
-    broadcastToAll("There are more Bless tokens than Curse tokens in the chaos bag.", "Red")
-  else
     broadcastToAll("There are more Curse tokens than Bless tokens in the chaos bag.", "Red")
+  else
+    broadcastToAll("There are more Bless tokens than Curse tokens in the chaos bag.", "Red")
   end
 end
 

--- a/src/playercards/cards/KohakuNarukami.ttslua
+++ b/src/playercards/cards/KohakuNarukami.ttslua
@@ -49,6 +49,7 @@ end
 function addTokenToBag(player, _, tokenType)
   if not updated then return end
   blessCurseManagerApi.addToken(tokenType, player.color)
+  faceDownReactionToken()
   updated = false
   Wait.frames(maybeUpdateButtonState, 2)
 end
@@ -59,6 +60,7 @@ function removeAndExtraAction(player)
   blessCurseManagerApi.removeToken("Bless", player.color)
   blessCurseManagerApi.removeToken("Curse", player.color)
   blessCurseManagerApi.removeToken("Curse", player.color)
+  faceDownReactionToken()
   updated = false
   Wait.frames(maybeUpdateButtonState, 2)
 
@@ -116,6 +118,15 @@ function maybeUpdateButtonState()
     state.Action = true
   end
 
+  local reactionToken = getReactionToken()
+  if reactionToken ~= nil then
+    if reactionToken.is_face_down then
+      state.Bless = false
+      state.Curse = false
+      state.Action = false
+    end
+  end
+
   setUiState(state)
   updated = true
 end
@@ -135,8 +146,14 @@ function setUiState(params)
 end
 
 function errorMessage(_, _, triggeringButton)
+  local reactionToken = getReactionToken()
+  local actionSpent = false
+  if reactionToken ~= nil then actionSpent = reactionToken.is_face_down end
+
   local numInBag = blessCurseManagerApi.getBlessCurseInBag()
-  if triggeringButton == "Action" then
+  if actionSpent and triggeringButton ~= "ElderSign" then
+    broadcastToAll("Ability already used.", "Red")
+  elseif triggeringButton == "Action" then
     broadcastToAll("There are not enough Blesses and/or Curses in the chaos bag.", "Red")
   elseif numInBag.Bless == 10 and numInBag.Curse == 10 then
     broadcastToAll("No more tokens can be added to the chaos bag.", "Red")


### PR DESCRIPTION
### Updates to Kohaku's Helper
- Flips reaction token on Investigator Card when Bless/Curse/Action buttons are pressed
- Adds "if reaction token is face down" to logic for enabling buttons
- Fixes reversed error messages for Bless/Curse already at 10 in bag
- Separates logic for enabling Elder Sign (available if _either_ Bless or Curse is < 10)