### PR TITLE
Added Arno-Pro

### DIFF
--- a/modsettings/CustomUIAssets.json
+++ b/modsettings/CustomUIAssets.json
@@ -70,6 +70,11 @@
     "URL": "https://steamusercontent-a.akamaihd.net/ugc/2424714310444718103/C96BEC602A96F3D302A6442B2EB8129AA4F814A1/"
   },
   {
+    "Name": "font_arno-pro",
+    "Type": 1,
+    "URL": "https://steamusercontent-a.akamaihd.net/ugc/11580651411710945045/C51521EBDE5474EBF3788016FF6D11C30E5D5634/"
+  },
+  {
     "Name": "font_teutonic-arkham",
     "Type": 1,
     "URL": "https://steamusercontent-a.akamaihd.net/ugc/2027213118467703445/89328E273B4C5180BF491516CE998DE3C604E162/"


### PR DESCRIPTION
Contains the regular, bold, italic and italic+bold versions.
They are accessed like so:
```
font="font_arno-pro/arno-pro-regular"
font="font_arno-pro/arno-pro-bold"
font="font_arno-pro/arno-pro-italic"
font="font_arno-pro/arno-pro-bold-italic"
```

Quick example:
<img width="691" height="1061" alt="grafik" src="https://github.com/user-attachments/assets/be1e35f9-d077-4741-a1d6-0feba595a351" />
