### PR TITLE
Increase size of search zone for playermats

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -272,8 +272,8 @@ function searchAroundSelf(filter)
   local scale             = self.getScale()
   local bounds            = self.getBoundsNormalized()
 
-  -- Increase the width to cover the set aside zone
-  local size              = Vector(bounds.size.x + SEARCH_AROUND_SELF_X_BUFFER, 2,
+  -- Increase the width to cover the set aside zone (height needs to account for cards "below" the playermat)
+  local size              = Vector(bounds.size.x + SEARCH_AROUND_SELF_X_BUFFER, 3,
     bounds.size.z + SEARCH_AROUND_SELF_Z_BUFFER)
 
   -- 'setAsideDirection' accounts for the set aside zone being on the left or right,


### PR DESCRIPTION
Cards on the table (for example in the set-aside zone) are technically "below" the playermat, so the size of the searched zone needs to take that into account.