### PR TITLE
Add additional metadata entry for Acts to skip spending clues

### DIFF
--- a/src/mythos/MythosArea.ttslua
+++ b/src/mythos/MythosArea.ttslua
@@ -136,9 +136,9 @@ function maybeSpendCluesForAdvancing(card)
 
   local md = JSON.decode(card.getGMNotes()) or {}
   if md.clueThreshold or md.clueThresholdPerInvestigator then
-    local playerCount = PlayAreaApi.getInvestigatorCount()
+    local playerCount      = PlayAreaApi.getInvestigatorCount()
     local totalNeededClues = (md.clueThreshold or 0) + (md.clueThresholdPerInvestigator or 0) * playerCount
-    if totalNeededClues > 0 then
+    if totalNeededClues > 0 and not md.keepClues then -- handling for Dealings in the Dark
       GlobalApi.showClueSpendingUi(totalNeededClues)
     end
   end


### PR DESCRIPTION
Primarily used by Dealings in the Dark atm