### PR TITLE
replace non-card objects inside the bags

### DIFF
--- a/src/mythos/AllEncounterCardsBag.ttslua
+++ b/src/mythos/AllEncounterCardsBag.ttslua
@@ -298,6 +298,16 @@ function updateBagData(bagData)
       if updateDeckData(objData) then
         changedSomething = true
       end
+    else
+      local md = JSON.decode(objData.GMNotes) or {}
+      if md.id then
+        local objectData = getObjectById({ id = md.id })
+        if objectData then
+          if updateOriginalItemData(objData, objectData.data) then
+            changedSomething = true
+          end
+        end
+      end
     end
   end
   return changedSomething


### PR DESCRIPTION
Add ability for the AllEncounterCardsBag to replace non-card objects (like campaign logs) while they are inside the containers