### PR TITLE
Enforce action version

### DIFF
--- a/.github/workflows/build-mod.yml
+++ b/.github/workflows/build-mod.yml
@@ -47,7 +47,7 @@ jobs:
           path: ./${{ env.filename }}
 
       - name: Add built mod to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: ${{ env.filename }}


### PR DESCRIPTION
IMPORTANT!
Newest release (2.3.0) of the action was just posted and it is broken, so we instead enforce the previous version (2.2.2).

https://github.com/softprops/action-gh-release/issues/627