### PR TITLE
fixed double rotation by "SidewaysCard" attribute for cards, replaced by EncounterBag

### DIFF
--- a/src/playercards/PlayerCardSpawner.ttslua
+++ b/src/playercards/PlayerCardSpawner.ttslua
@@ -91,7 +91,17 @@ Spawner.spawn = function(cardList, pos, rot, callback)
   if #cardList == 1 then
     -- handle sideways card
     if cardList[1].data.SidewaysCard then
-      rot = { rot.x, rot.y - 90, rot.z }
+      local replaced = false
+      for _, tag in ipairs(cardList[1].data.Tags or {}) do
+        if tag == "Replaced" then
+          replaced = true
+          break
+        end
+      end
+
+      if not replaced then
+        rot = { rot.x, rot.y - 90, rot.z }
+      end
     end
     return spawnObjectData({
       data = cardList[1].data,


### PR DESCRIPTION
### Bug
Cards replaced by AllEncounterCardsBag are rotated twice on spawn - one time on original card spawn and second time on replacing said card with one in index.

### Fix
In PlayerCardSpawner.Spawner.spawn - checking if card contains tag "Replaced". If its true -> no rotation applied spawn.