### PR TITLE
This change looks for the ModManager dictory in the directory above the

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
         "--modfile=${env:USERPROFILE}\\Documents\\My Games\\Tabletop Simulator\\Saves\\ArkhamSCE.json"
       ],
       "options": {
-        "cwd": "C:\\git\\TTSModManager"
+        "cwd": "${workspaceFolder}\\..\\TTSModManager"
       },
       "problemMatcher": [],
       "group": {


### PR DESCRIPTION
SCED repository directory.
Thus this should be a more universally compatible option.