### PR TITLE
Update Token Remover's Zone after movement

### DIFF
--- a/src/playermat/PlayermatApi.ttslua
+++ b/src/playermat/PlayermatApi.ttslua
@@ -423,6 +423,12 @@ do
         moveAndRotateObject(obj)
       end
     end
+
+    -- make sure the Token Remover Zone is updated
+    local tokenRemover = guidReferenceApi.getObjectByOwnerAndType(matColor, "TokenRemover")
+    if tokenRemover ~= nil then
+      tokenRemover.call("updateZone")
+    end
   end
 
   return PlayermatApi

--- a/src/tokens/TokenRemover.ttslua
+++ b/src/tokens/TokenRemover.ttslua
@@ -37,6 +37,13 @@ function disable()
   setMenu(true)
 end
 
+function updateZone()
+  if zone ~= nil then
+    zone.setPosition(self.getPosition() + Vector(0, 3.5 + 0.11, 0))
+    zone.setRotation(self.getRotation())
+  end
+end
+
 function setMenu(isEnabled)
   state = not isEnabled
   self.clearContextMenu()


### PR DESCRIPTION
Without this change the removal zone stays at the old position