### PR TITLE
Increase hover distance for Charlie Helper

### DIFF
--- a/src/playercards/cards/CharlieKane.ttslua
+++ b/src/playercards/cards/CharlieKane.ttslua
@@ -117,7 +117,7 @@ function addExhaustButtons()
                 padding  = "0 0 20 25",
                 scale    = ".2 .2 1",
                 rotation = "0 0 180",
-                position = "0 -85 -40",
+                position = "0 -85 -180",
                 color    = "rgba(0,0,0,0.9)",
                 onClick  = self.getGUID() .. "/bonnie"
               },
@@ -286,7 +286,7 @@ function makeExhaustButton(cardGUID)
       padding  = "0 0 20 25",
       scale    = ".35 .35 1",
       rotation = "0 0 180",
-      position = "0 20 -100",
+      position = "0 20 -180",
       color    = "rgba(0,0,0,0.9)",
       onClick  = self.getGUID() .. "/exhaustOrReadyAlly(" .. cardGUID .. ")"
     },


### PR DESCRIPTION
<img width="849" height="691" alt="image" src="https://github.com/user-attachments/assets/069c32fc-0c28-4743-b7d2-7555e22cea29" />

Keeps tokens from covering the exhaust buttons