### PR TITLE
Disable diagnostics in SkillSelectionCard file

### DIFF
--- a/src/playercards/SkillSelectionCard.ttslua
+++ b/src/playercards/SkillSelectionCard.ttslua
@@ -1,3 +1,4 @@
+---@diagnostic disable: undefined-global
 -- This is used for cards like Charlie Kane, Good Weather, Making Preparations and Whispers of Hypnos
 
 require("playercards/CardsWithHelper")


### PR DESCRIPTION
Without this, errors show up for the undefined global variables (like `extraButtons`)