### PR TITLE
Add code to support tag-based handling of act / agendas with upright backs

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -87,6 +87,18 @@ local DROPDOWN_DATA               = {
   }
 }
 
+-- viewing angles for specific double-sided cards
+local ALT_VIEW_ANGLE              = {
+  [false] = {                      -- Front
+    [false] = Vector(180, 0, 270), -- Normal
+    [true]  = Vector(180, 0, 0)    -- Sideways
+  },
+  [true] = {                       -- Back
+    [false] = Vector(180, 0, 180), -- Normal
+    [true]  = Vector(180, 0, 90)   -- Sideways
+  }
+}
+
 -- defines the area for the "regular" mythos area
 local MYTHOS_AREA_DATA            = {
   upperLeft  = { x = 5.09, z = 17.45 },
@@ -687,6 +699,8 @@ function onObjectRotate(obj, _, flip, _, _, oldFlip)
     for matColor, _ in pairs(GUIDReferenceApi.getObjectsByType("Playermat")) do
       Wait.frames(function() updateActionTrackerName(matColor) end, 75)
     end
+  elseif obj.hasTag("DynamicAltView") then
+    updateAltView(obj, flip >= 90 and flip <= 270)
   elseif TokenChecker.isChaosToken(obj) then
     if #chaosTokens == 0 then return end
 
@@ -722,6 +736,10 @@ function onObjectSpawn(obj)
     obj.highlightOn({ 0, 0.7843, 0.7843 })
   end
 
+  if obj.hasTag("DynamicAltView") then
+    updateAltView(obj)
+  end
+
   if obj.hasTag("Reloadable") then
     obj.addContextMenuItem("Redownload this", function(playerColor)
       local md = JSON.decode(obj.getGMNotes()) or {}
@@ -744,6 +762,8 @@ function onObjectDrop(playerColor, obj)
   if obj.hasTag("Investigator") then
     updateActionTrackerRows()
     updateActionTrackerWidth()
+  elseif obj.hasTag("DynamicAltView") then
+    updateAltView(obj)
   elseif obj.hasTag("Minicard") then
     -- sync the mini card with an investigator below
     for _, card in ipairs(SearchLib.belowPosition(obj.getPosition(), "isCard")) do
@@ -818,6 +838,13 @@ function maybeUpdateActionTrackerTokens(obj, delayFrames)
   local owner = GUIDReferenceApi.getOwnerOfObject(obj)
   if owner == "Mythos" then return end
   updateActionTrackerTokens(owner, delayFrames)
+end
+
+function updateAltView(obj, useBack)
+  if useBack == nil then
+    useBack = obj.is_face_down
+  end
+  obj.alt_view_angle = ALT_VIEW_ANGLE[useBack][obj.hasTag("Sideways")]
 end
 
 ---------------------------------------------------------


### PR DESCRIPTION
Adds special handling for cards with the tag "DynamicAltView":
-> will automatically determine the correct alt view angle and set it
(for Zoop-created cards [with a truly horizontal image] the additional tag "Sideways" is needed).