### PR TITLE
Phase Tracker verbosity mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.vscode/settings.json
 .mo
+.get-lua*
+.LUAcoding*.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,40 @@
     "need-check-nil",
     "assign-type-mismatch",
     "param-type-mismatch"
-  ]
+  ],
+
+  "Lua.workspace.ignoreDir": [
+    "**/*.py",
+    "**/*.po",
+    "**/*.md",
+    "**/CODEOWNERS",
+    "**/.gitignore",
+    "**/.gitattributes",
+    "**/*.json",
+    "**/*.yml",
+    "**/*.luascriptstate",
+    "**/*.gmnotes",
+    "**/*.xml",
+    "**/*.daniel",
+    "**/*.ps1",
+  ],
+  "workbench.colorTheme": "Default Dark+",
+  "workbench.colorCustomizations": {
+    
+    "titleBar.activeBackground": "#393900", // tema amarillento
+    "titleBar.activeForeground": "#ddddff",
+
+    "titleBar.inactiveBackground": "#292900",
+    "titleBar.inactiveForeground": "#aaaabb",
+
+    "editor.background": "#000000",
+    "editor.foreground": "#bbbbff",
+    
+    "editor.lineHighlightBackground": "#ffff0044", //amarillo, se ve bien en qué linea estoy
+    "editor.selectionBackground": "#ffff0066",
+
+    "editor.wordHighlightBackground": "#44004455", // ocurrencias de lectura
+    "editor.wordHighlightStrongBackground": "#66660055", // ocurrencias de escritura
+
+  },
 }

--- a/get-lua-code.ps1
+++ b/get-lua-code.ps1
@@ -1,0 +1,39 @@
+param(
+    [string]$JsonFile
+)
+
+if (-Not (Test-Path $JsonFile)) {
+    Write-Host "Error: File not found: $JsonFile"
+    exit 1
+}
+
+# Get the folder where the script is being run
+$scriptFolder = Get-Location
+
+# Get the base name without extension
+$baseName = [System.IO.Path]::GetFileNameWithoutExtension($JsonFile)
+
+# Create new filename
+$newFileName = "LUAcoding$baseName.txt"
+$outFile = Join-Path $scriptFolder $newFileName
+
+# Extract LuaScript string (keeps escaped sequences)
+$rawContent = Get-Content $JsonFile | ForEach-Object {
+    if ($_ -match '"LuaScript"\s*:\s*"((?:\\.|[^"])*)"' ) {
+        $matches[1]
+    }
+}
+
+# Decode escaped sequences into real characters
+$decoded = $rawContent -replace '\\n', "`r`n"
+$decoded = $decoded -replace '\\t', "`t"
+$decoded = $decoded -replace '\\r', "`r"
+$decoded = $decoded -replace '\\"', '"'
+$decoded = $decoded -replace '\\\\', '\'
+
+# Save to new filename
+$decoded | Set-Content $outFile -Encoding UTF8
+
+Write-Host "Readable LuaScript saved to $outFile"
+
+# Para usarlo hacer powershell ./get-lua-code.ps1 -JsonFile objects\PhaseTracker.d0c8fa.json desde cmd

--- a/objects/PhaseTracker.d0c8fa.json
+++ b/objects/PhaseTracker.d0c8fa.json
@@ -34,7 +34,7 @@
   "LayoutGroupSortIndex": 0,
   "Locked": true,
   "LuaScript": "require(\"playarea/PhaseTracker\")",
-  "LuaScriptState": "{\"broadcastChange\":false,\"phaseId\":1}",
+  "LuaScriptState": "{\"phaseId\":1, \"broadcastChange\": false, \"broadcastChangeVerbosity\": false, \"pingAndLookAtPhase\": false}",
   "MeasureMovement": false,
   "Name": "Custom_Tile",
   "Nickname": "Phase Tracker",

