### PR TITLE
AllEncounterCards bag fix

### DIFF
--- a/src/mythos/AllEncounterCardsBag.ttslua
+++ b/src/mythos/AllEncounterCardsBag.ttslua
@@ -195,7 +195,7 @@ function onObjectSpawn(obj)
     handleSpawnedCard(obj)
   elseif obj.type == "Deck" then
     handleSpawnedDeck(obj)
-  elseif obj.type == "Bag" then
+  elseif obj.type == "Bag" or obj.name == "Custom_Model_Bag" then
     handleSpawnedBag(obj)
   else
     handleSpawnedObject(obj)

--- a/src/mythos/AllEncounterCardsBag.ttslua
+++ b/src/mythos/AllEncounterCardsBag.ttslua
@@ -195,6 +195,8 @@ function onObjectSpawn(obj)
     handleSpawnedCard(obj)
   elseif obj.type == "Deck" then
     handleSpawnedDeck(obj)
+  -- when campaign/scenario box is downloaded, sometimes (semi-randomly) it has type "Generic"
+  -- instead of "Bag", so we are also checking the name here
   elseif obj.type == "Bag" or obj.name == "Custom_Model_Bag" then
     handleSpawnedBag(obj)
   else


### PR DESCRIPTION
Sometimes when you try to download campaign/scenario from the Downloadable Content window, items inside the bag do not get replaced. This PR fixes it.

The root of issue from what I understood is that sometimes when onObjectSpawn inside [AllEncounterCardsBag.ttslua](https://github.com/argonui/SCED/compare/main...Shestel12:fix-bags-localization?expand=1#diff-24e04ddfe6d4f742210d6624797250e71f59b64431d48fd7d1d1b7d8599c7fca) gets called, obj.type is "Generic" instead of "Bag". Looks like it happens because initially "Download" button downloads placeholder object, and then it is replaced by the actual box, so sometimes onObjectSpawn in AllEncounterCards bag picks up the placeholder, and sometimes - actual bag. Maybe there is a cleaner way to fix it, but I'm not completely sure how to do it.