### PR TITLE
Fix an issue with attached reprinted cards

### DIFF
--- a/src/deckbuilder/DeckImporter.ttslua
+++ b/src/deckbuilder/DeckImporter.ttslua
@@ -817,7 +817,13 @@ function moveListOfCardsFromDeck(cardsToSpawn, moveList, targetZone)
   -- Create a frequency map
   local moveCounts = {}
   for _, id in ipairs(moveList) do
-    moveCounts[id] = (moveCounts[id] or 0) + 1
+    -- use the actual ID from the index instead of the on from the list
+    -- since it might be replaced by a reprint
+    local card = AllCardsBagApi.getCardById(id)
+    if card and card.metadata and card.metadata.id then
+      local baseId = getBaseId(card.metadata.id)
+      moveCounts[baseId] = (moveCounts[baseId] or 0) + 1
+    end
   end
 
   -- Process Cards

--- a/src/deckbuilder/DeckImporter.ttslua
+++ b/src/deckbuilder/DeckImporter.ttslua
@@ -817,7 +817,7 @@ function moveListOfCardsFromDeck(cardsToSpawn, moveList, targetZone)
   -- Create a frequency map
   local moveCounts = {}
   for _, id in ipairs(moveList) do
-    -- use the actual ID from the index instead of the on from the list
+    -- use the actual ID from the index instead of the ID from the list
     -- since it might be replaced by a reprint
     local card = AllCardsBagApi.getCardById(id)
     if card and card.metadata and card.metadata.id then


### PR DESCRIPTION
This fixes an issue with cards that got replaced by a reprint. These cards will have a different ID than expected, so moving them to a different zone via the "originally requested" ID doesn't work - instead the actually served ID has to be used.

Closes: https://github.com/Chr1Z93/SCED/issues/1764