### PR TITLE
Fix token splash screen condition

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -1071,7 +1071,7 @@ function tokenSplash(matColor)
   else
     -- Work out the visibility from the settings
     local visibility = getTokenSplashVisibility(matColor)
-    if not visibility == "" then return end
+    if visibility == "" then return end
     UI.setAttribute("CTS_main", "visibility", visibility)
   end
 


### PR DESCRIPTION
This makes sure that the token splash screen does not get shown if there are no viewers for it.