### PR TITLE
Updated Table Layouts with handling for the shared bag area

### DIFF
--- a/src/core/GUIDReferenceApi.ttslua
+++ b/src/core/GUIDReferenceApi.ttslua
@@ -46,5 +46,15 @@ do
     return getGuidHandler().call("getOwnerOfObject", object)
   end
 
+  -- Remove object
+  ---@param owner string Parent of the object
+  ---@param type string Type of the object
+  GUIDReferenceApi.removeObjectByOwnerAndType = function(owner, type)
+    return getGuidHandler().call("removeObjectByOwnerAndType", {
+      owner = owner,
+      type = type
+    })
+  end
+
   return GUIDReferenceApi
 end

--- a/src/core/GUIDReferenceHandler.ttslua
+++ b/src/core/GUIDReferenceHandler.ttslua
@@ -225,3 +225,9 @@ function getOwnerOfObject(object)
   -- default to "Mythos"
   return "Mythos"
 end
+
+function removeObjectByOwnerAndType(params)
+  local obj = getObjectByOwnerAndType(params)
+  if obj ~= nil then obj.destruct() end
+  editIndex(params)
+end

--- a/src/core/Global.ttslua
+++ b/src/core/Global.ttslua
@@ -139,34 +139,20 @@ local TABLE_SETUP_OPTIONS         = {
 local TABLE_SETUP_DATA            = {
   ["Classic (4P)"] = {
     transforms = {
-      PlayermatWhite   = { position = Vector(-55.00, 1.45, 16.10), rotation = Vector(0, 270, 0) },
-      PlayermatOrange  = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
-      PlayermatGreen   = { position = Vector(-30.35, 1.45, 26.60), rotation = Vector(0, 0, 0) },
-      PlayermatRed     = { position = Vector(-30.35, 1.45, -26.60), rotation = Vector(0, 180, 0) },
-      MythosArea       = { position = Vector(-1.31, 1.45, 0.00), rotation = Vector(0, 270, 0) },
-      VictoryDisplay   = { position = Vector(-1.50, 1.45, 30.00), rotation = Vector(0, 270, 0) },
-      ClueTokenBag     = { position = Vector(-55.48, 1.58, -1.12), rotation = Vector(0, 270, 0) },
-      DynamicTokenBag  = { position = Vector(-51.00, 1.58, 1.12), rotation = Vector(0, 270, 0) },
-      DamageTokenBag   = { position = Vector(-53.24, 1.58, 1.12), rotation = Vector(0, 270, 0) },
-      DoomTokenBag     = { position = Vector(-55.48, 1.58, 1.12), rotation = Vector(0, 270, 0) },
-      HorrorTokenBag   = { position = Vector(-53.24, 1.58, -1.12), rotation = Vector(0, 270, 0) },
-      ResourceTokenBag = { position = Vector(-51.00, 1.58, -1.12), rotation = Vector(0, 270, 0) },
-      TokenRemover     = { position = Vector(-58.50, 1.48, 0.00), rotation = Vector(0, 270, 0) }
+      PlayermatWhite  = { position = Vector(-55.00, 1.45, 16.10), rotation = Vector(0, 270, 0) },
+      PlayermatOrange = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
+      PlayermatGreen  = { position = Vector(-30.35, 1.45, 26.60), rotation = Vector(0, 0, 0) },
+      PlayermatRed    = { position = Vector(-30.35, 1.45, -26.60), rotation = Vector(0, 180, 0) },
+      MythosArea      = { position = Vector(-1.31, 1.45, 0.00), rotation = Vector(0, 270, 0) },
+      VictoryDisplay  = { position = Vector(-1.50, 1.45, 30.00), rotation = Vector(0, 270, 0) }
     }
   },
   ["Classic (2P)"] = {
     transforms = {
-      PlayermatWhite   = { position = Vector(-55.00, 1.45, 16.10), rotation = Vector(0, 270, 0) },
-      PlayermatOrange  = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
-      MythosArea       = { position = Vector(-1.31, 1.45, 0.00), rotation = Vector(0, 270, 0) },
-      VictoryDisplay   = { position = Vector(-1.50, 1.45, 30.00), rotation = Vector(0, 270, 0) },
-      ClueTokenBag     = { position = Vector(-55.48, 1.58, -1.12), rotation = Vector(0, 270, 0) },
-      DynamicTokenBag  = { position = Vector(-51.00, 1.58, 1.12), rotation = Vector(0, 270, 0) },
-      DamageTokenBag   = { position = Vector(-53.24, 1.58, 1.12), rotation = Vector(0, 270, 0) },
-      DoomTokenBag     = { position = Vector(-55.48, 1.58, 1.12), rotation = Vector(0, 270, 0) },
-      HorrorTokenBag   = { position = Vector(-53.24, 1.58, -1.12), rotation = Vector(0, 270, 0) },
-      ResourceTokenBag = { position = Vector(-51.00, 1.58, -1.12), rotation = Vector(0, 270, 0) },
-      TokenRemover     = { position = Vector(-58.50, 1.48, 0.00), rotation = Vector(0, 270, 0) }
+      PlayermatWhite  = { position = Vector(-55.00, 1.45, 16.10), rotation = Vector(0, 270, 0) },
+      PlayermatOrange = { position = Vector(-55.00, 1.45, -16.10), rotation = Vector(0, 270, 0) },
+      MythosArea      = { position = Vector(-1.31, 1.45, 0.00), rotation = Vector(0, 270, 0) },
+      VictoryDisplay  = { position = Vector(-1.50, 1.45, 30.00), rotation = Vector(0, 270, 0) }
     }
   },
   ["Upright (4P)"] = {
@@ -191,47 +177,65 @@ local TABLE_SETUP_DATA            = {
   }
 }
 
--- skip these objects for white / orange (because of the combined bag area)
-local combinedBagAreaNames = {
-  ["Clue tokens"]     = true,
-  ["Damage tokens"]   = true,
-  ["Doom tokens"]     = true,
-  ["Dynamic tokens"]  = true,
-  ["Horror tokens"]   = true,
-  ["Resource tokens"] = true,
-  ["Token Remover"]   = true
+local SHARED_BAGS_DATA            = {
+  -- skip these objects for white / orange (because of the combined bag area)
+  objects = {
+    ["Clue tokens"]     = true,
+    ["Damage tokens"]   = true,
+    ["Doom tokens"]     = true,
+    ["Dynamic tokens"]  = true,
+    ["Horror tokens"]   = true,
+    ["Resource tokens"] = true,
+    ["Token Remover"]   = true
+  },
+  -- setups that have a shared bag area
+  setups = {
+    ["Classic (4P)"] = true,
+    ["Classic (2P)"] = true,
+    ["Upright (4P)"] = true
+  },
+  -- transform data for these shared bag areas
+  transforms = {
+    ClueTokenBag     = { position = Vector(-55.48, 1.58, -1.12), rotation = Vector(0, 270, 0) },
+    DynamicTokenBag  = { position = Vector(-51.00, 1.58, 1.12), rotation = Vector(0, 270, 0) },
+    DamageTokenBag   = { position = Vector(-53.24, 1.58, 1.12), rotation = Vector(0, 270, 0) },
+    DoomTokenBag     = { position = Vector(-55.48, 1.58, 1.12), rotation = Vector(0, 270, 0) },
+    HorrorTokenBag   = { position = Vector(-53.24, 1.58, -1.12), rotation = Vector(0, 270, 0) },
+    ResourceTokenBag = { position = Vector(-51.00, 1.58, -1.12), rotation = Vector(0, 270, 0) },
+    TokenRemover     = { position = Vector(-58.50, 1.48, 0.00), rotation = Vector(0, 270, 0) }
+  }
 }
-
-local setupsWithCombinedBagArea = {
-  ["Classic (4P)"] = true,
-  ["Classic (2P)"] = true,
-  ["Upright (4P)"] = true
-}
-
 -- this mapping of object names to index names is really important!
-local indexNames = {
-  ["Clues"]        = "ClickableClueCounter",
-  ["Clue Counter"] = "ClueCounter",
-  ["Damage"]       = "DamageCounter",
-  ["Horror"]       = "HorrorCounter",
-  ["Resources"]    = "ResourceCounter"
+local GUID_INDEX_MAP              = {
+  ["Clues"]           = "ClickableClueCounter",
+  ["Clue Counter"]    = "ClueCounter",
+  ["Damage"]          = "DamageCounter",
+  ["Horror"]          = "HorrorCounter",
+  ["Resources"]       = "ResourceCounter",
+  ["Clue tokens"]     = "ClueTokenBag",
+  ["Damage tokens"]   = "DamageTokenBag",
+  ["Doom tokens"]     = "DoomTokenBag",
+  ["Dynamic tokens"]  = "DynamicTokenBag",
+  ["Horror tokens"]   = "HorrorTokenBag",
+  ["Resource tokens"] = "ResourceTokenBag",
+  ["Token Remover"]   = "TokenRemover"
 }
 
 -- track player-specific visibilities
-local actionTrackerVisibility = {}
-local blurseVisibility        = {}
-local handVisibility          = {}
+local actionTrackerVisibility     = {}
+local blurseVisibility            = {}
+local handVisibility              = {}
 
 -- track cards' tokens
-local cardTokens              = {}
-local cardSettings            = {}
+local cardTokens                  = {}
+local cardSettings                = {}
 
 ---------------------------------------------------------
 -- data for tokens
 ---------------------------------------------------------
 
-TokenManager                  = {}
-local tokenOffsets            = {}
+TokenManager                      = {}
+local tokenOffsets                = {}
 
 -- Table of data extracted from the token source bag, keyed by the Memo on each token which
 -- should match the token type keys ("resource", "clue", etc)
@@ -239,7 +243,7 @@ local tokenTemplates
 local playerCardData, locationData
 
 -- state IDs for the multi-stated resource tokens
-local RESOURCE_STATES         = {
+local RESOURCE_STATES             = {
   ["resource"] = 1,
   ["ammo"]     = 2,
   ["bounty"]   = 3,
@@ -2459,11 +2463,11 @@ function collectPlayermatSpawnData()
 end
 
 function spawnPlayermatObjects(matColor, playermat, transformData, spawnData)
-  local hasCombinedBagArea = setupsWithCombinedBagArea[optionPanel["tableSetup"]] and (matColor == "White" or matColor == "Orange")
+  local sharesBags = SHARED_BAGS_DATA.setups[optionPanel["tableSetup"]] and (matColor == "White" or matColor == "Orange")
   for name, objData in pairs(spawnData) do
     if name ~= "Playermat" then
-      if not (hasCombinedBagArea and combinedBagAreaNames[name]) then
-        local indexName = indexNames[name] or string.gsub(name, " ", "")
+      if not (sharesBags and SHARED_BAGS_DATA.objects[name]) then
+        local indexName = GUID_INDEX_MAP[name] or string.gsub(name, " ", "")
 
         -- if the object already exists, skip it
         local ref = guidReferenceApi.getObjectByOwnerAndType(matColor, indexName)
@@ -2505,6 +2509,9 @@ function spawnPlayermatObjects(matColor, playermat, transformData, spawnData)
 end
 
 function spawnPlayermat(matColor, transformData)
+  local spawnData = collectPlayermatSpawnData()
+  if not spawnData then return end
+
   -- get transforms if not supplied
   if not transformData then
     local setupName = optionPanel["tableSetup"]
@@ -2517,9 +2524,6 @@ function spawnPlayermat(matColor, transformData)
   end
 
   function spawnCoro()
-    local spawnData = collectPlayermatSpawnData()
-    if not spawnData then return 1 end
-
     -- handle mat spawning first
     updateTransformData(spawnData.Playermat, transformData.position, transformData.rotation)
 
@@ -2575,13 +2579,60 @@ function returnTableSetupId(name)
   end
 end
 
+function spawnSharedBagArea()
+  spawnData = spawnData or collectPlayermatSpawnData()
+  if not spawnData then return end
+
+  for name, objData in pairs(spawnData) do
+    if SHARED_BAGS_DATA.objects[name] then
+      local indexName = GUID_INDEX_MAP[name] or string.gsub(name, " ", "")
+
+      -- if the object already exists, skip it
+      local ref = guidReferenceApi.getObjectByOwnerAndType("Mythos", indexName)
+      if not ref then
+        -- get the local position / rotation for it
+        local transformData = SHARED_BAGS_DATA.transforms[indexName]
+        if transformData then
+          updateTransformData(objData, transformData.position, transformData.rotation)
+
+          -- spawn object and update index
+          local obj = spawnObjectData({ data = objData })
+          Wait.frames(function() guidReferenceApi.editIndex("Mythos", indexName, obj.getGUID()) end, 3)
+        end
+      end
+    end
+  end
+end
+
+function removeSharedBagArea()
+  for name, _ in pairs(SHARED_BAGS_DATA.objects) do
+    local indexName = GUID_INDEX_MAP[name] or string.gsub(name, " ", "")
+    guidReferenceApi.removeObjectByOwnerAndType("Mythos", indexName)
+  end
+end
+
 function updateTableSetup(newSetupName, oldSetupName)
+  spawnData = spawnData or collectPlayermatSpawnData()
+  if not spawnData then return end
+
   if newSetupName == oldSetupName then return end
 
   local tableSetupData = TABLE_SETUP_DATA[newSetupName]
   if not tableSetupData then return end
 
   function tableSetupCoro()
+    -- if the new layout introduces a shares bag area, spawn them
+    if SHARED_BAGS_DATA.setups[newSetupName] and not SHARED_BAGS_DATA.setups[oldSetupName] then
+      spawnSharedBagArea()
+    end
+
+    -- if the current layout does not have a shared bag area, remove them
+    if not SHARED_BAGS_DATA.setups[newSetupName] then
+      removeSharedBagArea()
+    end
+
+    coWaitFrames(2)
+
     for _, matColor in ipairs(MAT_COLORS) do
       if tableSetupData.transforms["Playermat" .. matColor] then
         -- move existing mats upwards temporarily to avoid collisions
@@ -2599,14 +2650,22 @@ function updateTableSetup(newSetupName, oldSetupName)
       if transformData then
         local playermat = guidReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
         if playermat then
+          -- remove unneccessary objects
+          local sharesBags = SHARED_BAGS_DATA.setups[optionPanel["tableSetup"]] and (matColor == "White" or matColor == "Orange")
+          for name, objData in pairs(spawnData) do
+            if sharesBags and SHARED_BAGS_DATA.objects[name] then
+              local indexName = GUID_INDEX_MAP[name] or string.gsub(name, " ", "")
+              guidReferenceApi.removeObjectByOwnerAndType(matColor, indexName)
+            end
+          end
+
+          coWaitFrames(5)
+
           playermatApi.moveAndRotate(matColor, transformData.position, transformData.rotation.y)
 
           coWaitFrames(5)
 
           -- spawn missing objects
-          local spawnData = collectPlayermatSpawnData()
-          if not spawnData then return 1 end
-
           spawnPlayermatObjects(matColor, playermat, transformData, spawnData)
         else
           spawnPlayermat(matColor, transformData)

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1699,9 +1699,17 @@ end
 ---@param useClickableCounters boolean Controls which type of counter is getting checked
 function getClueCount(useClickableCounters)
   if useClickableCounters then
-    return ownedObjects.ClickableClueCounter.getVar("val")
+    if ownedObjects.ClickableClueCounter then
+      return ownedObjects.ClickableClueCounter.getVar("val")
+    else
+      return 0
+    end
   else
-    return ownedObjects.ClueCounter.getVar("exposedValue")
+    if ownedObjects.ClueCounter then
+      return ownedObjects.ClueCounter.getVar("exposedValue")
+    else
+      return 0
+    end
   end
 end
 


### PR DESCRIPTION
- personal token bags will be removed when switching to a layout with shared bags
- shared bags will be removed when switching to a layout without them
- shared bags will be spawned when switching to a layout with them
- added a function to the guidReferenceApi to directly remove objects
- added error handling for playermats to not get issues for the few frames that the clue counter doesn't exist yet

Closes: https://github.com/argonui/SCED/issues/1174