### PR TITLE
Bugfix for wrong index names for respawned mats

### DIFF
--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -2418,12 +2418,16 @@ function spawnPlayermat(matColor, transformData)
     Green  = Vector(0, 0, 0),
     Red    = Vector(0, 180, 0)
   }
+
+  -- this mapping of object names to index names is really important!
   local indexNames = {
-    ["Clues"]     = "ClickableClueCounter",
-    ["Damage"]    = "DamageCounter",
-    ["Horror"]    = "HorrorCounter",
-    ["Resources"] = "ResourceCounter"
+    ["Clues"]        = "ClickableClueCounter",
+    ["Clue Counter"] = "ClueCounter",
+    ["Damage"]       = "DamageCounter",
+    ["Horror"]       = "HorrorCounter",
+    ["Resources"]    = "ResourceCounter"
   }
+
   function spawnCoro()
     -- collect spawndata
     local spawnData = {}
@@ -2470,6 +2474,7 @@ function spawnPlayermat(matColor, transformData)
 
           if name == "HandZone" then
             rot = rot + Vector(0, 180, 0)
+            objData.FogColor = matColor
           elseif name == "Damage" or name == "Horror" then
             rot = rot + Vector(0, 10, 180)
           elseif name == "Clues" or name == "Clue Counter" or name == "Resources" then
@@ -2482,7 +2487,7 @@ function spawnPlayermat(matColor, transformData)
           Wait.frames(function()
             -- update index
             local indexName = string.gsub(name, " ", "")
-            guidReferenceApi.editIndex(matColor, indexName or indexNames[indexName], obj.getGUID())
+            guidReferenceApi.editIndex(matColor, indexNames[indexName] or indexName, obj.getGUID())
           end, 3)
         end
       end


### PR DESCRIPTION
Without this, the object references have the wrong names

Closes https://github.com/argonui/SCED/issues/1180
Closes https://github.com/argonui/SCED/issues/1181