### PR TITLE
Set default values for deck importer variables

### DIFF
--- a/src/arkhamdb/DeckImporter.ttslua
+++ b/src/arkhamdb/DeckImporter.ttslua
@@ -68,13 +68,13 @@ end
 -- Sets up the UI for the deck loader, populating fields from the given save state table decoded from onLoad()
 function initializeUi(savedUiState)
   if savedUiState ~= nil then
-    redDeckId      = savedUiState.redDeck
-    orangeDeckId   = savedUiState.orangeDeck
-    whiteDeckId    = savedUiState.whiteDeck
-    greenDeckId    = savedUiState.greenDeck
-    privateDeck    = savedUiState.privateDeck
-    loadNewestDeck = savedUiState.loadNewest
-    standalone     = savedUiState.standalone
+    redDeckId      = savedUiState.redDeck or ""
+    orangeDeckId   = savedUiState.orangeDeck or ""
+    whiteDeckId    = savedUiState.whiteDeck or ""
+    greenDeckId    = savedUiState.greenDeck or ""
+    privateDeck    = savedUiState.privateDeck or false
+    loadNewestDeck = savedUiState.loadNewest or false
+    standalone     = savedUiState.standalone or false
   end
 
   makeOptionToggles()

--- a/src/arkhamdb/DeckImporterApi.ttslua
+++ b/src/arkhamdb/DeckImporterApi.ttslua
@@ -13,6 +13,7 @@ do
   ---@field greenDeck string Deck ID to load for the green player
   ---@field privateDeck boolean True to load a private deck, false to load a public deck
   ---@field loadNewest boolean True if the most upgraded version of the deck should be loaded
+  ---@field standalone boolean True if playing in standlone mode
   ---@field investigators boolean True if investigator cards should be spawned
 
   -- Returns a table with the full state of the UI, including options and deck IDs.


### PR DESCRIPTION
This fixes an issue with the standalone variable being nil when importing an older savegame