### PR TITLE
fix rotation handling in card spawner

### DIFF
--- a/src/playercards/CardSpawner.ttslua
+++ b/src/playercards/CardSpawner.ttslua
@@ -110,7 +110,7 @@ do
         end
 
         if not replaced then
-          rot = rot - Vector(0, 90, 0)
+          rot = Vector(rot) - Vector(0, 90, 0)
         end
       end
 
@@ -137,7 +137,7 @@ do
     -- set the alt view angle for sideways decks
     if sidewaysDeck then
       deck.AltLookAngle = { x = 0, y = 180, z = 90 }
-      rot = rot - Vector(0, 90, 0)
+      rot = Vector(rot) - Vector(0, 90, 0)
     end
 
     return spawnObjectData({

--- a/src/playercards/PlayerCardPanel.ttslua
+++ b/src/playercards/PlayerCardPanel.ttslua
@@ -29,8 +29,8 @@ local CYCLE_BUTTONS_Z_OFFSET           = 0.2665
 local STARTER_DECK_MODE_SELECTED_COLOR = { 0.2, 0.2, 0.2, 0.8 }
 local TRANSPARENT                      = { 0, 0, 0, 0 }
 
-local FACE_UP_ROTATION                 = { x = 0, y = 270, z = 0 }
-local FACE_DOWN_ROTATION               = { x = 0, y = 270, z = 180 }
+local FACE_UP_ROTATION                 = Vector(0, 270, 0)
+local FACE_DOWN_ROTATION               = Vector(0, 270, 180)
 
 -- ----------  IMPORTANT  ----------
 -- Coordinates defined below are in global dimensions relative to the panel - DO NOT USE THESE


### PR DESCRIPTION
On the latest dev version, when attempting to spawn any sideways card (like the investigator), there is an error.
<details>
<summary> Image with an example</summary>
<img width="1280" height="719" alt="image" src="https://github.com/user-attachments/assets/74fb7560-6b43-4188-be15-fb13d2ba5e4e" />
</details>

The issue is that in `rot = rot - Vector(0, 90, 0)` line `rot` is not a vector, and so arithmetics between values with different types fails. Changes in either CardSpawner or PlayerCardPanel fix the issue, not sure which of them is better, and need to double check that changing FACE_UP_ROTATION/FACE_DOWN_ROTATION  values does not break anything else
