### PR TITLE
Attempt to fix HideWhenFaceDown in localizations

### DIFF
--- a/src/mythos/AllEncounterCardsBag.ttslua
+++ b/src/mythos/AllEncounterCardsBag.ttslua
@@ -385,14 +385,8 @@ function updateOriginalItemData(originalData, replaceData)
   end
 
   originalData["Tags"] = originalData["Tags"] or replaceData["Tags"] or {}
-  -- Try to set HideWhenFaceDown with following priority, depending on whether it is set or not:
-  -- Original -> Replacement -> true
   if originalData["HideWhenFaceDown"] == nil then
-    if replaceData["HideWhenFaceDown"] ~= nil then
-      originalData["HideWhenFaceDown"] = replaceData["HideWhenFaceDown"]
-    else
-      originalData["HideWhenFaceDown"] = true
-    end
+    originalData["HideWhenFaceDown"] = true
   end
   table.insert(originalData["Tags"], "Replaced")
 


### PR DESCRIPTION
Right now HideWhenFaceDown property seems to be ignored on cards that are replaced by the AllEncounterCardsBag - it always defaults to false. This PR attempts to fix it.