### PR TITLE
Made ui action tracker clickable

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -2611,9 +2611,9 @@ function createActionTrackerUI()
 
   -- Loop through playermats and create rows in the Action Tracker
   for _, matColor in ipairs(MAT_COLORS) do
-    local cellColors = getActionTrackerCellColors(matColor)
+    local cellColors  = getActionTrackerCellColors(matColor)
     local playerColor = PlayermatApi.getPlayerColor(matColor) or matColor
-    local playerRow = {
+    local playerRow   = {
       tag = "Row",
       attributes = { id = "playerRow" .. matColor, active = isUsed[matColor] or false },
       children = {
@@ -2637,11 +2637,11 @@ function createActionTrackerUI()
               tag = "HorizontalLayout",
               attributes = { spacing = 4 },
               children = {
-                { tag = "Panel", attributes = { id = "panelPlayerAction1" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction1" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[1] } } } },
-                { tag = "Panel", attributes = { id = "panelPlayerAction2" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction2" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[2] } } } },
-                { tag = "Panel", attributes = { id = "panelPlayerAction3" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction3" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[3] } } } },
-                { tag = "Panel", attributes = { id = "panelPlayerAction4" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction4" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[4] } } } },
-                { tag = "Panel", attributes = { id = "panelPlayerAction5" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction5" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[5] } } } }
+                getActionTrackerUiPanel(cellColors, matColor, 1),
+                getActionTrackerUiPanel(cellColors, matColor, 2),
+                getActionTrackerUiPanel(cellColors, matColor, 3),
+                getActionTrackerUiPanel(cellColors, matColor, 4),
+                getActionTrackerUiPanel(cellColors, matColor, 5)
               }
             }
           }
@@ -2656,6 +2656,17 @@ function createActionTrackerUI()
   return actionTrackerXml
 end
 
+function getActionTrackerUiPanel(cellColors, matColor, i)
+  return {
+    tag        = "Panel",
+    attributes = {
+      id      = "playerAction" .. i .. matColor,
+      onClick = "clickActionTrackerCell",
+      color   = cellColors[i]
+    }
+  }
+end
+
 function clickActionTrackerCell(_, clickType, buttonId)
   local index, matColor = buttonId:match("^playerAction(%d)(.+)$")
   index = tonumber(index)
@@ -2663,7 +2674,6 @@ function clickActionTrackerCell(_, clickType, buttonId)
   -- left click consumes action, right click restores action
   if clickType == "-1" then
     setActionTokenState(matColor, index, true)
-    
   elseif clickType == "-2" then
     setActionTokenState(matColor, index, false)
   end
@@ -2745,7 +2755,6 @@ function updateActionTrackerWidth()
   -- show / hide actions
   for i = 1, 5 do
     for _, matColor in ipairs(MAT_COLORS) do
-      UI.setAttribute("panelPlayerAction" .. i .. matColor, "active", i <= columnCount)
       UI.setAttribute("playerAction" .. i .. matColor, "active", i <= columnCount)
     end
   end
@@ -2770,9 +2779,7 @@ end
 
 function setActionTokenState(matColor, i, setfaceDown)
   local playermat = GUIDReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
-  if not playermat then
-    return
-  end
+  if not playermat then return end
 
   local localPos       = Vector(-1.2, 0.1, -0.28)
   local pos            = PlayermatApi.transformLocalPosition(localPos, matColor):setAt("y", 3)
@@ -2788,7 +2795,7 @@ function setActionTokenState(matColor, i, setfaceDown)
   table.sort(searchResult, function(a, b) return tokenPositions[a].x > tokenPositions[b].x end)
 
   for index, obj in ipairs(searchResult) do
-    if index == i and obj.resting and ((obj.is_face_down and not setfaceDown) or (not obj.is_face_down and setfaceDown)) then
+    if index == i and obj.resting and obj.is_face_down ~= setfaceDown then
       obj.flip()
       -- prematurely update ui button element color for better feedback
       UI.setAttribute("playerAction" .. i .. matColor, "color", setfaceDown and "grey" or "#C89B3C")

--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -2637,11 +2637,11 @@ function createActionTrackerUI()
               tag = "HorizontalLayout",
               attributes = { spacing = 4 },
               children = {
-                { tag = "Panel", attributes = { id = "playerAction1" .. matColor, color = cellColors[1] } },
-                { tag = "Panel", attributes = { id = "playerAction2" .. matColor, color = cellColors[2] } },
-                { tag = "Panel", attributes = { id = "playerAction3" .. matColor, color = cellColors[3] } },
-                { tag = "Panel", attributes = { id = "playerAction4" .. matColor, color = cellColors[4] } },
-                { tag = "Panel", attributes = { id = "playerAction5" .. matColor, color = cellColors[5] } }
+                { tag = "Panel", attributes = { id = "panelPlayerAction1" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction1" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[1] } } } },
+                { tag = "Panel", attributes = { id = "panelPlayerAction2" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction2" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[2] } } } },
+                { tag = "Panel", attributes = { id = "panelPlayerAction3" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction3" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[3] } } } },
+                { tag = "Panel", attributes = { id = "panelPlayerAction4" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction4" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[4] } } } },
+                { tag = "Panel", attributes = { id = "panelPlayerAction5" .. matColor }, children = { { tag = "Button", attributes = { id = "playerAction5" .. matColor, width = "24", height = "24", onClick = "clickActionTrackerCell", color = cellColors[5] } } } }
               }
             }
           }
@@ -2654,6 +2654,19 @@ function createActionTrackerUI()
 
   Wait.frames(updateActionTrackerWidth, 3)
   return actionTrackerXml
+end
+
+function clickActionTrackerCell(_, clickType, buttonId)
+  local index, matColor = buttonId:match("^playerAction(%d)(.+)$")
+  index = tonumber(index)
+
+  -- left click consumes action, right click restores action
+  if clickType == "-1" then
+    setActionTokenState(matColor, index, true)
+    
+  elseif clickType == "-2" then
+    setActionTokenState(matColor, index, false)
+  end
 end
 
 -- updates the layout of the action tracker
@@ -2732,6 +2745,7 @@ function updateActionTrackerWidth()
   -- show / hide actions
   for i = 1, 5 do
     for _, matColor in ipairs(MAT_COLORS) do
+      UI.setAttribute("panelPlayerAction" .. i .. matColor, "active", i <= columnCount)
       UI.setAttribute("playerAction" .. i .. matColor, "active", i <= columnCount)
     end
   end
@@ -2752,6 +2766,34 @@ function countActionTrackerColumns()
     end
   end
   return 1
+end
+
+function setActionTokenState(matColor, i, setfaceDown)
+  local playermat = GUIDReferenceApi.getObjectByOwnerAndType(matColor, "Playermat")
+  if not playermat then
+    return
+  end
+
+  local localPos       = Vector(-1.2, 0.1, -0.28)
+  local pos            = PlayermatApi.transformLocalPosition(localPos, matColor):setAt("y", 3)
+  local rot            = PlayermatApi.returnRotation(matColor)
+  local size           = Vector(5, 6, 0.1)
+  local searchResult   = SearchLib.inArea(pos, rot, size, "isUniversalToken")
+
+  local tokenPositions = {}
+  for _, obj in ipairs(searchResult) do
+    tokenPositions[obj] = playermat.positionToLocal(obj.getPosition())
+  end
+
+  table.sort(searchResult, function(a, b) return tokenPositions[a].x > tokenPositions[b].x end)
+
+  for index, obj in ipairs(searchResult) do
+    if index == i and obj.resting and ((obj.is_face_down and not setfaceDown) or (not obj.is_face_down and setfaceDown)) then
+      obj.flip()
+      -- prematurely update ui button element color for better feedback
+      UI.setAttribute("playerAction" .. i .. matColor, "color", setfaceDown and "grey" or "#C89B3C")
+    end
+  end
 end
 
 function isMiniReady(matColor)


### PR DESCRIPTION
The UI Action tracker window can now be used to flip the action tokens of the players. Left click consumes the action and right click restores it. The button takes effect when the token related to that button is "at rest" to fix a small bug.


<img width="570" height="280" alt="20260806-0903-10 0037109" src="https://github.com/user-attachments/assets/201505ef-f036-48fd-93af-38980294223b" />

