### PR TITLE
Updated encounter card bag

### DIFF
--- a/src/mythos/AllEncounterCardsBag.ttslua
+++ b/src/mythos/AllEncounterCardsBag.ttslua
@@ -12,6 +12,7 @@ end
 
 function rebuildIndex()
   if indexingDone then
+    print("Building Encounter Card index")
     startIndexBuild()
   end
 end
@@ -23,8 +24,8 @@ function startIndexBuild()
 end
 
 function buildIndex()
-  print("Building Encounter Card index")
   cardCount = 0
+  indexCount = 0
   indexingDone = false
   processContainedObjects(self.getData().ContainedObjects)
   indexingDone = true
@@ -92,6 +93,7 @@ function addCardToIndex(cardData)
       cardIdIndex[cardId] = { data = cardData, metadata = { id = cardId } }
     end
   end
+  indexCount = indexCount + 1
 end
 
 function isIndexReady()
@@ -126,6 +128,7 @@ end
 
 -- attempt to replace cards / decks
 function onObjectSpawn(obj)
+  if indexCount == 0 then return end
   if obj.hasTag("Replaced") then return end
 
   if obj.type == "Card" then
@@ -159,8 +162,6 @@ function handleSpawnedCard(obj)
 end
 
 function handleSpawnedDeck(deck)
-  if deck.hasTag("Replaced") then return end
-
   Wait.time(function()
     if deck ~= nil then
       deck.addTag("Replaced")


### PR DESCRIPTION
- only print a message when rebuilding, not on initial load
- only loop through spawned objects when there is at least something indexed