### PR TITLE
Added table layout selection to option panel

### DIFF
--- a/objects/LuaScriptState.luascriptstate
+++ b/objects/LuaScriptState.luascriptstate
@@ -25,6 +25,7 @@
     "showHandHelper": false,
     "showSearchAssistant": false,
     "showTitleSplash": true,
+    "tableSetup": "Classic (4P)",
     "useClassTexture": true,
     "useClueClickers": false,
     "useResourceCounters": "disabled",

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -2538,15 +2538,18 @@ function updateTableSetup(newSetupName, oldSetupName)
   if not tableSetupData then return end
 
   function tableSetupCoro()
-    -- remove unnecessary playermats (do this first to avoid unwanted collisions / interactions)
     for _, matColor in ipairs(MAT_COLORS) do
-      if not tableSetupData.transforms["Playermat" .. matColor] then
+      if tableSetupData.transforms["Playermat" .. matColor] then
+        -- move existing mats upwards temporarily to avoid collisions
+        playermatApi.moveAndRotate(matColor, nil, nil, Vector(0, 2, 0))
+      else
+        -- remove unnecessary playermats (do this first to avoid unwanted collisions / interactions)
         removePlayermat(matColor)
-        coWaitFrames(3)
       end
+      coWaitFrames(1)
     end
 
-    -- move / spawn other playermats
+    -- actual movement of objects
     for _, matColor in ipairs(MAT_COLORS) do
       local transformData = tableSetupData.transforms["Playermat" .. matColor]
       if transformData then

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -26,7 +26,7 @@ local chaosTokensLastMatGUID      = nil
 -- chaos token stat tracking
 local tokenDrawingStats           = { ["Overall"] = {} }
 local lastDrawnTokens             = {}
