### PR TITLE
Increased delay for attachment helper spawning

### DIFF
--- a/src/deckbuilder/DeckImporter.ttslua
+++ b/src/deckbuilder/DeckImporter.ttslua
@@ -384,7 +384,7 @@ function loadCards(slots, investigatorId, bondedList, deckMeta, playerColor, loa
           })
           helper.setScale({ 0.57, 0.65, 0.57 })
           Wait.frames(function() helper.call("loadDataFromMetadata", { md = { id = investigatorId } }) end, 3)
-        end, 1)
+        end, 1.5)
       end
     end
   end


### PR DESCRIPTION
This increases the delay for attachment helper spawning on imported investigators.

Confirmed to solve the issue on the machine of the user that reported the issue.