### PR TITLE
Updated images for investigator tokens

### DIFF
--- a/objects/Investigatortokens.0203af/Guardian.abd142.json
+++ b/objects/Investigatortokens.0203af/Guardian.abd142.json
@@ -13,8 +13,8 @@
       "Type": 2
     },
     "ImageScalar": 1,
-    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/15568232218171650620/0366B4583F0E034AAFA5A1423669B1F505AF6598/",
-    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/14624386528394069773/FED86B02323C864D182F9F0A8CF404B38346D5AE/",
+    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/15667294738589055746/A476C093DF6680A8A46A1D619209AB9565A09DE5/",
+    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/14063836797355917921/14FB31CEB6F93CB63BBD8166390604E7AED9D8E8/",
     "WidthScale": 0
   },
   "GUID": "abd142",

--- a/objects/Investigatortokens.0203af/Guardian.abd142/Mystic.abd145.json
+++ b/objects/Investigatortokens.0203af/Guardian.abd142/Mystic.abd145.json
@@ -12,8 +12,8 @@
       "Type": 2
     },
     "ImageScalar": 1,
-    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/11106704706603457114/3081B44E3DAEF944AF72733D9332ABADFEDC780B/",
-    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/9636656185503244840/CD2F55BE2F963C6CF3DA299CC2F4FA5528FA876B/",
+    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/15777177087374153014/BDA0E73BB98A97A8C200BD58830377239B59C603/",
+    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/9720923453586566896/EB48B13E90D758D236C1C99C478338199684120D/",
     "WidthScale": 0
   },
   "GUID": "abd145",

--- a/objects/Investigatortokens.0203af/Guardian.abd142/Rogue.abd144.json
+++ b/objects/Investigatortokens.0203af/Guardian.abd142/Rogue.abd144.json
@@ -12,8 +12,8 @@
       "Type": 2
     },
     "ImageScalar": 1,
-    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/16614682778237093038/684404A619134CBE4451103EA590BF3BA85A1DE1/",
-    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/13498406712279641771/5EE99E643332770E790950E824CD03E9597E4441/",
+    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/10970151364983170946/9DE40BA233C7238C9C4579812F0EF30302E6273B/",
+    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/9371461585973210328/CE868889626018577A2F2660CC137B747FB2D1AE/",
     "WidthScale": 0
   },
   "GUID": "abd144",

--- a/objects/Investigatortokens.0203af/Guardian.abd142/Seeker.abd143.json
+++ b/objects/Investigatortokens.0203af/Guardian.abd142/Seeker.abd143.json
@@ -12,8 +12,8 @@
       "Type": 2
     },
     "ImageScalar": 1,
-    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/16067172632375150659/9FE3D15CA6A67CF5F8B07DC59E6A0DD798FC5BC5/",
-    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/14656574939506513070/BEB5EE0E150E2FEE0131F72E95CEF24F674E46F1/",
+    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/11986441242692348183/6F3B63923FA5DCDAD70858DBC8E5E6989349A4F7/",
+    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/10874307622462796120/AF12BE867E35B356146B97A051C7F4C11D262630/",
     "WidthScale": 0
   },
   "GUID": "abd143",

--- a/objects/Investigatortokens.0203af/Guardian.abd142/Survivor.abd146.json
+++ b/objects/Investigatortokens.0203af/Guardian.abd142/Survivor.abd146.json
@@ -12,8 +12,8 @@
       "Type": 2
     },
     "ImageScalar": 1,
-    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/9308604966566473620/682FCAC0E895D11263AA2B435B8C5447CC9E3680/",
-    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/14306103847243982411/FFC02ECD6784610AA02CEB98177A3E20F8BC36D7/",
+    "ImageSecondaryURL": "https://steamusercontent-a.akamaihd.net/ugc/13290519951076312655/84F9B225B7EB68932357D96F113CF0CE0A5D348D/",
+    "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/18365770817537313115/9D975FC203EE9DD48F3806B81610FEF48AA8F430/",
     "WidthScale": 0
   },
   "GUID": "abd146",


### PR DESCRIPTION
Old scans (from Spanish mod) were oversaturated, used scans from another user.

<img width="384" height="358" alt="image" src="https://github.com/user-attachments/assets/5cc9ef8a-7e4a-4d5a-a445-193ec423f1f1" />
