### PR TITLE
Handling for currently reloading mat

### DIFF
--- a/src/playermat/PlayermatApi.ttslua
+++ b/src/playermat/PlayermatApi.ttslua
@@ -243,7 +243,7 @@ do
   PlayermatApi.getClueCount = function(useClickableCounters, matColor)
     local count = 0
     for _, mat in pairs(getMatForColor(matColor)) do
-      count = count + mat.call("getClueCount", useClickableCounters)
+      count = count + (mat.call("getClueCount", useClickableCounters) or 0)
     end
     return count
   end


### PR DESCRIPTION
Fixes an issue with trying to get the clue count of a mat that is currently reloading