### PR TITLE
Reposition minicard after clean-up

### DIFF
--- a/src/accessories/CleanUpHelper.ttslua
+++ b/src/accessories/CleanUpHelper.ttslua
@@ -282,7 +282,7 @@ function returnMiniCards()
   for _, matColor in ipairs(matColorList) do
     local data = PlayermatApi.getActiveInvestigatorData(matColor)
     if miniCardIndex[data.miniId] then
-      local pos = PlayermatApi.transformLocalPosition(Vector(-1.36, 0, -0.625), matColor)
+      local pos = PlayermatApi.transformLocalPosition(Vector(-0.911, 0, -0.625), matColor)
       miniCardIndex[data.miniId].setPosition(pos:setAt("y", 1.67))
     end
   end


### PR DESCRIPTION
Matches mini card location with Deck Importer's mini card import position after Clean-Up Helper is used (tidy playermats turned off)