### PR TITLE
Updates trackers based on token cancellation

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -498,6 +498,10 @@ function onObjectRotate(obj, _, flip, _, _, oldFlip)
     for matColor, _ in pairs(guidReferenceApi.getObjectsByType("Playermat")) do
       Wait.frames(function() updateActionTrackerName(matColor) end, 75)
     end
+  elseif tokenChecker.isChaosToken(obj) then
+    local matColor = playermatApi.getMatColorByPosition(obj.getPosition())
+    local tokenName = obj.getName()
+    trackChaosToken(tokenName, matColor, true)
   else
     maybeUpdateActionTrackerTokens(obj, 75)
   end
@@ -989,7 +993,7 @@ function trackChaosToken(tokenName, matColor, subtract)
 
   -- update any chaos token counters
   for _, obj in ipairs(getObjectsWithTag("ChaosTokenCounter")) do
-    obj.call("maybeUpdateCounter", { tokenName = tokenName, matColor = matColor })
+    obj.call("maybeUpdateCounter", { tokenName = tokenName, matColor = matColor, modifier = modifier })
   end
 
   -- add to list of last drawn tokens (if not subtracting)

--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -499,9 +499,19 @@ function onObjectRotate(obj, _, flip, _, _, oldFlip)
       Wait.frames(function() updateActionTrackerName(matColor) end, 75)
     end
   elseif tokenChecker.isChaosToken(obj) then
-    local matColor = playermatApi.getMatColorByPosition(obj.getPosition())
-    local tokenName = obj.getName()
-    trackChaosToken(tokenName, matColor, true)
+    if #chaosTokens == 0 then return end
+
+    for _, token in pairs(chaosTokens) do
+      if token == obj then
+        local matColor = playermatApi.getMatColorByPosition(obj.getPosition())
+        local tokenName = obj.getName()
+        if flip == 180 then
+          trackChaosToken(tokenName, matColor, true)
+        else
+          trackChaosToken(tokenName, matColor, false)
+        end
+      end
+    end
   else
     maybeUpdateActionTrackerTokens(obj, 75)
   end

--- a/src/tokens/ChaosTokenCounter.ttslua
+++ b/src/tokens/ChaosTokenCounter.ttslua
@@ -113,9 +113,9 @@ function maybeUpdateCounter(params)
     if enabled == true then
       if params.tokenName == counterToken then
         if counterMat and counterMat == params.matColor then
-          addOrSubtract(false)
+          modifyValue(params.modifier)
         elseif global then
-          addOrSubtract(false)
+          modifyValue(params.modifier)
         end
       end
     end


### PR DESCRIPTION
Flipping a chaos token removes it from the tracks (both on automatic counters and the chaos bag stat tracker