### PR TITLE
Small delay for mat texture change from investigator placement

### DIFF
--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1129,7 +1129,7 @@ function onClick_textureSelect(player)
   for texture, _ in pairs(nameToTexture) do
     table.insert(textureList, texture)
   end
-  player.showOptionsDialog("Select a texture:", textureList, _, updateTexture)
+  player.showOptionsDialog("Select a texture:", textureList, nil, updateTexture)
 end
 
 -- show the triggering player a dialog to select a new hand color for this mat
@@ -1568,7 +1568,9 @@ function maybeUpdateActiveInvestigator(card, md)
     md.combatIcons,
     md.agilityIcons
   })
-  updateTexture()
+
+  -- small delay to allow other objects to finish colliding
+  Wait.time(updateTexture, 0.3)
 
   newInvestigatorCallback(md.id)
 


### PR DESCRIPTION
Delay is necessary to allow other objects to finish their collision events which might require a call to the mat to check whether a resource counter needs to be spawned.