### PR TITLE
All encounters cards bag fix

### DIFF
--- a/src/mythos/AllEncounterCardsBag.ttslua
+++ b/src/mythos/AllEncounterCardsBag.ttslua
@@ -360,13 +360,20 @@ function updateOriginalItemData(originalData, replaceData)
   table.insert(originalData["Tags"], "Replaced")
 
   if originalData["Name"] == "Card" or originalData["Name"] == "CardCustom" then
-    processCard(originalData)
-    return true
+    return processCard(originalData)
   end
   return true
 end
 
 function processCard(cardData)
+  local _, customDeckData = next(cardData["CustomDeck"])
+  customDeckData["BackIsHidden"] = true
+
+  -- skip cards with decksheets as back
+  if (customDeckData["NumHeight"] ~= 1 or customDeckData["NumWidth"] ~= 1) or customDeckData["UniqueBack"] == true then
+    return true
+  end
+
   local hasPlayerCardTag   = false
   local hasScenarioCardTag = false
 
@@ -391,12 +398,6 @@ function processCard(cardData)
     newBack = CARD_BACK_URL.ScenarioCard
   end
 
-  local _, customDeckData = next(cardData["CustomDeck"])
-  customDeckData["BackIsHidden"] = true
-
-  -- skip cards with decksheets as back
-  if (customDeckData["NumHeight"] == 1 and customDeckData["NumWidth"] == 1) or customDeckData["UniqueBack"] == false then
-    customDeckData["BackURL"] = newBack
-  end
+  customDeckData["BackURL"] = newBack
   return true
 end


### PR DESCRIPTION
Move unique card back check to the beginning of the function. 

It ensures that even if the card with the unique card back does not have tags (supplies/decoys are examples of such cards), it will still be processed (processCard function requires one of two tags to be present)