### PR TITLE
Fix an issue with hidden investigators

### DIFF
--- a/src/deckbuilder/WebInterface.ttslua
+++ b/src/deckbuilder/WebInterface.ttslua
@@ -321,7 +321,7 @@ do
       for cardId, count in pairs(deckMeta.hidden_slots.slots or {}) do
         slots[cardId] = (slots[cardId] or 0) + count
       end
-      deck.investigator_code = deckMeta.hidden_slots.investigatorCode or deck.investigator_code
+      deck.investigator_code = deckMeta.hidden_slots.investigator_code or deck.investigator_code
     end
 
     -- make sure the necessary custom content is loaded


### PR DESCRIPTION
When arkham.build writes a deck to ArkhamDB and that deck does not have the investigator / card yet, it uses the "hidden_slots" field to hide that data since ArkhamDB would delete it.

We had a small typo in the investigator_code replacement logic, which surfaced now due to Isabelle not being on ArkhamDB.