### PR TITLE
Updated horizontal space between spawn positions for downloaded content

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -2242,7 +2242,7 @@ end
 function getValidSpawnPosition()
   local potentialSpawnPositionX = { 63, 48, 33 }
   local potentialSpawnPositionY = 1.5
-  local potentialSpawnPositionZ = { 32, 24, 16, 8, -8, -16, -24, -32 }
+  local potentialSpawnPositionZ = { 32, 16, 0, -16, -32 }
 
   for _, posX in ipairs(potentialSpawnPositionX) do
     for _, posZ in ipairs(potentialSpawnPositionZ) do


### PR DESCRIPTION
This way large campaign boxes don't overlap