### PR TITLE
Request decks from arkham.build always

### DIFF
--- a/src/deckbuilder/Configuration.ttslua
+++ b/src/deckbuilder/Configuration.ttslua
@@ -1,10 +1,11 @@
 ---@type table Contains fields used by the deck importer
 configuration = {
     -- arkham.build's API is now the default because of custom card support
-    arkhambuild_api_uri     = "https://api.arkham.build/v1/public/share",
-    ArkhamDB_api_uri        = "https://arkhamdb.com/api/public",
-    ArkhamDB_published_deck = "decklist",
-    ArkhamDB_private_deck   = "deck",
-    cards                   = "card",
-    taboo_api_uri           = "https://api.arkham.build/v1/cache/taboo_sets_with_cards"
+    arkhambuild_api_uri        = "https://api.arkham.build/v1/public/share",
+    arkhambuild_published_deck = "?type=decklist",
+    ArkhamDB_api_uri           = "https://arkhamdb.com/api/public",
+    ArkhamDB_published_deck    = "decklist",
+    ArkhamDB_private_deck      = "deck",
+    cards                      = "card",
+    taboo_api_uri              = "https://api.arkham.build/v1/cache/taboo_sets_with_cards"
 }

--- a/src/deckbuilder/WebInterface.ttslua
+++ b/src/deckbuilder/WebInterface.ttslua
@@ -428,13 +428,9 @@ do
       deckId
     }
 
-    -- use ArkhamDB's API for published decks
+    -- add parameter for published decks
     if not isPrivate then
-      deckUri = {
-        configuration.ArkhamDB_api_uri,
-        configuration.ArkhamDB_published_deck,
-        deckId
-      }
+      table.insert(deckUri, configuration.arkhambuild_published_deck)
     end
 
     WebRequestLib.get(deckUri, function(responseText)


### PR DESCRIPTION
Since arkham.build started supporting fan-made content, this PR implements it as default API for deck requests.