### PR TITLE
Adjusted Tour positioning

### DIFF
--- a/src/core/tour/TourManager.ttslua
+++ b/src/core/tour/TourManager.ttslua
@@ -50,7 +50,7 @@ do
     southwest   = "0.25 0.25",
 
     -- Used by the cards referencing the bottom-right panel, moved a little closer to them
-    southeast   = "0.85 0.23"
+    southeast   = "0.8 0.23"
   }
 
   -- Tracks the current state of the tours. Keyed by player color to keep each player's tour


### PR DESCRIPTION
Slightly moved the south east position left to ensure the bottom bar is visible for uncommon aspect ratios.