### PR TITLE
Taboo handling for bonded cards

### DIFF
--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -321,6 +321,11 @@ function buildSupplementalIndexes()
       if card.metadata.bonded then
         for _, bondedData in ipairs(card.metadata.bonded) do
           table.insert(bondedList, bondedData.id)
+
+          -- also added tabooed version of bonded cards
+          if cardIdIndex[bondedData.id .. "-t"] then
+            table.insert(bondedList, bondedData.id .. "-t")
+          end
         end
       end
 

--- a/src/playercards/AllCardsBag.ttslua
+++ b/src/playercards/AllCardsBag.ttslua
@@ -322,7 +322,7 @@ function buildSupplementalIndexes()
         for _, bondedData in ipairs(card.metadata.bonded) do
           table.insert(bondedList, bondedData.id)
 
-          -- also added tabooed version of bonded cards
+          -- Maybe add tabooed version of bonded card
           if cardIdIndex[bondedData.id .. "-t"] then
             table.insert(bondedList, bondedData.id .. "-t")
           end


### PR DESCRIPTION
Ensures that taboo versions of bonded cards also show up in the list in the player card panel (e.g. Pendant of the Queen).