### PR TITLE
Fix playermat options visibility after hand color change

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1054,9 +1054,9 @@ function onClick_handColorSelect(player)
     local handZone = ownedObjects.HandZone
     handZone.setValue(newColor)
 
-    -- update visibility for old and new color
-    GlobalApi.changeWindowVisibility(playerColor, "optionPanelMain", _, self)
-    GlobalApi.changeWindowVisibility(newColor, "optionPanelMain", _, self)
+    -- update visibility for old and new color (delay to allow first call to resolve)
+    GlobalApi.changeWindowVisibility(playerColor, "optionPanelMain", false, self)
+    Wait.frames(function() GlobalApi.changeWindowVisibility(newColor, "optionPanelMain", true, self) end, 3)
     navigationOverlayApi.copyVisibility(playerColor, newColor)
 
     -- if there was a seated player, reseat to the new color


### PR DESCRIPTION
Previously, the old color would still have the panel visible because the 2nd call was overriding the 1st call.