### PR TITLE
Improved code for mini card border creation

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -395,20 +395,26 @@ function maybeDrawBorderAroundMinicard(object)
 end
 
 function drawBorderAroundCard(params)
-  if params.card == nil then return end
+  local card = params.card
 
-  local bounds = params.card.getBoundsNormalized()
-  local scale  = params.card.getScale()
+  if card == nil then return end
+
+  local bounds = card.getBoundsNormalized()
+  local scale  = card.getScale()
   local xSize  = bounds.size.x / 2 / scale.x
   local zSize  = bounds.size.z / 2 / scale.z
 
   -- special handling for cards from custom decks because it seems like
   -- the internal model for those is somehow different than custom cards :)
-  if params.card.getData().Name == "Card" then
+  local data   = card.getData()
+
+  if data.Name == "CardCustom" or not isSingleCard(card) then
     xSize = xSize * 1.09
+  else
+    xSize = xSize / 1.035
   end
 
-  params.card.setVectorLines({ {
+  card.setVectorLines({ {
     points    = {
       { 0 - xSize, 0, 0 - zSize },
       { 0 + xSize, 0, 0 - zSize },
@@ -420,6 +426,12 @@ function drawBorderAroundCard(params)
     color     = params.borderColor,
     thickness = params.thickness
   } })
+end
+
+-- check the size of the decksheet to know whether this is a single card image
+function isSingleCard(card)
+  local _, customDeckData = next(card.getData()["CustomDeck"])
+  return customDeckData["NumHeight"] == 1 and customDeckData["NumWidth"] == 1
 end
 
 -- moves an object to the new position of the mythos area


### PR DESCRIPTION
This fixes a bug with wrong mini card border sizing (noticed by new Joe Diamond).
New code is tested with custom cards, custom decks and custom decks with single cards.

Example:
<img width="893" height="467" alt="grafik" src="https://github.com/user-attachments/assets/826d4332-6ea1-4697-b44d-70b10571a3c3" />