### PR TITLE
Use arkham.build's API per default

### DIFF
--- a/src/arkhamdb/ArkhamDb.ttslua
+++ b/src/arkhamdb/ArkhamDb.ttslua
@@ -67,11 +67,6 @@ do
       deckId
     }
 
-    -- use secondary api (arkham.build) if deckid is too long
-    if string.len(deckId) == 15 then
-      deckUri = { configuration.api_uri2, deckId }
-    end
-
     local deck = Request.start(deckUri, function(status)
       if string.find(status.text, "<!DOCTYPE html>") or string.find(status.text, "No share was found for this deck") then
         internal.maybePrint("Private deck ID " .. deckId .. " is not shared.", playerColor)

--- a/src/arkhamdb/Configuration.ttslua
+++ b/src/arkhamdb/Configuration.ttslua
@@ -1,7 +1,8 @@
 ---@type table Contains fields used by the deck importer
 configuration = {
-    api_uri = "https://arkhamdb.com/api/public",
-    api_uri2 = "https://api.arkham.build/v1/public/share",
+    -- arkham.build's API is now the default because of custom card support
+    api_uri = "https://api.arkham.build/v1/public/share",
+    api_uri2 = "https://arkhamdb.com/api/public",
     public_deck = "decklist",
     private_deck = "deck",
     cards = "card",


### PR DESCRIPTION
This enables the import of custom cards (which can be added to web-built decks soon via arkham.build - even for ArkhamDB synced decks!)