### PR TITLE
Bugfix for swapping away from a setup with removed mats

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -2484,14 +2484,14 @@ end
 -- removes a playermat and all related objects from play
 ---@param matColor string Color of the playermat to remove
 function removePlayermat(matColor)
+  local matObjects = GUIDReferenceApi.getObjectsByOwner(matColor)
+  if not matObjects.Playermat then return end
+
   -- if there's a seated player, move them to grey
   local handColor = PlayermatApi.getPlayerColor(matColor)
   if Player[handColor].seated then
     Player[handColor].changeColor("Grey")
   end
-
-  local matObjects = GUIDReferenceApi.getObjectsByOwner(matColor)
-  if not matObjects.Playermat then return end
 
   -- remove objects on mat
   local objectsToRemove = PlayermatApi.searchAroundPlayermat(matColor, "isInteractable")


### PR DESCRIPTION
This makes sure the check for the existance of the mat is performed first and potentially exists directly.