### PR TITLE
Added spawn location for Prophecy of the End

### DIFF
--- a/objects/AllPlayerCards.15bb07/TheStarsAreRight.600a3c.json
+++ b/objects/AllPlayerCards.15bb07/TheStarsAreRight.600a3c.json
@@ -42,7 +42,7 @@
   "Snap": true,
   "Sticky": true,
   "Tags": [
-    "PlayerCard"
+    "ScenarioCard"
   ],
   "Tooltip": true,
   "Transform": {

--- a/src/arkhamdb/DeckImporter.ttslua
+++ b/src/arkhamdb/DeckImporter.ttslua
@@ -227,8 +227,8 @@ function getDefaultCardZone(cardMetadata, bondedList)
     -- Have to check the Servitor before other minicards
     return "SetAside5"
   elseif cardMetadata.id == "09006" or cardMetadata.id == "06233" or cardMetadata.id == "06275"
-      or cardMetadata.id == "71052" or bondedList[cardMetadata.id] then
-    -- On The Mend, False Awakening, Jewel of Sarnath and bonded cards are set aside
+      or cardMetadata.id == "71052" or cardMetadata.id == "11016" or bondedList[cardMetadata.id] then
+    -- On The Mend, False Awakening, Jewel of Sarnath, Prophecy of the End, and bonded cards are set aside
     return "SetAside2"
   elseif cardMetadata.id == "07303" then
     -- Ancestral Knowledge


### PR DESCRIPTION
Now in set-aside cards, like Jewel of Sarnath (which also goes into the encounter deck).

Also changed The Stars Are Right to be a Scenario Card (discard hotkey caused it to go to the wrong pile)