### PR TITLE
Fix i18n for Ready Cards button

### DIFF
--- a/objects/PlayArea.721ba2.json
+++ b/objects/PlayArea.721ba2.json
@@ -988,6 +988,7 @@
     "CameraZoom_ignore",
     "CleanUpHelper_ignore",
     "displacement_excluded",
+    "i18n_XML",
     "NotInteractable"
   ],
   "Tooltip": false,


### PR DESCRIPTION
"Ready Cards in Play Area" button is not being translated on language switch - looks like  because PlayArea is missing required tag