### PR TITLE
identify scenario card by type in addition to name

### DIFF
--- a/src/mythos/MythosArea.ttslua
+++ b/src/mythos/MythosArea.ttslua
@@ -136,7 +136,7 @@ end
 -- maybe load data from reference card
 function getDataFromReferenceCard(card, cardName, md)
   local newScenarioName
-  if cardName == "Scenario" then
+  if cardName == "Scenario" or md.type == "ScenarioReference" then
     newScenarioName = card.getDescription()
   else
     newScenarioName = cardName


### PR DESCRIPTION
Minor change to fix splash screen with the scenario name, so that it can work even if name of the scenario card is not "Scenario"
<details>
       <summary>Example</summary>
 Before the change ("Scenario" (Сценарий) is dislayed instead of actual scenario name):
<img width="1280" height="719" alt="image" src="https://github.com/user-attachments/assets/68208919-99b7-4ba4-8387-87a774c31482" />
After the change ("The Devourer Below" (Пожиратель из глубин) is displayed on the splash screen)
<img width="1280" height="719" alt="image" src="https://github.com/user-attachments/assets/1146f712-5477-4f14-967a-6ec7969ecdba" />
     </details>
