### PR TITLE
Updated Scenario handling

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -137,6 +137,7 @@ function cleanUp(_, color)
   end
 
   getScenarioName()
+  mythosAreaApi.resetScenarioData()
   soundCubeApi.playSoundByName("Vacuum")
   ignoreCustomDataHelper()
   getTrauma()
@@ -154,7 +155,7 @@ function cleanUp(_, color)
   maybeIgnoreTekeliliCards()
 
   printToAll("Tidying main play area...", "White")
-  startLuaCoroutine(self, "tidyPlayareaCoroutine")
+  startLuaCoroutine(self, "tidyPlayAreaCoroutine")
 end
 
 ---------------------------------------------------------
@@ -316,11 +317,14 @@ function maybeIgnoreTekeliliCards()
 end
 
 -- clean up for play area
-function tidyPlayareaCoroutine()
+function tidyPlayAreaCoroutine()
   coWaitFrames(10)
 
   local trash = guidReferenceApi.getObjectByOwnerAndType("Mythos", "Trash")
   local playAreaZone = guidReferenceApi.getObjectByOwnerAndType("Mythos", "PlayAreaZone")
+
+  -- triggers an update to remove lines from helpers
+  playAreaApi.rebuildConnectionList()
 
   -- reset the playarea image by not providing an image
   playAreaApi.updateSurface()

--- a/src/mythos/MythosArea.ttslua
+++ b/src/mythos/MythosArea.ttslua
@@ -55,6 +55,14 @@ function onLoad(savedData)
   Wait.time(function() collisionEnabled = true end, 0.1)
 end
 
+function resetScenarioData()
+  currentScenario = ""
+  useFrontData = true
+  tokenData = {}
+  updateSave()
+  playAreaApi.onScenarioChanged("")
+end
+
 function copyScenarioReferenceCard()
   if scenarioCard == nil then
     broadcastToAll("No scenario reference card found.", "Red")

--- a/src/mythos/MythosAreaApi.ttslua
+++ b/src/mythos/MythosAreaApi.ttslua
@@ -11,6 +11,10 @@ do
     return getMythosArea().call("returnTokenData")
   end
 
+  MythosAreaApi.resetScenarioData = function()
+    getMythosArea().call("resetScenarioData")
+  end
+
   ---@return table: object references to the encounter deck objects
   MythosAreaApi.getEncounterDeckObjects = function()
     return getMythosArea().call("getEncounterDeckObjects")

--- a/src/playarea/PlayArea.ttslua
+++ b/src/playarea/PlayArea.ttslua
@@ -338,7 +338,6 @@ end
 function drawBaseConnections()
   if not showLocationLinks() then
     locationConnections = {}
-    self.setVectorLines({})
     return
   end
   local cardConnectionLines = {}
@@ -692,7 +691,9 @@ end
 function onScenarioChanged(scenarioName)
   currentScenario = scenarioName
   if not showLocationLinks() then
-    broadcastToAll("Automatic location connections not available for this scenario")
+    if connectionsEnabled then
+      broadcastToAll("Automatic location connections not available for this scenario")
+    end
   end
   updateSave()
 end

--- a/src/playarea/PlayAreaApi.ttslua
+++ b/src/playarea/PlayAreaApi.ttslua
@@ -51,6 +51,11 @@ do
     getPlayArea().call("setConnectionColor", color)
   end
 
+  -- triggers an update
+  PlayAreaApi.rebuildConnectionList = function()
+    getPlayArea().call("rebuildConnectionList")
+  end
+
   -- Event to be called when the current scenario has changed
   ---@param scenarioName string Name of the new scenario
   PlayAreaApi.onScenarioChanged = function(scenarioName)


### PR DESCRIPTION
- Scenario Name will be properly reset by the Clean Up Helper
- Play Area will not remove lines drawn by a helper unless a full redraw is triggered