### PR TITLE
Remove some Prints when no Changes were made

### DIFF
--- a/src/chaosbag/BlessCurseManager.ttslua
+++ b/src/chaosbag/BlessCurseManager.ttslua
@@ -10,8 +10,6 @@ buttonParamaters.width          = 700
 buttonParamaters.height         = 700
 
 local updating
-local waitIds                   = {}
-local currentCount              = {}
 
 ---------------------------------------------------------
 -- creating buttons and menus + initializing tables
@@ -194,10 +192,18 @@ function doRemove(color)
     end
   end
 
-  broadcastToColor("Removed " .. count.Bless .. " Bless and " ..
-    count.Curse .. " Curse tokens from the chaos bag.", color, "White")
-  broadcastToColor("Removed " .. removeTakenTokens("Bless") .. " Bless and " ..
-    removeTakenTokens("Curse") .. " Curse tokens from play.", color, "White")
+  if count.Bless > 0 or count.Curse > 0 then
+    broadcastToColor(
+    "Removed " .. count.Bless .. " Bless and " .. count.Curse .. " Curse tokens from the chaos bag.", color, "White")
+  end
+
+  local removedTakenBless = removeTakenTokens("Bless")
+  local removedTakenCurse = removeTakenTokens("Curse")
+
+  if removedTakenBless > 0 or removedTakenCurse > 0 then
+    broadcastToColor(
+    "Removed " .. removedTakenBless .. " Bless and " .. removedTakenCurse .. " Curse tokens from play.", color, "White")
+  end
 
   resetTables()
   updateButtonLabels()

--- a/src/mythos/DoomCounter.ttslua
+++ b/src/mythos/DoomCounter.ttslua
@@ -59,13 +59,13 @@ end
 
 -- sets the current count to the provided number
 function updateVal(number)
-  val = number or 0
-  self.editButton({ index = 0, label = tostring(val) })
   if number then
     broadcastDoom(val)
-  else
+  elseif val ~= 0 then
     broadcastToAll("0 doom on the agenda")
   end
+  val = number or 0
+  self.editButton({ index = 0, label = tostring(val) })
 end
 
 function onNumberTyped(_, number)
@@ -87,7 +87,8 @@ function broadcastDoom(val)
   end
 
   -- sum the doom thresholds and modifiers
-  local doomThreshold = (md.doomThreshold or 0) + mod + (md.doomThresholdPerInvestigator or 0) * invCount + soloDoomThreshold
+  local doomThreshold = (md.doomThreshold or 0) + mod + (md.doomThresholdPerInvestigator or 0) * invCount +
+      soloDoomThreshold
 
   local doomInPlayCounter = GUIDReferenceApi.getObjectByOwnerAndType("Mythos", "DoomInPlayCounter")
   if doomInPlayCounter and md.subtractDoomInPlay then

--- a/src/playarea/PlayArea.ttslua
+++ b/src/playarea/PlayArea.ttslua
@@ -804,13 +804,16 @@ function updateSurface(newURL)
   local customInfo = self.getCustomObject()
 
   if newURL ~= "" and newURL ~= nil and newURL ~= DEFAULT_URL then
-    customInfo.image = newURL
     broadcastToAll("New Playarea Image Applied", "Green")
   else
-    customInfo.image = DEFAULT_URL
+    newURL = DEFAULT_URL
     broadcastToAll("Default Playarea Image Applied", "Green")
   end
 
+  -- skip the reload if this is already the existing URL
+  if newURL == customInfo.image then return end
+
+  customInfo.image = newURL
   self.setCustomObject(customInfo)
   updateSave()
   self.reload()


### PR DESCRIPTION
This improves the message spam by the clean up helper - for example when the play area image doesn't change, it doesn't need to broadcast about that.