### PR TITLE
Search Assistant: Adjusted size of temporary hand

### DIFF
--- a/src/accessories/SearchAssistant.ttslua
+++ b/src/accessories/SearchAssistant.ttslua
@@ -135,6 +135,7 @@ function startSearch(messageColor, number)
     position = handZone.getPosition() + handData.forward * 7.5
   end
 
+  data.Transform.scaleX = data.Transform.scaleX * 0.8
   data.Transform.scaleZ = data.Transform.scaleZ * 0.6
 
   local newHand = spawnObjectData({ data = data, position = position })
@@ -147,7 +148,7 @@ function startSearch(messageColor, number)
       attributes = {
         height = 120,
         width = 1500,
-        scale = ".025 .167 1",
+        scale = ".03125 .167 1",
         position = "0 64 30",
       },
       children = {
@@ -201,7 +202,7 @@ function startSearch(messageColor, number)
       attributes = {
         height = 170,
         width = 1500,
-        scale = ".025 .167 1",
+        scale = ".03125 .167 1",
         position = "0 -67 30",
       },
       children = {


### PR DESCRIPTION
To stop an issue with cards re-entering the hand after being put into the deck when the search is ended