### PR TITLE
PhaseTracker Upgrades

### DIFF
--- a/src/playarea/PhaseTracker.ttslua
+++ b/src/playarea/PhaseTracker.ttslua
@@ -1,5 +1,7 @@
 local PlayermatApi = require("playermat/PlayermatApi")
 local MythosAreaApi = require("mythos/MythosAreaApi")
+local zones         = require("playermat/Zones")
+local SearchLib     = require("util/SearchLib")
 
 local PHASE_NAMES = {
   "I. Mythos Phase",
@@ -179,20 +181,19 @@ function expressChangeWithVerbosity(newId)
 end
 
 function pingAndMoveCameraInMythosPhase(playerColor)
-  local pl = getPlayer(playerColor)
+  local pl = Player[playerColor]
   local agenda_pos = MythosAreaApi.getAgendaPosition() or nil
   if agenda_pos then
     pl.pingTable(agenda_pos)
     pl.lookAt({ position = agenda_pos, pitch = 90, yaw = 90, distance = 50 })
     return
   end
-  log("Could not get the agenda position to ping and move the camera.")
 end
 
 function pingPlayerMiniCards(playerColor)
   -- Pings the Minicards and moves the camera to one of them
-  all = getObjects()
-  pl = getPlayer(playerColor)
+  local all = getObjects()
+  local pl = Player[playerColor]
   found = 0
   for _, obj in ipairs(all) do
     if obj.type == 'Card' then
@@ -208,7 +209,7 @@ end
 
 function moveToSingleMonster(playerColor, monster)
   pos = monster.getPosition()
-  pl = getPlayer(playerColor)
+  local pl = Player[playerColor]
   pl.lookAt({ position = pos, pitch = 90, yaw = 90, distance = 40 })
 end
 
@@ -218,15 +219,13 @@ function showHandResourceInfo()
   local playerColors = Player.getAvailableColors()
   for _, playerColor in ipairs(playerColors) do
     local color = COLORS[playerColor] or { 1, 1, 1 }
-    log(playerColor)
     local player = Player[playerColor] or nil
     local matColor = PlayermatApi.getMatColor(playerColor) or nil
-    log(matColor)
     local cards = player.getHandObjects(1)
     local num = #cards
     local resources = PlayermatApi.getCounterValue(matColor, "ResourceCounter")
     local investigator = PlayermatApi.getInvestigatorName(matColor)
-    if investigator == "" then investigator = playerColor end -- maybe the inv-card is not well placed, or they aret testing
+    if investigator == "" then investigator = playerColor end -- maybe the inv-card is not well placed, or they are testing
     printToAll(investigator .. ' has ' .. num .. ' cards in hand and ' .. resources .. ' resources.', color)
   end
 end
@@ -258,19 +257,31 @@ function showEnemyInThreatAreaInfo()
   end
 end
 
--- Basic Helper functions
+-- helper functions for this script
 
-function getPlayer(color)
-  --log('Calling getPlayer from the PhaseTracker code')
-  for _, pl in ipairs(Player.getPlayers()) do
-    if pl.color == color then
-      return pl
-    end
+function getThreatAreaPositions(matColor)
+  -- Returns a table with Vectors
+  local positions = {}
+
+  for i = 1, 4 do
+    local position = zones.getZonePosition(matColor, "Threat" .. i)
+    table.insert(positions, position)
   end
-  return nil
+
+  return positions
 end
 
--- helper functions for this script
+function getThreatAreaObjects(matColor)
+  -- Returns a table of objects
+  local objects = {}
+  for _, pos in ipairs(getThreatAreaPositions(matColor)) do
+    local thisObj = SearchLib.atPosition(pos, "isCardOrDeck")
+    if #thisObj > 0 then
+      table.insert(objects, thisObj[1])
+    end
+  end
+  return objects
+end
 
 function scanPlayArea()
   -- Returns all objects in the PlayArea (the central zone)
@@ -306,8 +317,9 @@ end
 
 function getEnemiesInThreatArea(matColor)
   -- returns a table of objects
+  -- only enemies that are face up (some custom scenarios can make you draw facedown enemies)
   local enemies = {}
-  local threats = PlayermatApi.getThreatAreaObjects(matColor)
+  local threats = getThreatAreaObjects(matColor)
   for _, obj in ipairs(threats) do
     if isVisibleEnemy(obj) then table.insert(enemies, obj) end
   end

--- a/src/playermat/Playermat.ttslua
+++ b/src/playermat/Playermat.ttslua
@@ -1944,30 +1944,6 @@ function getEncounterCardDrawPosition(stack)
   return drawPos
 end
 
--- returns the table that contains the six positions for the threat area
-function getThreatAreaPositions()
-  local positions = {}
-  local searchPos = Vector(-0.91, 0.5, -0.625)
-  for i = 1, 6 do
-    local globalSearchPos = self.positionToWorld(searchPos)
-    table.insert(positions, globalSearchPos)
-    searchPos.x = searchPos.x + 0.455
-  end
-  return positions
-end
-
--- Returns a list of objects in the threat area (max six)
-function getThreatAreaObjects()
-  local objects = {}
-  for _, pos in ipairs(getThreatAreaPositions()) do
-    local thisObj = SearchLib.atPosition(pos, "isCardOrDeck")
-    if #thisObj > 0 then
-      table.insert(objects, thisObj[1])
-    end
-  end
-  return objects
-end
-
 -- creates / removes the draw 1 button
 ---@param visible? boolean Whether the draw 1 button should be visible
 function showDrawButton(visible)

--- a/src/playermat/PlayermatApi.ttslua
+++ b/src/playermat/PlayermatApi.ttslua
@@ -162,18 +162,6 @@ do
     return Vector(callForSingleMat(matColor, "getEncounterCardDrawPosition", stack))
   end
 
-  -- Returns the positions of all the threat area slots, six in total
-  ---@param matColor string Does not support "All"
-  function PlayermatApi.getThreatAreaPositions(matColor)
-    return callForSingleMat(matColor, "getThreatAreaPositions")
-  end
-
-  -- Returns a list of objects in the threat area of the mat
-  ---@param matColor string Does not support "All"
-  function PlayermatApi.getThreatAreaObjects(matColor)
-    return callForSingleMat(matColor, "getThreatAreaObjects")
-  end
-
   -- Sets the requested playermat's snap points to limit snapping to matching card types or not
   ---@param matchCardTypes boolean Whether snap points should only snap for the matching card types
   function PlayermatApi.setLimitSnapsByType(matchCardTypes, matColor)


### PR DESCRIPTION
Feature 1. Toggleable verbosity mode of the PhaseTracker.
In this feature, The phase tracker can be toggled on to display more information, like
·the resources and hand cards that the players have, to keep a more detailed record, at the Investigator Phase
· The number of enemies in the Playarea and in the Threat area in the Enemy Phase.
· Highlighting for 10 seconds the enemies
·More colourful messages
·It enables future messaging, like displaying forced effects that trigger at the end of any given phase

Feature 2. Toggleable verbosity mode *and* camera moving of the PhaseTracker
This feature does all the previous things *and*
·moves the camera to the mythos area when the Mythos Phase begins
·moves the camera to the investigator miniplayer card when the Investigator Phase begins
·moves the camera to the enemy in the playarea if there is a single one (never forget that enemy in the corner)

Changes: this change adds variables to the PhaseTracker, so it changes the json file. It adds two functions to the playermat, that return the elements in the Threat area.

Notes:
·The feature 1 and 2 could be untangled in future versions.
· The functions that detect enemies and things in general in the playarea could be global if used by other features in the future
