### PR TITLE
Added Ancient Evils Replacements

### DIFF
--- a/config.json
+++ b/config.json
@@ -221,6 +221,7 @@
     "TableDivider.e10924",
     "AllEncounterCards.aa12bb",
     "TableDivider.e5f550",
+    "AncientEvilsReplacements.8f5b10",
     "CleanUpHelper.26cf4b",
     "CoreNightoftheZealot.64a613",
     "TheScarletKeys.300fcc",

--- a/objects/AncientEvilsReplacements.8f5b10.json
+++ b/objects/AncientEvilsReplacements.8f5b10.json
@@ -1,0 +1,54 @@
+{
+  "GUID": "8f5b10",
+  "Name": "Custom_Assetbundle",
+  "Transform": {
+    "posX": 69,
+    "posY": 1.725,
+    "posZ": 89,
+    "rotX": 0,
+    "rotY": 270,
+    "rotZ": 0,
+    "scaleX": 4,
+    "scaleY": 4,
+    "scaleZ": 4
+  },
+  "Nickname": "Ancient Evils Replacements",
+  "Description": "Contains full art replacement cards by hauke for the official Ancient Evils card with campaign specific art. ",
+  "GMNotes": "{\n  \"filename\": \"ancient_evils_replacements\"}",
+  "AltLookAngle": {
+    "x": 0.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "ColorDiffuse": {
+    "r": 1.0,
+    "g": 1.0,
+    "b": 1.0
+  },
+  "LayoutGroupSortIndex": 0,
+  "Value": 0,
+  "Locked": true,
+  "Grid": true,
+  "Snap": true,
+  "IgnoreFoW": false,
+  "MeasureMovement": false,
+  "DragSelectable": true,
+  "Autoraise": true,
+  "Sticky": true,
+  "Tooltip": true,
+  "GridProjection": false,
+  "HideWhenFaceDown": false,
+  "Hands": false,
+  "MaterialIndex": -1,
+  "MeshIndex": -1,
+  "CustomAssetbundle": {
+    "AssetbundleURL": "https://steamusercontent-a.akamaihd.net/ugc/931552412225871988/6F82627275B2EF83833777BB4ADEE538686153C4/",
+    "AssetbundleSecondaryURL": "",
+    "MaterialIndex": 0,
+    "TypeIndex": 1,
+    "LoopingEffectIndex": 0
+  },
+  "LuaScript": "require(\"core/DownloadBox\")",
+  "LuaScriptState": "",
+  "XmlUI": ""
+}


### PR DESCRIPTION
This new Cthulhu model contains the full art Ancient Evils replacements by hauke.
In the future, we could potentially collect the official Ancient Evils variants too and add those to it.

Pre-downloaded:
<img width="514" height="505" alt="grafik" src="https://github.com/user-attachments/assets/64c71da0-93ea-40ff-9dfa-115153f4db9b" />

Downloaded and placed:
<img width="922" height="873" alt="grafik" src="https://github.com/user-attachments/assets/e645eb9f-46fc-427a-82cf-884a578b6ec7" />