--- a/src/playarea/PhaseTracker.ttslua
+++ b/src/playarea/PhaseTracker.ttslua
@@ -1,4 +1,8 @@
-local PHASE_NAMES = {
+local PlayermatApi = require("playermat/PlayermatApi")
+local MythosAreaApi = require("mythos/MythosAreaApi")
+
+
+local PHASE_NAMES  = {
   "I. Mythos Phase",
   "II. Investigation Phase",
   "III. Enemy Phase",
@@ -14,7 +18,9 @@ local PHASE_IMAGES = {
 function onSave()
   return JSON.encode({
     phaseId = phaseId,
-    broadcastChange = broadcastChange
+    broadcastChange = broadcastChange,
+    broadcastChangeVerbosity = broadcastChangeVerbosity,
+    pingAndLookAtPhase = pingAndLookAtPhase
   })
 end
 
@@ -30,6 +36,8 @@ function onLoad(savedData)
   else
     phaseId = 1
     broadcastChange = false
+    broadcastChangeVerbosity = false
+    pingAndLookAtPhase = false
   end
 
   self.createButton({
@@ -38,21 +46,62 @@ function onLoad(savedData)
     function_owner = self,
     width          = 600,
     height         = 600,
-    color          = { r = 0, g = 0, b = 0, a = 0 }
+    color       = { r = 0, g = 0, b = 0, a = 0 }
   })
 
-  self.addContextMenuItem("Toggle Broadcasting", updateBroadcast)
+  self.addContextMenuItem("Toggle Broadcasting", toggleBroadcast)
+  self.addContextMenuItem("Toggle Verbosity Broadcasting", toggleBroadcastVerbosity)
+  self.addContextMenuItem("Toggle Ping Mythos Area", togglePing)
 end
 
-function updateBroadcast(playerColor)
+-- Context menu functions
+
+function toggleBroadcast(playerColor)
+  -- Changes (toggles) the if the phase changes are broadcast or not
   Player[playerColor].clearSelectedObjects()
   for _, tracker in ipairs(getObjectsWithTag("LinkedPhaseTracker")) do
     tracker.setVar("broadcastChange", not broadcastChange)
+    if not broadcastChange then
+      -- If broadcastChange is off, broadcastChangeVerbosity and pingAndLookAtPhase should also be off
+      tracker.setVar("broadcastChangeVerbosity", false)
+      tracker.setVar("pingAndLookAtPhase", false)
+    end
   end
   broadcastToAll("Broadcasting phase changes has been " .. (broadcastChange and "enabled." or "disabled."))
 end
 
-function changeState(_, _, isRightClick)
+function toggleBroadcastVerbosity(playerColor)
+  -- Changes (toggles) the if the phase changes are broadcast with a lot of verbosity or not
+  Player[playerColor].clearSelectedObjects()
+  for _, tracker in ipairs(getObjectsWithTag("LinkedPhaseTracker")) do
+    tracker.setVar("broadcastChangeVerbosity", not broadcastChangeVerbosity) -- Toggle  → Set the opposite
+    if broadcastChangeVerbosity then
+      -- If broadcastChangeVerbosity is on, broadcastChange should also be on
+      tracker.setVar("broadcastChange", true)
+    end
+  end
+  broadcastToAll("Broadcasting phase changes in (Verbosity mode) has been " ..
+    (broadcastChangeVerbosity and "enabled." or "disabled."))
+end
+
+function togglePing(playerColor)
+  -- Changes (toggles)
+  Player[playerColor].clearSelectedObjects()
+  for _, tracker in ipairs(getObjectsWithTag("LinkedPhaseTracker")) do
+    tracker.setVar("pingAndLookAtPhase", not pingAndLookAtPhase) -- Toggle  → Set the opposite
+    if pingAndLookAtPhase then
+      -- If pingAndLookAtPhase is on, broadcastChangeVerbosity and broadcastChange should also be on
+      tracker.setVar("broadcastChange", true)
+      tracker.setVar("broadcastChangeVerbosity", true)
+    end
+  end
+  broadcastToAll("Broadcasting phase changes in (Verbosity mode) has been " ..
+    (broadcastChangeVerbosity and "enabled" or "disabled") .. 'and the Phase Tracker will bring you to the Mythos Area.')
+end
+
+-- Functions that run when changing phase
+
+function changeState(_, playerColor, isRightClick)
   -- get newId for all trackers
   local newId = phaseId + (isRightClick and -1 or 1)
   if newId == 0 then
@@ -62,27 +111,237 @@ function changeState(_, _, isRightClick)
   end
 
   -- broadcast if option is enabled
-  if broadcastChange then
+  if broadcastChange and not broadcastChangeVerbosity then
     broadcastToAll(PHASE_NAMES[newId])
+  elseif broadcastChangeVerbosity then
+    expressChangeWithVerbosity(newId)
+    if pingAndLookAtPhase and newId == 1 then
+      pingAndMoveCameraInMythosPhase(playerColor)
+    elseif pingAndLookAtPhase and newId == 2 then
+      pingPlayerMiniCards(playerColor)
+    elseif pingAndLookAtPhase and newId == 3 then
+      local enemies = getEnemiesInPlayArea()
+      if #enemies == 1 then
+        moveToSingleMonster(playerColor, enemies[1])
+      end     
+    end
   end
 
-  -- manipulate data and then respawn
+  --
   local data = self.getData()
   data["CustomImage"]["ImageURL"] = PHASE_IMAGES[newId]
   data["CustomImage"]["ImageSecondaryURL"] = PHASE_IMAGES[newId]
-  data["LuaScriptState"] = "{\"broadcastChange\":" .. tostring(broadcastChange) .. ",\"phaseId\":" .. newId .. "}"
+  data["LuaScriptState"] = "{\"broadcastChange\":" ..
+      tostring(broadcastChange) ..
+      ",\"phaseId\":" .. newId ..
+      ",\"broadcastChangeVerbosity\":" ..
+      tostring(broadcastChangeVerbosity) ..
+      ",\"pingAndLookAtPhase\":" ..
+      tostring(pingAndLookAtPhase) ..
+      "}"
 
   -- update all trackers with tag
-  for _, tracker in ipairs(getObjectsWithTag("LinkedPhaseTracker")) do
+  for i, tracker in ipairs(getObjectsWithTag("LinkedPhaseTracker")) do
     local pos = tracker.getPosition()
     local rot = tracker.getRotation()
     local scale = tracker.getScale()
     tracker.destruct()
-    spawnObjectData({
+    spawnObjectData({ -- Esto es una funcion de tts
       data     = data,
       position = pos,
       rotation = rot,
       scale    = scale
     })
   end
+end
+
+function expressChangeWithVerbosity(newId)
+  -- This function shows every change in the Phase tracker
+
+  local color_bone = { r = 1, g = 1, b = 0.8 }
+
+  if newId == 1 then
+    printToAll('End of the round', color_bone)
+    printToAll("-------", color_bone)
+    broadcastToAll('Mythos Phase', { r = 1, g = 0, b = 0 })
+  elseif newId == 2 then
+    printToAll('End of Mythos Phase', { r = 1, g = 0, b = 0 })
+    broadcastToAll('Investigation Phase.', color_bone)
+    showHandResourceInfo()
+  elseif newId == 3 then
+    printToAll('End of Investigation Phase', color_bone)
+    printToAll('Enemy Phase.', color_bone)
+    showEnemyInPlayInfo(color_bone)
+    showEnemyInThreatAreaInfo()
+  elseif newId == 4 then
+    printToAll('End of Enemy Phase', color_bone)
+    printToAll('Upkeep Phase.', color_bone)
+  end
+end
+
+function pingAndMoveCameraInMythosPhase(playerColor)
+  local pl = getPlayer(playerColor)
+  local agenda_pos = MythosAreaApi.getAgendaPosition() or nil
+  if agenda_pos then
+    pl.pingTable(agenda_pos)
+    pl.lookAt({ position = agenda_pos, pitch = 90, yaw = 90, distance = 50 })
+    return
+  end
+  log("Could not get the agenda position to ping and move the camera.")
+end
+
+function pingPlayerMiniCards(playerColor)
+  -- Pings the Minicards and moves the camera to one of them
+  all = getObjects()
+  pl = getPlayer(playerColor)
+  found = 0
+  for _, obj in ipairs(all) do
+    if obj.type == 'Card' then
+      if string.find(obj.getGMNotes(), 'Minicard') or obj.hasTag('Minicard') then
+        pos = obj.getPosition()
+        pl.pingTable(pos)
+        found = found + 1
+        if found == 1 then pl.lookAt({ position = pos, pitch = 90, yaw = 90, distance = 30 }) end -- Look at one of them
+      end
+    end
+  end
+end
+
+function moveToSingleMonster(playerColor, monster)
+  pos = monster.getPosition()
+  pl = getPlayer(playerColor)
+  pl.lookAt({ position = pos, pitch = 90, yaw = 90, distance = 40 })
+end
+
+function showHandResourceInfo()
+  local COLORS = { White = Color.White, Orange = Color.Orange, Green = Color.Green, Red = Color.Red }
+  -- It iterates all players, -- The mod makes shure the number of players is the same as the number of mats
+  local playerColors = Player.getAvailableColors()
+  for _, playerColor in ipairs(playerColors) do
+    local color = COLORS[playerColor] or { 1, 1, 1 }
+    log(playerColor)local player = Player[playerColor] or nil
+    local matColor = PlayermatApi.getMatColor(playerColor) or nil
+    log(matColor)local cards = player.getHandObjects(1)
+    local num = #cards
+    local resources = PlayermatApi.getCounterValue(matColor, "ResourceCounter")
+    local investigator = PlayermatApi.getInvestigatorName(matColor)
+    if investigator == "" then investigator = playerColor end -- maybe the inv-card is not well placed, or they aret testing
+    printToAll(investigator .. ' has ' .. num .. ' cards in hand and ' .. resources .. ' resources.', color)
+  end
+end
+
+function showEnemyInPlayInfo(colorPrint)
+  -- This searches for all enemies in the play area and highlights them
+  local enemies = getEnemiesInPlayArea()
+  local num = #enemies
+  if num > 1 then
+    printToAll('There are ' .. tostring(num) .. ' enemies', colorPrint)
+  elseif num == 1 then
+    printToAll('There is ' .. tostring(num) .. ' enemy', colorPrint)
+  end
+  highlightObjects(enemies, { r = 0, g = 1, b = 0 }, 10)
+end
+
+function showEnemyInThreatAreaInfo()
+  -- This searches for all enemies in the threat area of all mats and highlights them
+  local matColors = Player.getAvailableColors()
+  for _, matColor in ipairs(matColors) do
+    local enemies = getEnemiesInThreatArea(matColor)
+    local num = #enemies
+    if num > 1 then
+      printToAll(matColor .. ' has ' .. tostring(num) .. ' enemies in the threat area')
+    elseif num == 1 then
+        printToAll(matColor .. ' has ' .. tostring(num) .. ' enemy in the threat area')
+    end
+    highlightObjects(enemies, { r = 1, g = 0.5, b = 0 }, 10)
+  end
+end
+
+-- Basic Helper functions
+
+function getPlayer(color)
+  --log('Calling getPlayer from the PhaseTracker code')
+  for _, pl in ipairs(Player.getPlayers()) do
+    if pl.color == color then
+      return pl
+    end
+  end
+  return nil
+end
+
+-- helper functions for this script
+
+function scanPlayArea()
+  -- Returns all objects in the PlayArea (the central zone)
+  local zoneGUID = "a2f932"
+  local zone = getObjectFromGUID(zoneGUID)
+
+  if not zone then
+    log("Zone not found (GUID " .. zoneGUID .. ")")
+    return
+  end
+
+  if zone.tag ~= "Scripting" then
+    log("Object is not a ScriptingTrigger zone. Tag: " .. zone.tag)
+    return
+  end
+
+  -- Obtener los objetos dentro de la zona
+  local objs = zone.getObjects()
+  return objs
+end
+
+function getEnemiesInPlayArea()
+  -- returns a table of objects
+  local enemies = {}
+  local objs = scanPlayArea()
+  for _, obj in ipairs(objs) do
+    if isVisibleEnemy(obj) then
+      table.insert(enemies, obj)
+    end
+  end
+  return enemies
+end
+
+function getEnemiesInThreatArea(matColor)
+  -- returns a table of objects
+  local enemies = {}
+  local  threats = PlayermatApi.getThreatAreaObjects(matColor)
+  for _, obj in ipairs(threats) do
+    if isVisibleEnemy(obj) then table.insert(enemies, obj) end
+  end
+  return enemies
+end
+
+function highlightObjects(objects, color, duration)
+  for _, obj in ipairs(objects) do
+    obj.highlightOn(color, duration)
+  end
+end
+
+function isVisibleEnemy(obj)
+  -- Receives an object, takes its metadata and checks if it's an enemy
+  -- And if it is face up, because some scenarios have facedown enemies, like Blood on the Alter
+  -- Returns boolean
+  local rawNotes = obj.getGMNotes() or "{}"
+  local md = JSON.decode(rawNotes) or {}
+  local type = md['type'] or ''
+  if type == 'Enemy' and not obj.is_face_down then
+    return true
+  elseif type == 'Enemy' and obj.is_face_down then
+    return false
+  end
+  -- Second check, because some enemies are in the back of Agenda Cards
+  local specialEnemies = {
+    ["03241"] = true,
+    ['01121a'] = true,
+    ['50026a'] = true,
+    ['11537a'] = true
+  }
+  local id = md['id'] or ''
+  local isSpecial = specialEnemies[id] or false
+  if isSpecial and obj.is_face_down then
+    return true
+  end
+  return false
 end

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1944,6 +1944,30 @@ function getEncounterCardDrawPosition(stack)
   return drawPos
 end
 
+-- returns the table that contains the six positions for the threat area
+function getThreatAreaPositions()
+  local positions = {}
+  local searchPos = Vector(-0.91, 0.5, -0.625)
+  for i = 1, 6 do
+    local globalSearchPos = self.positionToWorld(searchPos)
+    table.insert(positions, globalSearchPos)
+    searchPos.x = searchPos.x + 0.455
+  end
+  return positions
+end
+
+-- Returns a list of objects in the threat area (max six)
+function getThreatAreaObjects()
+  local objects = {}
+  for _, pos in ipairs(getThreatAreaPositions()) do
+    local thisObj = SearchLib.atPosition(pos, "isCardOrDeck")
+    if #thisObj > 0 then
+      table.insert(objects, thisObj[1])
+    end
+  end
+  return objects
+end
+
 -- creates / removes the draw 1 button
 ---@param visible? boolean Whether the draw 1 button should be visible
 function showDrawButton(visible)

--- a/src/playermat/PlayermatApi.ttslua
+++ b/src/playermat/PlayermatApi.ttslua
@@ -3,6 +3,7 @@ do
   local GUIDReferenceApi          = require("core/GUIDReferenceApi")
   local SearchLib                 = require("util/SearchLib")
   local localInvestigatorPosition = Vector(-1.17, 1, -0.01)
+  
 
   -- General notes:
   -------------------------------------------------------------------
@@ -160,6 +161,18 @@ do
   ---@param stack boolean If true, returns the leftmost position instead of the first empty from the right
   function PlayermatApi.getEncounterCardDrawPosition(matColor, stack)
     return Vector(callForSingleMat(matColor, "getEncounterCardDrawPosition", stack))
+  end
+
+  -- Returns the positions of all the threat area slots, six in total
+  ---@param matColor string Does not support "All"
+  function PlayermatApi.getThreatAreaPositions(matColor)
+    return callForSingleMat(matColor, "getThreatAreaPositions")
+  end
+  
+  -- Returns a list of objects in the threat area of the mat
+  ---@param matColor string Does not support "All"
+  function PlayermatApi.getThreatAreaObjects(matColor)
+    return callForSingleMat(matColor, "getThreatAreaObjects")
   end
 
   -- Sets the requested playermat's snap points to limit snapping to matching card types or not


### PR DESCRIPTION
The phase tracker has a second level of verbosity that displays in the chat how many resources and cards the characters have at the begining of the inv phase. It also reminds you in the chat if there are enemies in the play area and in the threat area of playermats. There is a third level of verbosity that does all that and, additionally, moves the camera and shows clearly the position of the investigator minicards and highlights enemies in the enemy phase. I've been using these phase tracker in my games and it helps me follow the game, since the chat messages integrate well with messages like "removed charge" or "spent clues".