-local autoFailMessages = {
+local AUTO_FAIL_MESSAGES          = {
   "<Name> has mastered the art of failure!",
   "The Auto-fail seems to have <Name>'s address.",
   "If there's an Auto-fail in the bag, <Name> will find it.",
@@ -48,8 +48,7 @@ local autoFailMessages = {
   "Auto-fails are like moths to <Name>'s flame.",
   "It's not bad luck—it’s a lifestyle for <Name>."
 }
-
-local elderSignMessages = {
+local ELDER_SIGN_MESSAGES         = {
   "<Name> is blessed by the elder gods!",
   "Luck flows through <Name>'s veins.",
   "<Name> is the chosen one!",
@@ -71,8 +70,7 @@ local elderSignMessages = {
   "<Name>'s touch turns chaos into triumph.",
   "Elder Signs follow <Name> like moths to a flame."
 }
-
-local dualMessages = {
+local DUAL_MESSAGES               = {
   "<Name> is the embodiment of extreme luck—both good and bad!",
   "No one has soared so high and fallen so hard as <Name>.",
   "Fate can’t decide what to do with <Name>—miracle one moment, disaster the next!",
@@ -95,7 +93,6 @@ local dualMessages = {
   "Legend will speak of <Name>’s ridiculous streak of fortune *and* disaster."
 }
 
-
 local bagSearchers                = {}
 local lastZoneEnterObject         = nil
 
@@ -105,7 +102,7 @@ local acknowledgedUpgradeVersions = {}
 local authorList                  = {}
 local contentToShow               = "campaign"
 local currentListItem             = 1
-local tabIdTable                  = {
+local TAB_IDS                     = {
   tab1 = "campaign",
   tab2 = "scenario",
   tab3 = "fanmade-campaign",
@@ -131,29 +128,79 @@ local RESOURCE_OPTIONS            = {
   "disabled"
 }
 
+-- data for preset table layouts
+local MAT_COLORS = { "White", "Orange", "Green", "Red" }
+local TABLE_SETUP_OPTIONS         = {
+  "Classic (4P)",
+  "Classic (2P)",
+  "Upright (4P)",
+  "Sides (4P)"
+}
+local TABLE_SETUP_DATA            = {
+  ["Classic (4P)"] = {
+    transforms = {
+      PlayermatWhite  = { position = Vector(-55.00, 1.45, 16.10),  rotation = Vector(0, 270, 0) },
+      PlayermatOrange = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
+      PlayermatGreen  = { position = Vector(-30.35, 1.45, 26.60),  rotation = Vector(0, 0, 0) },
+      PlayermatRed    = { position = Vector(-30.35, 1.45, -26.60), rotation = Vector(0, 180, 0) },
+      MythosArea      = { position = Vector(-1.31, 1.45, 0.00),    rotation = Vector(0, 270, 0) },
+      VictoryDisplay  = { position = Vector(-1.50, 1.45, 30.00),   rotation = Vector(0, 270, 0) }
+    }
+  },
+  ["Classic (2P)"] = {
+    transforms = {
+      PlayermatWhite  = { position = Vector(-55.00, 1.45, 16.10),  rotation = Vector(0, 270, 0) },
+      PlayermatOrange = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
+      MythosArea      = { position = Vector(-1.31, 1.45, 0.00),    rotation = Vector(0, 270, 0) },
+      VictoryDisplay  = { position = Vector(-1.50, 1.45, 30.00),   rotation = Vector(0, 270, 0) }
+    }
+  },
+  ["Upright (4P)"] = {
+    transforms = {
+      PlayermatWhite  = { position = Vector(-55.00, 1.45, 16.10),  rotation = Vector(0, 270, 0) },
+      PlayermatOrange = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
+      PlayermatGreen  = { position = Vector(-30.35, 1.45, 35.00),  rotation = Vector(0, 270, 0) },
+      PlayermatRed    = { position = Vector(-30.35, 1.45, -35.00), rotation = Vector(0, 270, 0) },
+      MythosArea      = { position = Vector(-1.31, 1.45, 0.00),    rotation = Vector(0, 270, 0) },
+      VictoryDisplay  = { position = Vector(-1.50, 1.45, 30.00),   rotation = Vector(0, 270, 0) }
+    }
+  },
+  ["Sides (4P)"] = {
+    transforms = {
+      PlayermatWhite  = { position = Vector(-40.00, 1.45, 35.00),  rotation = Vector(0, 270, 0) },
+      PlayermatOrange = { position = Vector(-40.00, 1.45, -35.00), rotation = Vector(0, 270, 0) },
+      PlayermatGreen  = { position = Vector(-17.50, 1.45, 35.00),  rotation = Vector(0, 270, 0) },
+      PlayermatRed    = { position = Vector(-17.50, 1.45, -35.00), rotation = Vector(0, 270, 0) },
+      MythosArea      = { position = Vector(-1.31, 1.45, 0.00),    rotation = Vector(0, 270, 0) },
+      VictoryDisplay  = { position = Vector(-1.50, 1.45, 30.00),   rotation = Vector(0, 270, 0) }
+    }
+  }
+}
+
+
 -- track player-specific visibilities
-local actionTrackerVisibility     = {}
-local blurseVisibility            = {}
-local handVisibility              = {}
+local actionTrackerVisibility = {}
+local blurseVisibility        = {}
+local handVisibility          = {}
 
 -- track cards' tokens
-local cardTokens                  = {}
-local cardSettings                = {}
+local cardTokens              = {}
+local cardSettings            = {}
 
 ---------------------------------------------------------
 -- data for tokens
 ---------------------------------------------------------
 
-TokenManager                      = {}
-local tokenOffsets                = {}
+TokenManager                  = {}
+local tokenOffsets            = {}
 
 -- Table of data extracted from the token source bag, keyed by the Memo on each token which
 -- should match the token type keys ("resource", "clue", etc)
 local tokenTemplates
 local playerCardData, locationData
 
--- stateIDs for the multi-stated resource tokens
-local stateTable                  = {
+-- state IDs for the multi-stated resource tokens
+local RESOURCE_STATES         = {
   ["resource"] = 1,
   ["ammo"]     = 2,
   ["bounty"]   = 3,
@@ -493,7 +540,12 @@ function onObjectDrop(playerColor, obj)
     -- spawn matching tokens after a delay
     waitIds["addToken" .. cardGuid] = Wait.time(function()
       if card ~= nil then
-        local result = TokenManager.addUseToCard({ card = card, useType = "resource", additionalCount = #dynamicTokensPerCard[card] })
+        local result = TokenManager.addUseToCard({
+          card = card,
+          useType = "resource",
+          additionalCount = #
+              dynamicTokensPerCard[card]
+        })
         for _, token in ipairs(dynamicTokensPerCard[card]) do
           if token ~= nil then
             if result == true then
@@ -808,7 +860,7 @@ function drawChaosToken(params)
 
     -- get data for token description
     local name = token.getName()
-        
+
     if name == "Bless" or name == "Curse" then
       local isLuckyPennyEnabled = params.mat.getVar("luckyPennyEnabled")
       if isLuckyPennyEnabled then
@@ -872,7 +924,7 @@ function luckyPenny(_, tokenGUID)
       type = 'Custom_Tile',
       position = pos,
       scale = { 0.5, 1.0, 0.5 },
-      rotation = { 0, 270, 0 },
+      rotation = Vector(0, 270, 0),
       callback_function = function(obj)
         blurseToken.UI.setXml("")
         blurseToken.addAttachment(obj)
@@ -1018,10 +1070,10 @@ function handleStatTrackerClick(player, clickType, _)
 
     -- print the player with the most auto-fails / elder signs
     if mostAutoFails == mostElderSigns then
-      outputRandomMessage(mostAutoFails, dualMessages, { r = 200 / 255, g = 100 / 255, b = 255 / 255 })
+      outputRandomMessage(mostAutoFails, DUAL_MESSAGES, { r = 200 / 255, g = 100 / 255, b = 255 / 255 })
     else
-      outputRandomMessage(mostAutoFails, autoFailMessages, { r = 215 / 255, g = 30 / 255, b = 60 / 255 })
-      outputRandomMessage(mostElderSigns, elderSignMessages, { r = 30 / 255, g = 185 / 255, b = 215 / 255 })
+      outputRandomMessage(mostAutoFails, AUTO_FAIL_MESSAGES, { r = 215 / 255, g = 30 / 255, b = 60 / 255 })
+      outputRandomMessage(mostElderSigns, ELDER_SIGN_MESSAGES, { r = 30 / 255, g = 185 / 255, b = 215 / 255 })
     end
   else
     printToAll("No tokens have been drawn yet.", "Yellow")
@@ -1255,7 +1307,7 @@ function spawnChaosToken(id)
       type = 'Custom_Tile',
       position = { 0.49, 3, 0 },
       scale = { 0.81, 1.0, 0.81 },
-      rotation = { 0, 270, 0 },
+      rotation = Vector(0, 270, 0),
       callback_function = function(obj)
         obj.setName(ID_URL_MAP[id].name)
         chaosBag.putObject(obj)
@@ -1361,7 +1413,7 @@ end
 -- forwards the requested content type to the update function and sets highlight to clicked tab
 ---@param tabId string Id of the clicked tab
 function onClick_tab(_, _, tabId)
-  for listId, listContent in pairs(tabIdTable) do
+  for listId, listContent in pairs(TAB_IDS) do
     if listId == tabId then
       UI.setClass(listId, 'downloadTab activeTab')
       contentToShow = listContent
@@ -1556,7 +1608,7 @@ function onClick_spawnPlaceholder(player)
   local placeholder = spawnObject({
     type = "Custom_Model",
     position = spawnPos,
-    rotation = { 0, 270, 0 },
+    rotation = Vector(0, 270, 0),
     scale = scaleTable[item.boxsize],
   })
 
@@ -1617,7 +1669,7 @@ function onClick_toggleOptionPanel(player, clickType)
     end
 
     player.showOptionsDialog("Choose an option preset", presetNames, 1,
-      function (presetName)
+      function(presetName)
         loadOptionPanelState(OPTION_PRESETS[presetName])
         printToAll("Loaded option preset: " .. presetName, "Green")
       end)
@@ -2036,13 +2088,13 @@ function determineActionCount(matColor)
   local playermat = guidReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
   if not playermat then return end
 
-  local localPos     = Vector(-1.2, 0.1, -0.28)
-  local pos          = playermatApi.transformLocalPosition(localPos, matColor):setAt("y", 3)
-  local rot          = playermatApi.returnRotation(matColor)
-  local size         = Vector(5, 6, 0.1)
-  local searchResult = searchLib.inArea(pos, rot, size, "isUniversalToken")
+  local localPos       = Vector(-1.2, 0.1, -0.28)
+  local pos            = playermatApi.transformLocalPosition(localPos, matColor):setAt("y", 3)
+  local rot            = playermatApi.returnRotation(matColor)
+  local size           = Vector(5, 6, 0.1)
+  local searchResult   = searchLib.inArea(pos, rot, size, "isUniversalToken")
 
-  local actionCount  = {
+  local actionCount    = {
     available = 0,
     used      = 0,
     total     = #searchResult,
@@ -2145,7 +2197,7 @@ function contentDownloadCallback(request, params)
     end
 
     spawnTable.position = pos
-    spawnTable.rotation = { 0, 270, 0 }
+    spawnTable.rotation = Vector(0, 270, 0)
   end
 
   spawnTable["callback_function"] = function(obj)
@@ -2289,8 +2341,7 @@ end
 function playermatRemovalSelected(player, selectedIndex, id)
   if selectedIndex == "0" then return end
 
-  local matColorList = { "White", "Orange", "Green", "Red" }
-  local matColor = matColorList[tonumber(selectedIndex)]
+  local matColor = MAT_COLORS[tonumber(selectedIndex)]
   local mat = guidReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
 
   if mat then
@@ -2302,7 +2353,7 @@ function playermatRemovalSelected(player, selectedIndex, id)
       function() removePlayermat(matColor) end)
   else
     player.showConfirmDialog("Do you want to respawn " .. matColor .. "'s playermat and related objects?",
-    function() spawnPlayermat(matColor) end)
+      function() spawnPlayermat(matColor) end)
   end
 
   -- set selected value back to first option
@@ -2321,11 +2372,15 @@ function removePlayermat(matColor)
   local matObjects = guidReferenceApi.getObjectsByOwner(matColor)
   if not matObjects.Playermat then return end
 
-  -- remove action tokens
-  local actionTokens = playermatApi.searchAroundPlayermat(matColor, "isUniversalToken")
-  for _, obj in ipairs(actionTokens) do
-    obj.destruct()
-  end
+  -- remove objects on mat
+  local objectsToRemove = playermatApi.searchAroundPlayermat(matColor, "isInteractable")
+  Wait.frames(function()
+    for _, obj in ipairs(objectsToRemove) do
+      if obj ~= nil and not obj.hasTag("CleanUpHelper_ignore") then
+        obj.destruct()
+      end
+    end
+  end, 10)
 
   -- remove mat owned objects
   for _, obj in pairs(matObjects) do
@@ -2339,7 +2394,7 @@ function removePlayermat(matColor)
   updateActionTrackerRows()
 end
 
-function spawnPlayermat(matColor)
+function spawnPlayermat(matColor, transformData)
   local sourceBag = guidReferenceApi.getObjectByOwnerAndType("Mythos", "ObjectSourceBag")
 
   -- error handling for missing sourceBag
@@ -2349,16 +2404,16 @@ function spawnPlayermat(matColor)
   end
 
   local defaultPosition = {
-    White  = Vector( -55, 1.45, 16.1 ),
-    Orange = Vector( -55, 1.45, -16.1 ),
-    Green  = Vector( -30.35, 1.45, 26.6 ),
-    Red    = Vector( -30.35, 1.45, -26.6 )
+    White  = Vector(-55, 1.45, 16.1),
+    Orange = Vector(-55, 1.45, -16.1),
+    Green  = Vector(-30.35, 1.45, 26.6),
+    Red    = Vector(-30.35, 1.45, -26.6)
   }
   local defaultRotation = {
-    White  = Vector( 0, 270, 0 ),
-    Orange = Vector( 0, 270, 0 ),
-    Green  = Vector( 0, 0, 0 ),
-    Red    = Vector( 0, 180, 0 )
+    White  = Vector(0, 270, 0),
+    Orange = Vector(0, 270, 0),
+    Green  = Vector(0, 0, 0),
+    Red    = Vector(0, 180, 0)
   }
   local indexNames = {
     ["Clues"]     = "ClickableClueCounter",
@@ -2380,7 +2435,11 @@ function spawnPlayermat(matColor)
     end
 
     -- handle mat spawning first
-    updateTransformData(spawnData.Playermat, defaultPosition[matColor], defaultRotation[matColor])
+    if transformData then
+      updateTransformData(spawnData.Playermat, transformData.position, transformData.rotation)
+    else
+      updateTransformData(spawnData.Playermat, defaultPosition[matColor], defaultRotation[matColor])
+    end
 
     -- update color data of mat
     spawnData.Playermat.Memo = matColor
@@ -2390,7 +2449,7 @@ function spawnPlayermat(matColor)
 
     -- spawn the mat
     local playermat = spawnObjectData({ data = spawnData.Playermat })
-    coWaitFrames(10)
+    coWaitFrames(5)
     guidReferenceApi.editIndex(matColor, "Playermat", playermat.getGUID())
 
     -- spawn objects
@@ -2399,7 +2458,12 @@ function spawnPlayermat(matColor)
         local localPos = zones.getLocalZoneData(matColor, name)
         if localPos then
           local pos = playermat.positionToWorld(localPos)
-          local rot = defaultRotation[matColor]:copy()
+          local rot
+          if transformData then
+            rot = transformData.rotation:copy()
+          else
+            rot = defaultRotation[matColor]:copy()
+          end
 
           if name == "Hand" then
             rot = rot + Vector(0, 180, 0)
@@ -2411,23 +2475,25 @@ function spawnPlayermat(matColor)
 
           updateTransformData(objData, pos, rot)
           local obj = spawnObjectData({ data = objData })
-          coWaitFrames(3)
 
-          -- update index
-          local indexName = string.gsub(name, " ", "")
-          guidReferenceApi.editIndex(matColor, indexName or indexNames[indexName], obj.getGUID())
+          Wait.frames(function()
+            -- update index
+            local indexName = string.gsub(name, " ", "")
+            guidReferenceApi.editIndex(matColor, indexName or indexNames[indexName], obj.getGUID())
+          end, 3)
         end
       end
     end
 
     -- also spawn any helpers that are already enabled (hardcoded list atm)
-    for _, helperName in ipairs({ "Hand Helper", "Search Assistant "}) do
+    for _, helperName in ipairs({ "Hand Helper", "Search Assistant " }) do
       if optionPanel["show" .. string.gsub(helperName, " ", "")] then
         local data = playermatApi.getHelperSpawnData(matColor, helperName)
         spawnOrRemoveHelper(state, helperName, data.position, data.rotation, matColor)
-        coWaitFrames(3)
       end
     end
+
+    coWaitFrames(5)
 
     -- ensure playermat has correct references
     playermat.call("getOwnedObjects")
@@ -2436,6 +2502,7 @@ function spawnPlayermat(matColor)
     updateActionTrackerRows()
     return 1
   end
+
   startLuaCoroutine(Global, "spawnCoro")
 end
 
@@ -2448,6 +2515,57 @@ function updateTransformData(data, position, rotation)
   data.Transform.rotZ = rotation.z
 end
 
+-- called by the table setup selection dropdown
+function tableSetupSelected(_, selectedIndex, id)
+  local selectedValue = TABLE_SETUP_OPTIONS[tonumber(selectedIndex) + 1]
+  updateTableSetup(selectedValue, optionPanel[id])
+  optionPanel[id] = selectedValue
+end
+
+-- returns the ID for the provided option name
+function returnTableSetupId(name)
+  for index, optionName in ipairs(TABLE_SETUP_OPTIONS) do
+    if optionName == name then
+      return index
+    end
+  end
+end
+
+function updateTableSetup(newSetupName, oldSetupName)
+  if newSetupName == oldSetupName then return end
+
+  local tableSetupData = TABLE_SETUP_DATA[newSetupName]
+  if not tableSetupData then return end
+
+  function tableSetupCoro()
+    -- remove unnecessary playermats (do this first to avoid unwanted collisions / interactions)
+    for _, matColor in ipairs(MAT_COLORS) do
+      if not tableSetupData.transforms["Playermat" .. matColor] then
+        removePlayermat(matColor)
+        coWaitFrames(3)
+      end
+    end
+
+    -- move / spawn other playermats
+    for _, matColor in ipairs(MAT_COLORS) do
+      local transformData = tableSetupData.transforms["Playermat" .. matColor]
+      if transformData then
+        local playermat = guidReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
+        if playermat then
+          playermatApi.moveAndRotate(matColor, transformData.position, transformData.rotation.y)
+        else
+          spawnPlayermat(matColor, transformData)
+        end
+        coWaitFrames(5)
+      end
+    end
+
+    return 1
+  end
+
+  startLuaCoroutine(Global, "tableSetupCoro")
+end
+
 -- sets the option panel to the correct state (corresponding to 'optionPanel')
 function updateOptionPanelState()
   for id, optionValue in pairs(optionPanel) do
@@ -2456,6 +2574,9 @@ function updateOptionPanelState()
       UI.setAttribute(id, "value", dropdownId)
     elseif id == "useResourceCounters" and type(optionValue) == "string" then
       local dropdownId = returnResourceCounterId(optionValue) - 1
+      UI.setAttribute(id, "value", dropdownId)
+    elseif id == "tableSetup" and type(optionValue) == "string" then
+      local dropdownId = returnTableSetupId(optionValue) - 1
       UI.setAttribute(id, "value", dropdownId)
     elseif id == "playAreaConnectionColor" then
       UI.setAttribute(id, "color", "#" .. Color.new(optionValue):toHex())
@@ -2658,6 +2779,7 @@ function onClick_defaultSettings()
     showOneDamageHorror       = false,
     showSearchAssistant       = false,
     showTitleSplash           = true,
+    tableSetup                = "Classic (4P)",
     useClassTexture           = true,
     useClueClickers           = false,
     useResourceCounters       = "disabled",
@@ -3034,7 +3156,7 @@ function TokenManager.spawnMultipleTokens(card, tokenType, tokenCount, shiftDown
   end
 
   -- if a special resource exists, spawn it directly
-  if stateTable[string.lower(subType or "")] then
+  if RESOURCE_STATES[string.lower(subType or "")] then
     tokenType = string.lower(subType)
   end
 
@@ -3169,7 +3291,7 @@ function TokenManager.initTokenTemplates()
 
   if tokenTemplates["resource"] ~= nil then
     -- add templates for the resource token states
-    for subType, subTypeStateId in pairs(stateTable) do
+    for subType, subTypeStateId in pairs(RESOURCE_STATES) do
       if subTypeStateId ~= 1 then
         tokenTemplates[subType] = TokenManager.getTemplateForState(subTypeStateId)
       end
@@ -3364,7 +3486,7 @@ function TokenManager.replenishTokens(card, useInfo)
   else
     -- search for the token instead if there's no special resource state for it
     local searchType = string.lower(useInfo.type)
-    if stateTable[searchType] == nil then
+    if RESOURCE_STATES[searchType] == nil then
       searchType = useInfo.token
     end
 

--- a/src/playermat/PlayermatApi.ttslua
+++ b/src/playermat/PlayermatApi.ttslua
@@ -375,46 +375,42 @@ do
   PlayermatApi.moveAndRotate = function(matColor, position, rotationY)
     -- get mat and related objects
     local mat = guidReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
-    local matObjects = guidReferenceApi.getObjectsByOwner(matColor)
-
     if not mat then return end
 
     -- use current value if undefined
+    local currentMatPos = mat.getPosition()
+    local currentMatRotY = mat.getRotation().y
     position = position or mat.getPosition()
     rotationY = rotationY or mat.getRotation().y
 
-    -- store relative positions
-    local storedPositions = {}
-    for _, obj in pairs(matObjects) do
-      if obj ~= mat then
-        storedPositions[obj.getGUID()] = mat.positionToLocal(obj.getPosition())
+    local movedObjects = {}
+    local function moveAndRotateObject(obj)
+      local relativePos = obj.getPosition() - currentMatPos
+      obj.setPosition(position + relativePos:rotateOver("y", rotationY - currentMatRotY))
+
+      local objRot = obj.getRotation()
+      local relativeRotY = objRot.y - currentMatRotY
+      obj.setRotation({ objRot.x, rotationY + relativeRotY, objRot.z })
+
+      movedObjects[obj.getGUID()] = true
+    end
+
+    -- get objects on the mat
+    for _, obj in ipairs(searchLib.onObject(mat, "isInteractable")) do
+      if not movedObjects[obj.getGUID()] then
+        -- make sure object isn't owned by another mat
+        local owner = guidReferenceApi.getOwnerOfObject(obj)
+        if owner == "Mythos" or owner == matColor then
+          moveAndRotateObject(obj)
+        end
       end
     end
 
-    -- also get objects on the mat
-    local objectsOnMat = searchLib.onObject(mat)
-    for _, obj in ipairs(objectsOnMat) do
-      if obj ~= mat and storedPositions[obj.getGUID()] == nil and obj.interactable ~= false then
-        storedPositions[obj.getGUID()] = mat.positionToLocal(obj.getPosition())
+    -- move owned objects (including the mat)
+    for _, obj in pairs(guidReferenceApi.getObjectsByOwner(matColor)) do
+      if not movedObjects[obj.getGUID()] then
+        moveAndRotateObject(obj)
       end
-    end
-
-    -- move main mat
-    mat.setPosition(position)
-    mat.setRotation({ 0, rotationY, 0 })
-
-    -- set new position + rotation (preserve object X / Z rotation)
-    for guid, pos in pairs(storedPositions) do
-      local obj = getObjectFromGUID(guid)
-      obj.setPosition(mat.positionToWorld(pos))
-
-      -- offset the rotation by 180 degrees if the guid matches the player hand zones
-      local finalRotationY = rotationY
-      if obj.type == "Hand" then
-        finalRotationY = rotationY + 180
-      end
-
-      obj.setRotation(obj.getRotation():setAt("y", finalRotationY))
     end
   end
 

--- a/src/playermat/PlayermatApi.ttslua
+++ b/src/playermat/PlayermatApi.ttslua
@@ -370,9 +370,10 @@ do
 
   -- moves + rotates a playermat (and related objects)
   ---@param matColor string Color of the playermat - White, Orange, Green, Red or All
-  ---@param position table New position for the playermat
-  ---@param rotationY number New y-rotation for the playermat (X and Z will be 0)
-  PlayermatApi.moveAndRotate = function(matColor, position, rotationY)
+  ---@param position? table New position for the playermat
+  ---@param rotationY? number New y-rotation for the playermat (X and Z will be 0)
+  ---@param positionOffset? table Positional offset for the playermat
+  PlayermatApi.moveAndRotate = function(matColor, position, rotationY, positionOffset)
     -- get mat and related objects
     local mat = guidReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
     if not mat then return end
@@ -382,6 +383,10 @@ do
     local currentMatRotY = mat.getRotation().y
     position = position or mat.getPosition()
     rotationY = rotationY or mat.getRotation().y
+
+    if positionOffset then
+      position = Vector(position) + Vector(positionOffset)
+    end
 
     local movedObjects = {}
     local function moveAndRotateObject(obj)

--- a/xml/Global/OptionPanel.xml
+++ b/xml/Global/OptionPanel.xml
@@ -381,6 +381,27 @@
             </Cell>
           </Row>
 
+          <!-- Option: choose a table setup -->
+          <Row class="option-text"
+            tooltip="Choose a predetermined table layout.">
+            <Cell class="option-singleColumn">
+              <Panel class="singleColumn-wrapper">
+                <Text class="option-header">Choose a table layout</Text>
+              </Panel>
+            </Cell>
+            <Cell class="option-doubleColumn">
+              <Panel class="doubleColumn-wrapper">
+                <Dropdown id="tableSetup"
+                  onValueChanged="tableSetupSelected(selectedIndex)">
+                  <Option>Classic (4P)</Option>
+                  <Option>Classic (2P)</Option>
+                  <Option>Upright (4P)</Option>
+                  <Option>Sides (4P)</Option>
+                </Dropdown>
+              </Panel>
+            </Cell>
+          </Row>
+
           <!-- Group: accessories -->
           <Row class="group-header">
             <Cell class="group-header">


### PR DESCRIPTION
This comes with 4 layouts for now:
  - "Classic (4P)" - the status quo
  - "Classic (2P)" - same as above but without Green / Red
  - "Upright (4P)" - Classic, but rotated in place
  - "Sides (4P)" - Rotated mats and moved to the sides of the playarea
  
  There's no change to the rest of the table to account for the necessary horizontal space yet (that will be a separate PR).