### PR TITLE
Adjust Token spawning for few Clues on non-Locations

### DIFF
--- a/src/Global/Global.ttslua
+++ b/src/Global/Global.ttslua
@@ -4830,10 +4830,10 @@ function TokenManager.spawnMultipleTokens(params)
   local cardWorldPosition = card.getPosition()
 
   local offsets = {}
-  if tokenType == "clue" then
+  if (card.hasTag("Location") or tokenCount > 4) and tokenType == "clue" then
     offsets = TokenManager.buildClueOffsets(card, tokenCount)
   else
-    if tokenCount > 12 then
+    if tokenType == "resource" and tokenCount > 12 then
       printToAll("Attempting to spawn " .. tokenCount .. " tokens. Spawning clickable counter instead.")
       TokenManager.spawnResourceCounterToken(params)
       return


### PR DESCRIPTION
Uses the regular "central" spawning location for cards that aren't locations and just spawn a small number of clues.

<img width="1079" height="603" alt="grafik" src="https://github.com/user-attachments/assets/d43d4c0e-3e38-4e10-b1ba-4517a979d2d5" />